### PR TITLE
Feature: Add Mobile Support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Threejs Sims House Builder
+# Three.js Sims-like House Builder
+
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://ch-bas.github.io/threejs-sims-house-builder/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![TypeScript](https://img.shields.io/badge/TypeScript-strict-blue)](tsconfig.json)

--- a/app/globals.css
+++ b/app/globals.css
@@ -34,48 +34,210 @@
   body {
     @apply bg-background text-foreground;
   }
+}
 
-  /* Responsive bottom HUD — collapse on narrow screens */
-  @media (max-width: 1100px) {
-    .pc-bottom-hud {
-      flex-wrap: wrap;
-      gap: 8px;
-      padding: 10px;
-    }
-    /* Hide the catalog strip on narrow screens — users can still
-       access the full catalog from the sidebar's Buy tab. */
-    .pc-bottom-hud .pc-catalog-strip {
-      display: none;
-    }
+/* ================================================================
+   Dark overrides inside frosted-glass sidebar
+   ================================================================ */
+.pc-glass--dark {
+  --background: 215 25% 12%;
+  --foreground: 210 20% 90%;
+  --card: 215 25% 14%;
+  --card-foreground: 210 20% 90%;
+  --popover: 215 25% 14%;
+  --popover-foreground: 210 20% 90%;
+  --muted: 215 20% 20%;
+  --muted-foreground: 215 15% 60%;
+  --border: 215 20% 25%;
+  --input: 215 20% 18%;
+  --ring: 186 100% 69%;
+  --accent: 215 20% 20%;
+  --accent-foreground: 210 20% 90%;
+  --primary: 186 100% 69%;
+  --primary-foreground: 215 25% 10%;
+  --secondary: 215 20% 18%;
+  --secondary-foreground: 210 20% 90%;
+}
+
+/* Cards inside dark glass panels: inherit dark theme */
+.pc-glass--dark .rounded-lg.border.bg-card {
+  background: hsl(215 25% 14%) !important;
+  color: hsl(210 20% 90%) !important;
+  border-color: hsl(215 20% 25%) !important;
+}
+
+/* Sidebar close button: hidden on desktop, visible on mobile */
+.pc-sidebar-close {
+  display: none;
+}
+
+/* ================================================================
+   Responsive: tablet (<1100px)
+   ================================================================ */
+@media (max-width: 1100px) {
+  .pc-bottom-hud {
+    flex-wrap: wrap;
+    gap: 8px;
+    padding: 10px;
+  }
+}
+
+/* ================================================================
+   Responsive: mobile (<768px)
+   ================================================================ */
+@media (max-width: 768px) {
+  /* Bottom HUD: single column */
+  .pc-bottom-hud {
+    flex-direction: column !important;
+    align-items: stretch !important;
+    padding: 8px !important;
+    gap: 6px !important;
+  }
+  /* Catalog strip: full width, compact */
+  .pc-bottom-hud .pc-catalog-strip {
+    width: 100% !important;
+    max-width: 100% !important;
+    padding: 6px 8px 8px !important;
+    order: -1;
+  }
+  /* Left column wraps horizontally */
+  .pc-bottom-hud > div:first-child {
+    flex-direction: row !important;
+    flex-wrap: wrap !important;
+    max-height: none !important;
+    overflow: visible !important;
   }
 
-  @media (max-width: 768px) {
-    .pc-bottom-hud {
-      flex-direction: column;
-      align-items: stretch;
-    }
+  /* Lot badge: compact */
+  .pc-lot-badge {
+    top: 8px !important;
+    left: 8px !important;
+    gap: 4px !important;
   }
 
-  /* Dark overrides inside the frosted-glass sidebar — covers cards,
-     inputs, selects, labels, and any shadcn component that reads these
-     CSS custom properties. */
-  .pc-glass--dark {
-    --background: 215 25% 12%;
-    --foreground: 210 20% 90%;
-    --card: 215 25% 14%;
-    --card-foreground: 210 20% 90%;
-    --popover: 215 25% 14%;
-    --popover-foreground: 210 20% 90%;
-    --muted: 215 20% 20%;
-    --muted-foreground: 215 15% 60%;
-    --border: 215 20% 25%;
-    --input: 215 20% 18%;
-    --ring: 186 100% 69%;
-    --accent: 215 20% 20%;
-    --accent-foreground: 210 20% 90%;
-    --primary: 186 100% 69%;
-    --primary-foreground: 215 25% 10%;
-    --secondary: 215 20% 18%;
-    --secondary-foreground: 210 20% 90%;
+  /* Header stats: hide on mobile */
+  .pc-header-stats {
+    display: none !important;
+  }
+
+  /* Top-right controls: tighter */
+  .pc-top-right {
+    top: 8px !important;
+    right: 8px !important;
+    gap: 4px !important;
+  }
+
+  /* Item popover: bottom sheet */
+  .pc-item-popover {
+    top: auto !important;
+    right: 0 !important;
+    bottom: 0 !important;
+    left: 0 !important;
+    width: 100% !important;
+    max-width: 100% !important;
+    max-height: 50vh !important;
+    overflow-y: auto !important;
+    border-radius: 16px 16px 0 0 !important;
+  }
+
+  /* Sidebar: full screen */
+  .pc-sidebar {
+    width: 100% !important;
+    left: 0 !important;
+    top: 0 !important;
+    bottom: 0 !important;
+    border-radius: 0 !important;
+  }
+  .pc-sidebar-close {
+    display: flex !important;
+  }
+
+  /* Build tools: horizontal icon strip on mobile */
+  .pc-build-tools {
+    width: auto !important;
+    padding: 6px !important;
+  }
+  .pc-build-tools-header {
+    display: none !important;
+  }
+  .pc-build-tools-grid {
+    display: flex !important;
+    overflow-x: auto !important;
+    gap: 3px !important;
+    padding: 4px !important;
+    border-radius: 10px !important;
+    scrollbar-width: none;
+  }
+  .pc-build-tools-grid::-webkit-scrollbar {
+    display: none;
+  }
+  .pc-build-tools-grid .pc-tile {
+    height: 38px !important;
+    width: 38px !important;
+    min-width: 38px !important;
+    padding: 4px !important;
+    border-radius: 8px !important;
+  }
+  .pc-build-tools-label {
+    display: none !important;
+  }
+
+  /* Mode panel: fixed bottom footer on mobile */
+  .pc-mode-panel {
+    width: 100% !important;
+    padding: 6px 10px 10px !important;
+    gap: 4px !important;
+    border-radius: 0 !important;
+  }
+  /* Dollar amount: compact single line */
+  .pc-mode-panel > div:first-child {
+    text-align: center !important;
+  }
+  .pc-mode-panel > div:first-child .pc-money {
+    font-size: 18px !important;
+    display: inline !important;
+  }
+  .pc-mode-panel > div:first-child .pc-hud-header {
+    display: inline !important;
+    margin-left: 6px !important;
+    font-size: 9px !important;
+  }
+  /* Hide action buttons row on mobile — in sidebar */
+  .pc-mode-panel > div:last-child {
+    display: none !important;
+  }
+  /* Mode pill: compact */
+  .pc-mode-pill {
+    gap: 2px !important;
+  }
+  .pc-mode-pill__cell {
+    padding: 4px 6px !important;
+  }
+  .pc-wall-paint {
+    width: auto !important;
+    max-width: calc(100vw - 32px) !important;
+  }
+
+  /* Camera pad: hide — touch orbit works */
+  .pc-camera-pad {
+    display: none !important;
+  }
+
+  /* Constrain glass panels */
+  .pc-glass {
+    max-width: calc(100vw - 16px);
+  }
+}
+
+/* ================================================================
+   Responsive: small mobile (<480px)
+   ================================================================ */
+@media (max-width: 480px) {
+  .pc-mode-panel {
+    min-width: 120px !important;
+  }
+  /* Lot badge: icon only */
+  .pc-lot-badge .pc-glass > div:last-child {
+    display: none !important;
   }
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -6,6 +6,13 @@ export const metadata: Metadata = {
   description: 'Design and visualize rooms in 3D with furniture, Wi-Fi, and CCTV planning',
 };
 
+export const viewport = {
+  width: 'device-width',
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">

--- a/components/room-organizer/hooks/use-achievements.ts
+++ b/components/room-organizer/hooks/use-achievements.ts
@@ -9,12 +9,18 @@ export interface UseAchievementsResult {
   dismiss(): void;
 }
 
-export function useAchievements(layout: RoomLayout): UseAchievementsResult {
-  const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => loadUnlocked());
+const EMPTY_SET: ReadonlySet<string> = new Set();
+const EMPTY_ARRAY: readonly Achievement[] = [];
+const NOOP = () => {};
+
+export function useAchievements(layout: RoomLayout, enabled = false): UseAchievementsResult {
+  const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => enabled ? loadUnlocked() : new Set());
   const [pending, setPending] = useState<readonly Achievement[]>([]);
   const initialisedRef = useRef(false);
 
   useEffect(() => {
+    if (!enabled) return;
+
     const next: Achievement[] = [];
     let mutated = false;
     const newUnlocked = new Set(unlocked);
@@ -33,14 +39,12 @@ export function useAchievements(layout: RoomLayout): UseAchievementsResult {
     setUnlocked(newUnlocked);
     saveUnlocked(newUnlocked);
 
-    // Skip the initial flood of unlocks when an existing layout is hydrated —
-    // they were earned in a previous session and shouldn't pop again.
     if (!initialisedRef.current) {
       initialisedRef.current = true;
       return;
     }
     setPending((current) => [...current, ...next]);
-  }, [layout, unlocked]);
+  }, [layout, unlocked, enabled]);
 
   // Mark initialised after the first paint so the very first user-driven
   // change still triggers a toast even on a fresh slate.

--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -167,6 +167,7 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
       controls.enableDamping = true;
       controls.dampingFactor = 0.05;
       controls.maxPolarAngle = Math.PI / 2.5;
+      controls.screenSpacePanning = true;
       controlsRef.current = controls;
       cleanup.push(() => {
         controls.dispose();

--- a/components/room-organizer/panels/build-tools-panel.tsx
+++ b/components/room-organizer/panels/build-tools-panel.tsx
@@ -32,17 +32,22 @@ export interface BuildToolsPanelProps {
 export function BuildToolsPanel(props: BuildToolsPanelProps): JSX.Element {
   return (
     <div
-      className="pointer-events-auto pc-glass"
+      className="pointer-events-auto pc-glass pc-build-tools"
       style={{ width: 232, padding: 'var(--pc-s-3)' }}
     >
-      <div
-        className="pc-hud-header"
-        style={{ fontSize: 11, marginBottom: 8, paddingLeft: 2 }}
-      >
-        Build Tools
+      {/* Desktop: header + 3x3 grid */}
+      <div className="pc-build-tools-header">
+        <div
+          className="pc-hud-header"
+          style={{ fontSize: 11, marginBottom: 8, paddingLeft: 2 }}
+        >
+          Build Tools
+        </div>
       </div>
 
+      {/* Desktop: 3-col grid */}
       <div
+        className="pc-build-tools-grid"
         style={{
           background: 'rgba(0, 0, 0, 0.20)',
           border: '1px solid rgba(255, 255, 255, 0.08)',
@@ -78,6 +83,7 @@ export function BuildToolsPanel(props: BuildToolsPanelProps): JSX.Element {
             >
               <Icon name={tool.icon} size={18} />
               <span
+                className="pc-build-tools-label"
                 style={{
                   fontFamily: 'var(--pc-font-display)',
                   fontWeight: 600,

--- a/components/room-organizer/panels/camera-pad.tsx
+++ b/components/room-organizer/panels/camera-pad.tsx
@@ -22,7 +22,7 @@ export function CameraPad(props: CameraPadProps): JSX.Element {
 
   return (
     <div
-      className="pointer-events-auto"
+      className="pointer-events-auto pc-camera-pad"
       style={{
         background: 'rgba(60, 90, 105, 0.32)',
         backdropFilter: 'var(--pc-glass-blur)',

--- a/components/room-organizer/panels/item-context-popover.tsx
+++ b/components/room-organizer/panels/item-context-popover.tsx
@@ -51,7 +51,7 @@ export function ItemContextPopover(props: ItemContextPopoverProps): JSX.Element 
   const { onClose } = props;
   return (
     <div
-      className="pc-glass pc-glass--dark"
+      className="pc-glass pc-glass--dark pc-item-popover"
       role="dialog"
       aria-label={`Edit ${item.name}`}
       style={{

--- a/components/room-organizer/panels/lot-badge.tsx
+++ b/components/room-organizer/panels/lot-badge.tsx
@@ -13,6 +13,7 @@ export function LotBadge({ sidebarCollapsed, onToggleSidebar }: LotBadgeProps): 
 
   return (
     <div
+      className="pc-lot-badge"
       style={{
         position: 'absolute',
         top: 16,

--- a/components/room-organizer/panels/mode-panel.tsx
+++ b/components/room-organizer/panels/mode-panel.tsx
@@ -33,7 +33,7 @@ export function ModePanel({ onSetMode, onSurprise }: ModePanelProps): JSX.Elemen
 
   return (
     <div
-      className="pointer-events-auto pc-glass"
+      className="pointer-events-auto pc-glass pc-mode-panel"
       style={{
         width: 248,
         padding: '14px 16px',

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -8,6 +8,7 @@ import { hasCollisions } from '../lib/geometry';
 import { applyTheme } from '../lib/themes';
 import { buildFurnitureSet } from '../lib/furniture-sets';
 import { readImageAsDataUrl } from '../lib/file-io';
+import { Icon } from '../plotcraft/icon';
 import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
 import { SidebarTabs, type SidebarTab } from './sidebar-tabs';
@@ -103,7 +104,7 @@ export function SidebarDrawer({
       />
       <aside
         aria-label="Side panels"
-        className="pc-glass pc-glass--dark"
+        className="pc-glass pc-glass--dark pc-sidebar"
         style={{
           position: 'absolute',
           top: 72,
@@ -117,7 +118,26 @@ export function SidebarDrawer({
           overflow: 'hidden',
         }}
       >
-        <SidebarTabs active={sidebarTab} onChange={setSidebarTab} />
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <SidebarTabs active={sidebarTab} onChange={setSidebarTab} />
+          <button
+            type="button"
+            onClick={onCollapse}
+            aria-label="Close panels"
+            className="pc-tile pc-sidebar-close"
+            style={{
+              width: 36,
+              height: 36,
+              borderRadius: 10,
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+              flexShrink: 0,
+            }}
+          >
+            <Icon name="close" size={18} />
+          </button>
+        </div>
 
         <div
           style={{

--- a/components/room-organizer/panels/touch-mode-toggle.tsx
+++ b/components/room-organizer/panels/touch-mode-toggle.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useCallback, useEffect, useState, type MutableRefObject } from 'react';
+import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
+import { Icon, type PlotcraftIconName } from '../plotcraft/icon';
+
+type TouchMode = 'orbit' | 'pan';
+
+export interface TouchModeToggleProps {
+  controlsRef: MutableRefObject<OrbitControls | null>;
+  onFit(): void;
+}
+
+export function TouchModeToggle({ controlsRef, onFit }: TouchModeToggleProps): JSX.Element {
+  const [mode, setMode] = useState<TouchMode>('orbit');
+  const [isTouchDevice, setIsTouchDevice] = useState(false);
+
+  useEffect(() => {
+    const isTouch =
+      'ontouchstart' in window ||
+      navigator.maxTouchPoints > 0 ||
+      window.matchMedia('(pointer: coarse)').matches;
+    setIsTouchDevice(isTouch);
+  }, []);
+
+  const applyMode = useCallback((m: TouchMode) => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+    if (m === 'pan') {
+      controls.mouseButtons = {
+        LEFT: 2 as never,
+        MIDDLE: 1 as never,
+        RIGHT: 0 as never,
+      };
+    } else {
+      controls.mouseButtons = {
+        LEFT: 0 as never,
+        MIDDLE: 1 as never,
+        RIGHT: 2 as never,
+      };
+    }
+  }, [controlsRef]);
+
+  useEffect(() => {
+    applyMode(mode);
+    const timer = window.setTimeout(() => applyMode(mode), 1000);
+    return () => window.clearTimeout(timer);
+  }, [mode, applyMode]);
+
+  const handleZoom = (direction: '+' | '-') => {
+    const controls = controlsRef.current;
+    if (!controls) return;
+    const camera = controls.object;
+    const offset = camera.position.clone().sub(controls.target);
+    offset.multiplyScalar(direction === '+' ? 0.75 : 1.3);
+    camera.position.copy(controls.target).add(offset);
+    controls.update();
+  };
+
+  if (!isTouchDevice) return <></>;
+
+  return (
+    <div
+      className="pointer-events-auto pc-touch-controls"
+      style={{
+        position: 'absolute',
+        right: 10,
+        top: '50%',
+        transform: 'translateY(-50%)',
+        zIndex: 35,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <TouchButton
+        icon="rotate"
+        label="Orbit Rotation"
+        active={mode === 'orbit'}
+        onClick={() => setMode('orbit')}
+      />
+      <TouchButton
+        icon="target"
+        label="Center"
+        active={mode === 'pan'}
+        onClick={() => setMode('pan')}
+      />
+      <TouchButton
+        icon="magnify"
+        label="Zoom In"
+        onClick={() => handleZoom('+')}
+      />
+      <TouchButton
+        icon="magnify"
+        label="Zoom Out"
+        onClick={() => handleZoom('-')}
+        flipIcon
+      />
+      <TouchButton
+        icon="home"
+        label="Fit"
+        onClick={onFit}
+      />
+    </div>
+  );
+}
+
+function TouchButton({ icon, label, active, onClick, flipIcon }: {
+  icon: PlotcraftIconName;
+  label: string;
+  active?: boolean;
+  onClick(): void;
+  flipIcon?: boolean;
+}): JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`pc-tile${active ? ' pc-tile--active' : ''}`}
+      style={{
+        width: 44,
+        height: 44,
+        borderRadius: 22,
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        gap: 2,
+        background: active ? 'rgba(127,243,255,0.15)' : 'rgba(30, 45, 55, 0.6)',
+        backdropFilter: 'blur(8px)',
+        border: active ? '1.5px solid var(--pc-cyan-glow)' : '1px solid rgba(255,255,255,0.12)',
+        boxShadow: active ? 'var(--pc-halo-cyan-soft)' : '0 2px 8px rgba(0,0,0,0.3)',
+      }}
+      title={label}
+    >
+      <Icon
+        name={icon}
+        size={18}
+        style={{
+          transform: flipIcon ? 'rotate(180deg)' : undefined,
+          color: active ? 'var(--pc-cyan-glow)' : 'var(--pc-paper-soft)',
+        }}
+      />
+      <span
+        style={{
+          fontFamily: 'var(--pc-font-display)',
+          fontWeight: 600,
+          fontSize: 6,
+          letterSpacing: '0.04em',
+          textTransform: 'uppercase',
+          color: active ? 'var(--pc-cyan-glow)' : 'var(--pc-paper-soft)',
+          lineHeight: 1,
+        }}
+      >
+        {label.split(' ')[0]}
+      </span>
+    </button>
+  );
+}

--- a/components/room-organizer/panels/viewport.tsx
+++ b/components/room-organizer/panels/viewport.tsx
@@ -87,6 +87,7 @@ export function Viewport(props: ViewportProps): JSX.Element {
             width: '100%',
             height: '100%',
             display: props.view2D ? 'none' : 'block',
+            touchAction: 'none',
           }}
           onDragOver={handleDragOver}
           onDrop={handleDrop}

--- a/components/room-organizer/panels/wall-paint-panel.tsx
+++ b/components/room-organizer/panels/wall-paint-panel.tsx
@@ -172,7 +172,7 @@ export function WallPaintPanel(props: WallPaintPanelProps): JSX.Element {
 
   return (
     <div
-      className="pointer-events-auto pc-glass"
+      className="pointer-events-auto pc-glass pc-wall-paint"
       style={{ width: 280, padding: '10px 12px' }}
     >
       {/* Title + Surface toggle */}

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -33,6 +33,7 @@ import { LotBadge } from './panels/lot-badge';
 import { SidebarDrawer } from './panels/sidebar-drawer';
 import { HeaderStats } from './panels/header-stats';
 import { ItemContextPopover } from './panels/item-context-popover';
+import { TouchModeToggle } from './panels/touch-mode-toggle';
 import { WelcomeBanner } from './panels/welcome-banner';
 import { FloorPill } from './panels/floor-pill';
 import { WallDisplayPill } from './panels/wall-display-pill';
@@ -807,6 +808,7 @@ export function RoomOrganizer(): JSX.Element {
 
       {/* Top-center: live stats */}
       <div
+        className="pc-header-stats"
         style={{
           position: 'absolute',
           top: 16,
@@ -829,6 +831,7 @@ export function RoomOrganizer(): JSX.Element {
 
       {/* Top-right: floor pill + wall display */}
       <div
+        className="pc-top-right"
         style={{
           position: 'absolute',
           top: 16,
@@ -887,6 +890,9 @@ export function RoomOrganizer(): JSX.Element {
         onFit={fitToRoom}
         placeCatalogItem={placeCatalogItem}
       />
+
+      {/* Touch mode toggle — visible on mobile only */}
+      <TouchModeToggle controlsRef={controlsRef} onFit={fitToRoom} />
 
       {/* Welcome modal — auto-shows once, dismissible */}
       <WelcomeBanner />


### PR DESCRIPTION
### Feature: Add Mobile Support 

  Mobile:
  - Responsive layout with breakpoints at 1100/768/480px
  - Vertical touch controls strip (orbit/pan/zoom/fit)
  - Build tools collapse to horizontal icon strip
  - Catalog strip full-width on mobile
  - Mode panel compact footer with inline total
  - Item popover becomes bottom sheet
  - Sidebar goes full-screen with close button
  - touch-action: none on canvas, viewport meta for no-zoom
  - Camera pad hidden (OrbitControls handles touch natively)

  Other:
  - Achievements disabled by default

Should fix #1 
<img width="233" height="507" alt="Screenshot 2026-06-01 at 12 11 26" src="https://github.com/user-attachments/assets/150ee322-b835-47e1-89af-8586e8ef6869" />
