### PR TITLE
Resolves 2 npm audit vulnerabilities:

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,11 +19,14 @@
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.453.0",
-    "next": "15.0.3",
+    "next": "^15.5.19",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4",
     "three": "^0.169.0"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   },
   "devDependencies": {
     "@types/node": "^20.16.11",
@@ -31,7 +34,7 @@
     "@types/react-dom": "^18.3.0",
     "@types/three": "^0.169.0",
     "autoprefixer": "^10.4.20",
-    "postcss": "^8.4.47",
+    "postcss": "^8.5.10",
     "tailwindcss": "^3.4.13",
     "tailwindcss-animate": "^1.0.7",
     "typescript": "^5.6.3"


### PR DESCRIPTION
Fix for #5 :
- next@15.0.3 critical (CVE-2025-66478): DoS, SSRF, cache poisoning
- postcss <8.5.10 moderate: XSS via unescaped </style>

Added npm overrides for postcss to patch next's bundled copy.

Verification                                                                                                                                                                    
  - [x] `npm audit` returns 0 vulnerabilities                                                                                                                                        
  - [x] `npm run typecheck` passes                          
  - [x] `npm run build` passes                                                                                                                                                       
  - [x] Static export works   