### PR TITLE
Feature: Add wall-mounted Security Camera with animated vision

### DIFF
--- a/components/room-organizer/hooks/use-camera-vision.ts
+++ b/components/room-organizer/hooks/use-camera-vision.ts
@@ -1,0 +1,36 @@
+import { useEffect } from 'react';
+import type * as ThreeNS from 'three';
+import { stepVisionCones } from '../three/camera-vision';
+
+type ThreeModule = typeof import('three');
+
+export interface UseCameraVisionOptions {
+  enabled: boolean;
+  threeModuleRef: React.MutableRefObject<ThreeModule | null>;
+  sceneRef: React.MutableRefObject<ThreeNS.Scene | null>;
+}
+
+/**
+ * Animates the security cameras' vision cones — sweeping the scan line across
+ * each field of view and pulsing the wedge — every animation frame. The cone
+ * meshes themselves are created/torn down in `useSceneEffects`; this hook only
+ * drives them, so it stays correct across scene rebuilds. The shared render
+ * loop in `useThreeScene` paints the updated transforms.
+ */
+export function useCameraVision({ enabled, threeModuleRef, sceneRef }: UseCameraVisionOptions): void {
+  useEffect(() => {
+    if (!enabled) return undefined;
+    const scene = sceneRef.current;
+    if (!threeModuleRef.current || !scene) return undefined;
+
+    let rafId = 0;
+    const start = performance.now();
+    const tick = () => {
+      rafId = requestAnimationFrame(tick);
+      stepVisionCones(scene, (performance.now() - start) / 1000);
+    };
+    rafId = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(rafId);
+  }, [enabled, threeModuleRef, sceneRef]);
+}

--- a/components/room-organizer/hooks/use-layout-state.ts
+++ b/components/room-organizer/hooks/use-layout-state.ts
@@ -46,6 +46,7 @@ export interface LayoutActions {
   rotateItem(id: string): void;
   moveItem(id: string, x: number, z: number): void;
   resizeItem(id: string, dimension: 'width' | 'depth' | 'height', value: number): void;
+  updateItem(id: string, patch: Partial<FurnitureItem>): void;
   setSofaShape(id: string, shape: SofaShape): void;
   setSignalRange(id: string, range: number): void;
   setColor(id: string, color: string): void;
@@ -117,6 +118,7 @@ export function useLayoutState(initial: RoomLayout = INITIAL_LAYOUT): UseLayoutS
       rotateItem: (id) => dispatch({ type: 'rotateItem', id }),
       moveItem: (id, x, z) => dispatch({ type: 'moveItem', id, x, z }),
       resizeItem: (id, dimension, value) => dispatch({ type: 'resizeItem', id, dimension, value }),
+      updateItem: (id, patch) => dispatch({ type: 'updateItem', id, patch }),
       setSofaShape: (id, shape) => dispatch({ type: 'setSofaShape', id, shape }),
       setSignalRange: (id, range) => dispatch({ type: 'setSignalRange', id, range }),
       setColor: (id, color) => dispatch({ type: 'setColor', id, color }),

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -16,6 +16,7 @@ import { clearMeasurement, measurementDistance, renderMeasurement } from '../thr
 import { setOutdoorVisible } from '../three/outdoor';
 import { buildRoof, removeRoof } from '../three/roof';
 import { addSignalOverlays } from '../three/signal-overlay';
+import { addVisionCones } from '../three/camera-vision';
 import { ROOM_OBJECT_TAGS, applyWallDisplay, buildRoom, removeTagged } from '../three/room-builder';
 import { computeFloorOpenings, computeWallOpenings } from '../three/wall-openings';
 import { createFurnitureModel } from '../three/furniture-builders';
@@ -225,7 +226,7 @@ export function useSceneEffects({
     const scene = sceneRef.current;
     if (!THREE || !scene) return;
 
-    removeTagged(scene, ROOM_OBJECT_TAGS.Furniture, ROOM_OBJECT_TAGS.Signal);
+    removeTagged(scene, ROOM_OBJECT_TAGS.Furniture, ROOM_OBJECT_TAGS.Signal, ROOM_OBJECT_TAGS.CameraVision);
 
     const floorsToRender = view.showAllFloors
       ? layout.floors.map((floor, index) => ({ floor, index }))
@@ -280,13 +281,16 @@ export function useSceneEffects({
       if (view.showWiFiSignals) {
         addSignalOverlays(THREE, scene, floor.items, floorY);
       }
+      if (view.showCameraVision) {
+        addVisionCones(THREE, scene, floor.items, floorY);
+      }
     }
   }, [
     isReady, threeModuleRef, sceneRef,
     layout.floors, layout.width, layout.height,
     activeFloor, activeFloorIndex,
     selectedItemId, extraSelectedIds, highlightedIds,
-    view.showWiFiSignals, view.showAllFloors,
+    view.showWiFiSignals, view.showCameraVision, view.showAllFloors,
   ]);
 
   // Lighting

--- a/components/room-organizer/lib/cctv-models.ts
+++ b/components/room-organizer/lib/cctv-models.ts
@@ -1,0 +1,88 @@
+/**
+ * Curated library of real-world CCTV / security-camera models with their
+ * published specifications, so a placed Security Camera reflects an actual
+ * product instead of made-up numbers.
+ *
+ * `fov` is the HORIZONTAL field of view in degrees and `range` is the
+ * effective IR / night-vision distance in metres — the two figures that drive
+ * the on-floor vision cone. For consumer cameras whose manufacturers only
+ * publish a diagonal FOV, the horizontal value is derived for a 16:9 sensor
+ * (≈ diagonal × 0.87) and the original diagonal is kept in `note`.
+ *
+ * Specs sourced from manufacturer datasheets / official spec pages
+ * (Hikvision, Axis, Dahua, Hanwha Vision, Reolink, Ubiquiti, Google, Ring,
+ * Arlo) — see the PR description for the citations.
+ */
+
+export type CctvModelType = 'Dome' | 'Bullet' | 'PTZ' | 'Indoor' | 'Battery';
+
+export interface CctvModel {
+  id: string;
+  brand: string;
+  model: string;
+  type: CctvModelType;
+  /** Horizontal field of view, degrees. */
+  fov: number;
+  /** Effective IR / night-vision range, metres. */
+  range: number;
+  /** Headline resolution as marketed. */
+  resolution: string;
+  /** Lens / FOV caveats worth surfacing (varifocal ranges, diagonal source). */
+  note?: string;
+}
+
+export const CCTV_MODELS: readonly CctvModel[] = [
+  { id: 'hik-2cd2143g2', brand: 'Hikvision', model: 'DS-2CD2143G2-I', type: 'Dome', fov: 103, range: 30, resolution: '4 MP', note: '2.8 mm fixed lens' },
+  { id: 'axis-p3245lve', brand: 'Axis', model: 'P3245-LVE', type: 'Dome', fov: 100, range: 40, resolution: '1080p', note: 'Varifocal 100°–36°' },
+  { id: 'dahua-hfw2831t', brand: 'Dahua', model: 'IPC-HFW2831T-AS', type: 'Bullet', fov: 105, range: 80, resolution: '4K · 8 MP', note: '2.8 mm, 80 m IR' },
+  { id: 'reolink-rlc810a', brand: 'Reolink', model: 'RLC-810A', type: 'Bullet', fov: 87, range: 30, resolution: '4K · 8 MP', note: '4 mm fixed lens' },
+  { id: 'hanwha-qno8080r', brand: 'Hanwha', model: 'Wisenet QNO-8080R', type: 'Bullet', fov: 100, range: 30, resolution: '5 MP', note: 'Varifocal 100°–31°' },
+  { id: 'unifi-g5-bullet', brand: 'Ubiquiti', model: 'UniFi G5 Bullet', type: 'Bullet', fov: 84, range: 10, resolution: '2K · 4 MP' },
+  { id: 'hik-2de4425iw', brand: 'Hikvision', model: 'DS-2DE4425IW-DE', type: 'PTZ', fov: 55, range: 100, resolution: '4 MP', note: '25× zoom, 55°–2.4°' },
+  { id: 'nest-cam-battery', brand: 'Google', model: 'Nest Cam (battery)', type: 'Indoor', fov: 113, range: 6, resolution: '1080p', note: '130° diagonal' },
+  { id: 'ring-spotlight-plus', brand: 'Ring', model: 'Spotlight Cam Plus', type: 'Battery', fov: 115, range: 9, resolution: '1080p', note: '143° diagonal' },
+  { id: 'arlo-pro5s', brand: 'Arlo', model: 'Pro 5S', type: 'Battery', fov: 130, range: 7, resolution: '2K · 4 MP', note: '160° diagonal' },
+  // Additional common models (reuse the five existing shapes via `type`).
+  { id: 'hik-colorvu-2047', brand: 'Hikvision', model: 'DS-2CD2047G2-LU ColorVu', type: 'Bullet', fov: 112, range: 40, resolution: '4 MP', note: '2.8 mm, full-colour night' },
+  { id: 'dahua-wizsense-3441', brand: 'Dahua', model: 'IPC-HDBW3441E-AS WizSense', type: 'Dome', fov: 103, range: 50, resolution: '4 MP', note: '2.8 mm' },
+  { id: 'axis-m2036le', brand: 'Axis', model: 'M2036-LE', type: 'Bullet', fov: 129, range: 20, resolution: '4 MP', note: '2.4 mm wide' },
+  { id: 'amcrest-ip8m2496', brand: 'Amcrest', model: 'IP8M-2496E', type: 'Bullet', fov: 112, range: 40, resolution: '4K · 8 MP', note: '2.8 mm' },
+  { id: 'lorex-e892ab', brand: 'Lorex', model: 'E892AB', type: 'Bullet', fov: 108, range: 30, resolution: '4K · 8 MP', note: '2.8 mm, deterrence light' },
+  { id: 'tapo-c320ws', brand: 'TP-Link', model: 'Tapo C320WS', type: 'Bullet', fov: 97, range: 30, resolution: '2K · 4 MP', note: 'colour night vision' },
+  { id: 'eufycam-3', brand: 'eufy', model: 'eufyCam 3 (S330)', type: 'Battery', fov: 130, range: 10, resolution: '4K · 8 MP', note: '135° FOV, solar' },
+  { id: 'wyze-cam-v3', brand: 'Wyze', model: 'Cam v3', type: 'Indoor', fov: 105, range: 9, resolution: '1080p', note: '121° diagonal' },
+  { id: 'blink-outdoor-4', brand: 'Blink', model: 'Outdoor 4', type: 'Battery', fov: 124, range: 8, resolution: '1080p', note: '143° diagonal' },
+];
+
+/** Default model a freshly-placed Security Camera adopts. */
+export const DEFAULT_CCTV_MODEL_ID = 'hik-2cd2143g2';
+
+export function getCctvModel(id: string | undefined): CctvModel | undefined {
+  if (!id) return undefined;
+  return CCTV_MODELS.find((entry) => entry.id === id);
+}
+
+/** Order the dedicated camera menu groups the models by. */
+export const CCTV_TYPE_ORDER: readonly CctvModelType[] = ['Dome', 'Bullet', 'PTZ', 'Indoor', 'Battery'];
+
+/** One-line description of each form factor for the camera menu tiles. */
+export const CCTV_TYPE_BLURB: Record<CctvModelType, string> = {
+  Dome: 'Wide-angle dome',
+  Bullet: 'Long-range barrel',
+  PTZ: 'Pan-tilt-zoom dome',
+  Indoor: 'Compact indoor pod',
+  Battery: 'Wireless spotlight cam',
+};
+
+/** The model placed when a user picks a type tile (they can switch model after). */
+export const REPRESENTATIVE_MODEL_BY_TYPE: Record<CctvModelType, string> = {
+  Dome: 'hik-2cd2143g2',
+  Bullet: 'reolink-rlc810a',
+  PTZ: 'hik-2de4425iw',
+  Indoor: 'nest-cam-battery',
+  Battery: 'ring-spotlight-plus',
+};
+
+export function modelsOfType(type: CctvModelType): CctvModel[] {
+  return CCTV_MODELS.filter((entry) => entry.type === type);
+}

--- a/components/room-organizer/lib/constants.ts
+++ b/components/room-organizer/lib/constants.ts
@@ -9,6 +9,9 @@ export const CURRENCY_SYMBOL = '$';
 
 export const MAX_FLOORS = 4;
 
+/** How far a bracketed security camera stands off the wall, in metres. */
+export const CAMERA_BRACKET_ARM = 0.22;
+
 export const CATEGORIES: readonly CategoryMeta[] = [
   { key: 'seating', label: 'Seating', icon: '🪑' },
   { key: 'tables', label: 'Tables', icon: '🟫' },
@@ -17,6 +20,7 @@ export const CATEGORIES: readonly CategoryMeta[] = [
   { key: 'kitchen', label: 'Kitchen', icon: '🍳' },
   { key: 'bathroom', label: 'Bathroom', icon: '🛁' },
   { key: 'electronics', label: 'Electronics', icon: '📺' },
+  { key: 'security', label: 'Security', icon: '🎥' },
   { key: 'decor', label: 'Decor', icon: '🪴' },
   { key: 'outdoor', label: 'Outdoor', icon: '🌳' },
   { key: 'people', label: 'People', icon: '🧍' },
@@ -69,6 +73,10 @@ export const FURNITURE_CATALOG = [
   { type: 'wifi', category: 'electronics', name: 'Wi-Fi AP', width: 0.2, depth: 0.2, height: 0.1, color: '#0088FF', icon: '📶', price: 140, isWiFiAccessPoint: true, signalRange: 10 },
   { type: 'router', category: 'electronics', name: 'Router', width: 0.3, depth: 0.2, height: 0.1, color: '#1a1a1a', icon: '🌐', price: 160 },
   { type: 'cctv', category: 'electronics', name: 'CCTV Camera', width: 0.15, depth: 0.15, height: 0.2, color: '#2C2C2C', icon: '📹', price: 230, isCCTV: true, signalRange: 8 },
+  // Security — cameras live in their own category and are browsed via the
+  // dedicated CctvMenu (grouped by type); this base entry backs every model.
+  // Defaults mirror the Hikvision DS-2CD2143G2-I dome (see lib/cctv-models); height doubles as the wall-mount height (≈2.4 m).
+  { type: 'security-camera', category: 'security', name: 'Security Camera', width: 0.25, depth: 0.2, height: 2.4, color: '#1F2933', icon: '🎥', price: 380, hasVisionCone: true, visionRange: 30, visionFov: 103, cctvModelId: 'hik-2cd2143g2' },
 
   // Decor
   { type: 'plant', category: 'decor', name: 'House Plant', width: 0.4, depth: 0.4, height: 1.0, color: '#228B22', icon: '🪴', price: 60 },

--- a/components/room-organizer/lib/geometry.ts
+++ b/components/room-organizer/lib/geometry.ts
@@ -29,6 +29,9 @@ export function hasCollisions(
   roomDepth: number
 ): boolean {
   if (!item.position) return false;
+  // Security cameras mount on the wall plane and may sit on its exterior side
+  // when aimed outward, so the room-bounds test doesn't apply to them.
+  if (item.type === 'security-camera') return false;
   if (!itemInBounds(item, roomWidth, roomDepth)) return true;
   return allItems.some((other) => other.id !== item.id && itemsOverlap(item, other));
 }

--- a/components/room-organizer/lib/opening-snap.ts
+++ b/components/room-organizer/lib/opening-snap.ts
@@ -116,3 +116,71 @@ function projectOntoSegment(
 export function isOpening(type: string): boolean {
   return type === 'door' || type === 'window';
 }
+
+
+/**
+ * Items that belong flush against a wall. Openings (doors/windows) cut through
+ * the wall; surface-mounted items (security cameras) sit against it and face
+ * into the room.
+ */
+export function isWallMounted(type: string): boolean {
+  return isOpening(type) || type === 'security-camera';
+}
+
+/**
+ * Snap a surface-mounted item (e.g. a security camera) to the nearest wall,
+ * then inset its centre into the room by half its depth so the body's back
+ * face rests on the wall and the footprint stays in-bounds (otherwise
+ * `itemInBounds` would flag a false collision). The returned rotation faces
+ * the item's local +Z axis into the room, matching how the camera and its
+ * vision cone are modelled.
+ */
+export function snapWallMountedItem(options: SnapOpeningOptions & { itemDepth: number }): OpeningSnap {
+  const snap = snapOpeningToWall(options);
+  const inset = options.itemDepth / 2 + 0.02;
+  // Three.js rotation.y maps the local +Z axis to (sin θ, cos θ) in world XZ;
+  // that direction points into the room for every wall snapOpeningToWall picks.
+  const forwardX = Math.sin(snap.rotation);
+  const forwardZ = Math.cos(snap.rotation);
+  return {
+    ...snap,
+    position: {
+      x: snap.position.x + forwardX * inset,
+      z: snap.position.z + forwardZ * inset,
+    },
+  };
+}
+
+/**
+ * Re-seat a wall-mounted item against the nearest wall.
+ *
+ * - Default (flush): the item's back rests on the wall and its body sits on
+ *   whichever side it currently *faces*, so a camera turned to face outside
+ *   moves to the exterior side and its cone starts at the wall surface instead
+ *   of passing through it.
+ * - With `bracketArm`: the item stands off the wall by that distance along the
+ *   wall's inward normal (a stand-off mount), independent of facing — so a
+ *   bracketed camera can pan freely while its base stays on the wall.
+ */
+export function reseatWallMountedItem(
+  options: SnapOpeningOptions & { itemDepth: number; rotation: number; bracketArm?: number }
+): { x: number; z: number } {
+  const snap = snapOpeningToWall(options); // wall-plane point + inward-facing rotation
+  const inwardX = Math.sin(snap.rotation);
+  const inwardZ = Math.cos(snap.rotation);
+  if (options.bracketArm != null) {
+    return {
+      x: snap.position.x + inwardX * options.bracketArm,
+      z: snap.position.z + inwardZ * options.bracketArm,
+    };
+  }
+  const facingX = Math.sin(options.rotation);
+  const facingZ = Math.cos(options.rotation);
+  // +1 if the item faces the room interior, −1 if it faces the exterior.
+  const side = facingX * inwardX + facingZ * inwardZ >= 0 ? 1 : -1;
+  const inset = options.itemDepth / 2 + 0.02;
+  return {
+    x: snap.position.x + inwardX * side * inset,
+    z: snap.position.z + inwardZ * side * inset,
+  };
+}

--- a/components/room-organizer/lib/types.ts
+++ b/components/room-organizer/lib/types.ts
@@ -27,6 +27,7 @@ export type FurnitureType =
   | 'wifi'
   | 'router'
   | 'cctv'
+  | 'security-camera'
   | 'fridge'
   | 'stove'
   | 'dishwasher'
@@ -62,6 +63,7 @@ export type FurnitureCategory =
   | 'kitchen'
   | 'bathroom'
   | 'electronics'
+  | 'security'
   | 'decor'
   | 'outdoor'
   | 'people'
@@ -90,6 +92,25 @@ export interface FurnitureItem {
   isWiFiAccessPoint?: boolean;
   isCCTV?: boolean;
   signalRange?: number;
+  /** When true, this item projects a Desperados-style directional vision cone. */
+  hasVisionCone?: boolean;
+  /** How far the vision cone reaches into the room, in metres. */
+  visionRange?: number;
+  /** Horizontal field of view of the vision cone, in degrees. */
+  visionFov?: number;
+  /** Id of the real-world CCTV model this camera mimics (see lib/cctv-models). */
+  cctvModelId?: string;
+  /**
+   * Yaw (radians) of the inward normal of the wall a camera is mounted on — its
+   * in/out axis. A flush camera's rotation is locked to this or this + π.
+   */
+  wallRotation?: number;
+  /**
+   * When true, a security camera sits on a stand-off bracket arm and can pan
+   * left/right freely; otherwise it is flush-mounted and locked to facing
+   * straight into the room or straight out.
+   */
+  cameraBracket?: boolean;
   sofaShape?: SofaShape;
   locked?: boolean;
   mirrored?: boolean;
@@ -195,6 +216,8 @@ export interface ViewSettings {
   showItemLabels: boolean;
   /** When true, animated NPCs wander the active floor. */
   showNpcs: boolean;
+  /** When true, security cameras project an animated vision cone on the floor. */
+  showCameraVision: boolean;
 }
 
 export type ThemeKey = 'modern' | 'rustic' | 'minimalist' | 'cozy' | 'tropical';

--- a/components/room-organizer/panels/build-tools-panel.tsx
+++ b/components/room-organizer/panels/build-tools-panel.tsx
@@ -21,6 +21,7 @@ const TOOLS: readonly ToolSpec[] = [
   { key: 'bathroom',    icon: 'bath',      label: 'Bathroom' },
   { key: 'decor',       icon: 'plant',     label: 'Decor'    },
   { key: 'electronics', icon: 'light',     label: 'Tech'     },
+  { key: 'security',    icon: 'vision',    label: 'Security' },
 ];
 
 export interface BuildToolsPanelProps {

--- a/components/room-organizer/panels/catalog-strip.tsx
+++ b/components/room-organizer/panels/catalog-strip.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { CATEGORIES, CURRENCY_SYMBOL, FURNITURE_CATALOG } from '../lib/constants';
 import { CATALOG_DRAG_MIME } from '../lib/catalog-drag';
 import { Icon, iconForItem, type PlotcraftIconName } from '../plotcraft/icon';
+import { CctvMenu } from './cctv-menu';
 import type { CatalogItem, FurnitureCategory } from '../lib/types';
 
 const PAGE_SIZE = 8;
@@ -15,6 +16,35 @@ export interface CatalogStripProps {
 
 export function CatalogStrip({ category, onAdd }: CatalogStripProps): JSX.Element {
   const [page, setPage] = useState(0);
+
+  // Cameras get a dedicated, type-grouped menu rather than the paged grid.
+  if (category === 'security') {
+    return (
+      <div
+        className="pointer-events-auto pc-glass pc-catalog-strip"
+        style={{ width: 540, maxWidth: '100%', padding: '10px 14px 12px' }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8 }}>
+          <div className="pc-hud-header" style={{ fontSize: 12 }}>
+            Security Cameras
+          </div>
+          <div style={{ flex: 1, height: 1, background: 'var(--pc-glass-inner)' }} />
+        </div>
+        <div
+          style={{
+            background: 'rgba(0, 0, 0, 0.20)',
+            border: '1px solid rgba(255, 255, 255, 0.08)',
+            borderRadius: 14,
+            padding: 8,
+            boxShadow: 'inset 0 2px 6px rgba(0, 0, 0, 0.35)',
+          }}
+        >
+          <CctvMenu variant="strip" onAdd={onAdd} />
+        </div>
+      </div>
+    );
+  }
+
   const items =
     category === 'all'
       ? FURNITURE_CATALOG

--- a/components/room-organizer/panels/cctv-menu.tsx
+++ b/components/room-organizer/panels/cctv-menu.tsx
@@ -1,0 +1,126 @@
+'use client';
+
+import { FURNITURE_CATALOG } from '../lib/constants';
+import {
+  CCTV_TYPE_ORDER,
+  CCTV_TYPE_BLURB,
+  REPRESENTATIVE_MODEL_BY_TYPE,
+  getCctvModel,
+  modelsOfType,
+  type CctvModelType,
+} from '../lib/cctv-models';
+import { Icon } from '../plotcraft/icon';
+import type { CatalogItem } from '../lib/types';
+
+const BASE_CAMERA = FURNITURE_CATALOG.find((entry) => entry.type === 'security-camera');
+
+/** Build the catalog item placed when a camera type is chosen — the base camera
+ *  carrying that type's representative model so the cone + silhouette are right. */
+function catalogItemForType(type: CctvModelType): CatalogItem | null {
+  const model = getCctvModel(REPRESENTATIVE_MODEL_BY_TYPE[type]);
+  if (!BASE_CAMERA || !model) return null;
+  return {
+    ...BASE_CAMERA,
+    name: `${type} Camera`,
+    cctvModelId: model.id,
+    visionFov: model.fov,
+    visionRange: model.range,
+  };
+}
+
+export interface CctvMenuProps {
+  /** 'strip' = dark bottom catalog; 'panel' = light sidebar Buy tab. */
+  variant: 'strip' | 'panel';
+  onAdd(item: CatalogItem): void;
+}
+
+export function CctvMenu({ variant, onAdd }: CctvMenuProps): JSX.Element {
+  return variant === 'strip' ? <StripMenu onAdd={onAdd} /> : <PanelMenu onAdd={onAdd} />;
+}
+
+/** Dark, horizontal row of five type tiles for the bottom catalog strip. */
+function StripMenu({ onAdd }: { onAdd(item: CatalogItem): void }): JSX.Element {
+  return (
+    <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 6 }}>
+      {CCTV_TYPE_ORDER.map((type) => {
+        const item = catalogItemForType(type);
+        if (!item) return null;
+        const count = modelsOfType(type).length;
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onAdd(item)}
+            title={`${type} camera — ${CCTV_TYPE_BLURB[type]} (${count} model${count > 1 ? 's' : ''})`}
+            className="pc-tile"
+            style={{
+              height: 64,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+              justifyContent: 'center',
+              gap: 3,
+              padding: 4,
+            }}
+          >
+            <Icon name="vision" size={20} />
+            <span
+              style={{
+                fontFamily: 'var(--pc-font-display)',
+                fontWeight: 700,
+                fontSize: 9,
+                letterSpacing: '0.04em',
+                textTransform: 'uppercase',
+                lineHeight: 1,
+              }}
+            >
+              {type}
+            </span>
+            <span style={{ fontSize: 8, opacity: 0.7, lineHeight: 1 }}>
+              {count} model{count > 1 ? 's' : ''}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** Light, vertical list of five type rows for the sidebar Buy tab. */
+function PanelMenu({ onAdd }: { onAdd(item: CatalogItem): void }): JSX.Element {
+  return (
+    <div className="flex flex-col gap-2">
+      {CCTV_TYPE_ORDER.map((type) => {
+        const item = catalogItemForType(type);
+        if (!item) return null;
+        const models = modelsOfType(type);
+        const rep = getCctvModel(REPRESENTATIVE_MODEL_BY_TYPE[type]);
+        return (
+          <button
+            key={type}
+            type="button"
+            onClick={() => onAdd(item)}
+            className="group flex items-center gap-3 rounded-xl border bg-gradient-to-b from-white to-slate-50 hover:from-amber-50 hover:to-amber-100 hover:border-amber-300 active:scale-[0.99] transition-all p-2.5 text-left shadow-sm"
+          >
+            <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-slate-900 text-cyan-300">
+              <Icon name="vision" size={18} />
+            </span>
+            <span className="min-w-0 flex-1">
+              <span className="block text-xs font-semibold leading-tight">{type} Camera</span>
+              <span className="block truncate text-[10px] text-muted-foreground">
+                {CCTV_TYPE_BLURB[type]}
+                {rep ? ` · e.g. ${rep.brand} ${rep.model}` : ''}
+              </span>
+            </span>
+            <span className="shrink-0 text-[10px] font-medium text-amber-700">
+              {models.length} model{models.length > 1 ? 's' : ''}
+            </span>
+          </button>
+        );
+      })}
+      <p className="mt-1 text-center text-[10px] text-muted-foreground">
+        Drops on the nearest wall · switch the exact model in its panel
+      </p>
+    </div>
+  );
+}

--- a/components/room-organizer/panels/furniture-catalog-panel.tsx
+++ b/components/room-organizer/panels/furniture-catalog-panel.tsx
@@ -5,6 +5,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { CATEGORIES, CURRENCY_SYMBOL, FURNITURE_CATALOG } from '../lib/constants';
 import { CATALOG_DRAG_MIME } from '../lib/catalog-drag';
+import { CCTV_MODELS } from '../lib/cctv-models';
+import { CctvMenu } from './cctv-menu';
 import type { CatalogItem, CategoryMeta, FurnitureCategory } from '../lib/types';
 
 type FilterKey = 'all' | FurnitureCategory;
@@ -61,7 +63,9 @@ export function FurnitureCatalogPanel({
         <CategoryRail filter={filter} onSelect={setFilter} />
       </CardHeader>
       <CardContent className="pt-3">
-        {filtered.length === 0 ? (
+        {filter === 'security' ? (
+          <CctvMenu variant="panel" onAdd={onAdd} />
+        ) : filtered.length === 0 ? (
           <p className="text-xs text-muted-foreground py-8 text-center">
             No items match this filter.
             <br />
@@ -103,7 +107,7 @@ function CategoryRail({ filter, onSelect }: CategoryRailProps): JSX.Element {
           active={filter === category.key}
           icon={category.icon}
           label={category.label}
-          count={COUNTS_BY_CATEGORY.get(category.key) ?? 0}
+          count={category.key === 'security' ? CCTV_MODELS.length : (COUNTS_BY_CATEGORY.get(category.key) ?? 0)}
           onClick={() => onSelect(category.key)}
         />
       ))}

--- a/components/room-organizer/panels/item-context-popover.tsx
+++ b/components/room-organizer/panels/item-context-popover.tsx
@@ -3,6 +3,7 @@
 import { useId } from 'react';
 import { Icon, iconForItem, type PlotcraftIconName } from '../plotcraft/icon';
 import type { SofaShape } from '../lib/types';
+import { CCTV_MODELS, getCctvModel } from '../lib/cctv-models';
 import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
 
@@ -41,6 +42,7 @@ export interface ItemContextPopoverProps {
   onRemove(id: string): void;
   onDuplicate(id: string): void;
   onRotate(id: string): void;
+  onToggleCameraBracket(id: string): void;
   onClose(): void;
 }
 
@@ -106,17 +108,29 @@ export function ItemContextPopover(props: ItemContextPopoverProps): JSX.Element 
             >
               {item.name}
             </p>
-            {item.position && (
+            {item.type === 'security-camera' ? (
               <p
                 className="pc-blurb"
-                style={{
-                  margin: 0,
-                  fontSize: 10,
-                  fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-                }}
+                style={{ margin: 0, fontSize: 10, color: 'var(--pc-cyan-glow)' }}
               >
-                ({item.position.x.toFixed(2)}, {item.position.z.toFixed(2)})
+                {(() => {
+                  const model = getCctvModel(item.cctvModelId);
+                  return model ? `${model.brand} ${model.model}` : 'Custom camera';
+                })()}
               </p>
+            ) : (
+              item.position && (
+                <p
+                  className="pc-blurb"
+                  style={{
+                    margin: 0,
+                    fontSize: 10,
+                    fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+                  }}
+                >
+                  ({item.position.x.toFixed(2)}, {item.position.z.toFixed(2)})
+                </p>
+              )
             )}
           </div>
         </div>
@@ -139,7 +153,7 @@ export function ItemContextPopover(props: ItemContextPopoverProps): JSX.Element 
         </button>
       </header>
 
-      <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12 }}>
+      <div style={{ padding: 12, display: 'flex', flexDirection: 'column', gap: 12, maxHeight: 'calc(100vh - 180px)', overflowY: 'auto' }}>
         {props.hasCollision && (
           <div
             className="pc-body"
@@ -154,6 +168,62 @@ export function ItemContextPopover(props: ItemContextPopoverProps): JSX.Element 
           >
             Overlaps another item or escapes the room.
           </div>
+        )}
+
+        {item.type === 'security-camera' && (
+          <CameraModelCard
+            modelId={item.cctvModelId ?? ''}
+            fov={item.visionFov ?? 70}
+            range={item.visionRange ?? 7}
+            onPickModel={(modelId) => {
+              const model = getCctvModel(modelId);
+              if (model) {
+                actions.updateItem(item.id, {
+                  cctvModelId: model.id,
+                  visionFov: model.fov,
+                  visionRange: model.range,
+                });
+              } else {
+                actions.updateItem(item.id, { cctvModelId: '' });
+              }
+            }}
+            onSetFov={(value) => actions.updateItem(item.id, { visionFov: value, cctvModelId: '' })}
+            onSetRange={(value) => actions.updateItem(item.id, { visionRange: value, cctvModelId: '' })}
+          />
+        )}
+
+        {item.type === 'security-camera' && (
+          <button
+            type="button"
+            onClick={() => props.onToggleCameraBracket(item.id)}
+            aria-pressed={item.cameraBracket === true}
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 8,
+              padding: '8px 10px',
+              borderRadius: 8,
+              cursor: 'pointer',
+              border: '1px solid rgba(255,255,255,0.12)',
+              background: item.cameraBracket ? 'rgba(56,189,248,0.18)' : 'rgba(255,255,255,0.04)',
+              color: 'inherit',
+              textAlign: 'left',
+              font: 'inherit',
+            }}
+          >
+            <span style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              <span style={{ fontSize: 12, fontWeight: 600 }}>Stand-off bracket</span>
+              <span style={{ fontSize: 10.5, opacity: 0.7 }}>
+                {item.cameraBracket
+                  ? 'On its arm — pan left/right freely'
+                  : 'Flush mount — Rotate flips in/out only'}
+              </span>
+            </span>
+            <span style={{ fontSize: 11, fontWeight: 700, opacity: 0.9 }}>
+              {item.cameraBracket ? 'ON' : 'OFF'}
+            </span>
+          </button>
         )}
 
         <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 4 }}>
@@ -428,6 +498,194 @@ function SignalRangeRow({ label, value, min, max, onChange }: SignalRangeRowProp
         }}
       >
         {value.toFixed(1)} m
+      </span>
+    </div>
+  );
+}
+
+interface CameraModelCardProps {
+  modelId: string;
+  fov: number;
+  range: number;
+  onPickModel(modelId: string): void;
+  onSetFov(value: number): void;
+  onSetRange(value: number): void;
+}
+
+function CameraModelCard({ modelId, fov, range, onPickModel, onSetFov, onSetRange }: CameraModelCardProps): JSX.Element {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+        padding: 10,
+        borderRadius: 12,
+        background: 'rgba(127,243,255,0.08)',
+        border: '1px solid var(--pc-cyan-glow)',
+        boxShadow: 'var(--pc-halo-cyan-soft)',
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+        <Icon name="vision" size={14} style={{ color: 'var(--pc-cyan-glow)' }} />
+        <span
+          style={{
+            fontFamily: 'var(--pc-font-display)',
+            fontWeight: 700,
+            fontSize: 11,
+            letterSpacing: 'var(--pc-tr-caps)',
+            textTransform: 'uppercase',
+            color: 'var(--pc-cyan-glow)',
+          }}
+        >
+          Choose a real camera
+        </span>
+      </div>
+      <CctvModelRow value={modelId} onChange={onPickModel} />
+      <VisionSliderRow
+        label="FOV"
+        value={fov}
+        min={20}
+        max={140}
+        step={1}
+        format={(v) => `${Math.round(v)}°`}
+        onChange={onSetFov}
+      />
+      <VisionSliderRow
+        label="Range"
+        value={range}
+        min={2}
+        max={100}
+        step={0.5}
+        format={(v) => `${v.toFixed(1)} m`}
+        onChange={onSetRange}
+      />
+    </div>
+  );
+}
+
+const CCTV_TYPES = ['Dome', 'Bullet', 'PTZ', 'Indoor', 'Battery'] as const;
+
+interface CctvModelRowProps {
+  value: string;
+  onChange(modelId: string): void;
+}
+
+function CctvModelRow({ value, onChange }: CctvModelRowProps): JSX.Element {
+  const id = useId();
+  const selected = getCctvModel(value);
+  const spec = selected
+    ? `${selected.type} · ${selected.resolution} · ${selected.fov}° · ${selected.range} m IR${selected.note ? ` · ${selected.note}` : ''}`
+    : 'Custom — tune FOV and range below';
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
+      <label
+        htmlFor={id}
+        style={{
+          fontFamily: 'var(--pc-font-display)',
+          fontWeight: 600,
+          fontSize: 10,
+          letterSpacing: 'var(--pc-tr-caps)',
+          textTransform: 'uppercase',
+          color: 'var(--pc-paper-soft)',
+        }}
+      >
+        Camera model
+      </label>
+      <select
+        id={id}
+        value={value}
+        onChange={(event) => onChange(event.target.value)}
+        style={{
+          width: '100%',
+          padding: '6px 8px',
+          borderRadius: 8,
+          background: 'rgba(0,0,0,0.30)',
+          border: '1px solid rgba(255,255,255,0.12)',
+          color: 'var(--pc-paper)',
+          fontFamily: 'var(--pc-font-display)',
+          fontSize: 11,
+        }}
+      >
+        <option value="">Custom</option>
+        {CCTV_TYPES.map((type) => {
+          const models = CCTV_MODELS.filter((entry) => entry.type === type);
+          if (models.length === 0) return null;
+          return (
+            <optgroup key={type} label={type}>
+              {models.map((entry) => (
+                <option key={entry.id} value={entry.id}>
+                  {entry.brand} {entry.model}
+                </option>
+              ))}
+            </optgroup>
+          );
+        })}
+      </select>
+      <span
+        style={{
+          fontFamily: 'var(--pc-font-body)',
+          fontSize: 9.5,
+          lineHeight: 1.3,
+          color: 'var(--pc-paper-soft)',
+        }}
+      >
+        {spec}
+      </span>
+    </div>
+  );
+}
+
+interface VisionSliderRowProps {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  format(value: number): string;
+  onChange(value: number): void;
+}
+
+function VisionSliderRow({ label, value, min, max, step, format, onChange }: VisionSliderRowProps): JSX.Element {
+  const id = useId();
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <label
+        htmlFor={id}
+        style={{
+          width: 48,
+          fontFamily: 'var(--pc-font-display)',
+          fontWeight: 600,
+          fontSize: 10,
+          letterSpacing: 'var(--pc-tr-caps)',
+          textTransform: 'uppercase',
+          color: 'var(--pc-paper-soft)',
+        }}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(parseFloat(event.target.value))}
+        style={{ flex: 1, accentColor: 'var(--pc-cyan-glow)' }}
+      />
+      <span
+        style={{
+          width: 48,
+          textAlign: 'right',
+          fontFamily: 'var(--pc-font-display)',
+          fontWeight: 600,
+          fontSize: 10,
+          fontVariantNumeric: 'tabular-nums',
+          color: 'var(--pc-paper)',
+        }}
+      >
+        {format(value)}
       </span>
     </div>
   );

--- a/components/room-organizer/panels/mode-panel.tsx
+++ b/components/room-organizer/panels/mode-panel.tsx
@@ -150,6 +150,12 @@ export function ModePanel({ onSetMode, onSurprise }: ModePanelProps): JSX.Elemen
           active={view.soundsEnabled}
           onClick={() => toggle('soundsEnabled')}
         />
+        <ActionButton
+          label={view.showCameraVision ? 'Hide camera cones' : 'Show camera cones'}
+          icon="vision"
+          active={view.showCameraVision}
+          onClick={() => toggle('showCameraVision')}
+        />
       </div>
     </div>
   );

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
-import type { CameraPreset, RoomLayout } from '../lib/types';
+import type { CameraPreset, CatalogItem, RoomLayout } from '../lib/types';
 import type { AlignEdge, DistributeAxis } from '../lib/alignment';
 import { alignSelection, distributeSelection } from '../lib/alignment';
 import { hasCollisions } from '../lib/geometry';
@@ -42,6 +42,8 @@ export interface SidebarDrawerProps {
   onImport(file: File): void;
   onExportGlb(): void;
   onShareLink(): void;
+  /** Wall-aware placement (snaps doors/windows/cameras to walls) shared with the bottom catalog. */
+  placeCatalogItem(catalogItem: CatalogItem, position?: { x: number; z: number }): string;
 }
 
 export function SidebarDrawer({
@@ -54,6 +56,7 @@ export function SidebarDrawer({
   onImport,
   onExportGlb,
   onShareLink,
+  placeCatalogItem,
 }: SidebarDrawerProps): JSX.Element {
   const { layout, activeFloor, actions, view, isReady, playCue, history, catalogQuery, setCatalogQuery } = useRoomEditor();
   const { selectedItem, setSelectedItemId, allSelectedIds } = useSelection();
@@ -71,11 +74,6 @@ export function SidebarDrawer({
     actions.removeItem(id);
     playCue('remove');
     setSelectedItemId((current) => (current === id ? null : current));
-  };
-
-  const placeCatalogItem = (catalogItem: Parameters<typeof actions.addCatalogItem>[0]) => {
-    const id = actions.addCatalogItem(catalogItem);
-    return id;
   };
 
   const handleFloorPlanUpload = async (file: File) => {

--- a/components/room-organizer/plotcraft/icon.tsx
+++ b/components/room-organizer/plotcraft/icon.tsx
@@ -84,7 +84,8 @@ export type PlotcraftIconName =
   // HUD toggles
   | 'minimap'
   | 'grid'
-  | 'sound';
+  | 'sound'
+  | 'vision';
 
 const PATHS: Record<PlotcraftIconName, ReactNode> = {
   wall: (
@@ -557,6 +558,12 @@ const PATHS: Record<PlotcraftIconName, ReactNode> = {
       <path d="M18 5a8 8 0 0 1 0 14" />
     </>
   ),
+  vision: (
+    <>
+      <path d="M5 4l8 7l-8 7z" />
+      <path d="M13 11h6M13 7l5 -1M13 15l5 1" />
+    </>
+  ),
 };
 
 export interface IconProps extends Omit<SVGProps<SVGSVGElement>, 'name'> {
@@ -607,7 +614,7 @@ const TYPE_TO_ICON: Record<string, PlotcraftIconName> = {
   toilet: 'toilet', bathtub: 'bath', shower: 'shower', 'bathroom-sink': 'sink',
   // electronics
   tv: 'tv', computer: 'computer', lamp: 'lamp', 'floor-lamp': 'light',
-  router: 'router', wifi: 'wifi', cctv: 'cctv',
+  router: 'router', wifi: 'wifi', cctv: 'cctv', 'security-camera': 'vision',
   // decor
   plant: 'plant', flowerpot: 'vase', vase: 'vase',
   painting: 'painting', mirror: 'mirror', rug: 'rug',
@@ -629,7 +636,7 @@ const TYPE_TO_ICON: Record<string, PlotcraftIconName> = {
 const CATEGORY_TO_ICON: Record<string, PlotcraftIconName> = {
   seating: 'chair', tables: 'table', bedroom: 'bed', storage: 'box',
   kitchen: 'fireplace', bathroom: 'bath', electronics: 'light',
-  decor: 'plant', outdoor: 'tree', people: 'person', structure: 'window',
+  security: 'vision', decor: 'plant', outdoor: 'tree', people: 'person', structure: 'window',
 };
 
 export function iconForItem(type: string, category?: string): PlotcraftIconName {

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -10,16 +10,17 @@ import { useKeyboardShortcuts } from './hooks/use-keyboard-shortcuts';
 import { useLayoutPersistence } from './hooks/use-layout-persistence';
 import { useLayoutState } from './hooks/use-layout-state';
 import { useNpcs } from './hooks/use-npcs';
+import { useCameraVision } from './hooks/use-camera-vision';
 import { useSceneEffects, measurementDistance } from './hooks/use-scene-effects';
 import { useThreeScene } from './hooks/use-three-scene';
 import { useWalkthrough } from './hooks/use-walkthrough';
-import { GRID_SIZE_METERS } from './lib/constants';
+import { CAMERA_BRACKET_ARM, GRID_SIZE_METERS } from './lib/constants';
 import {
   snapToGrid as snapValueToGrid,
   snapToNeighbors,
   snapToWall as snapPositionToWall,
 } from './lib/geometry';
-import { isOpening, snapOpeningToWall } from './lib/opening-snap';
+import { isOpening, snapOpeningToWall, snapWallMountedItem, reseatWallMountedItem } from './lib/opening-snap';
 import {
   downloadCanvasAsPng,
   downloadSceneAsGlb,
@@ -113,6 +114,7 @@ const INITIAL_VIEW_SETTINGS: ViewSettings = {
   showHeatmap: false,
   showItemLabels: false,
   showNpcs: false,
+  showCameraVision: true,
 };
 
 export function RoomOrganizer(): JSX.Element {
@@ -336,9 +338,110 @@ export function RoomOrganizer(): JSX.Element {
     [actions]
   );
 
-  const handleDragEnd = useCallback(() => {
-    dragOriginsRef.current = null;
-  }, []);
+  const handleDragEnd = useCallback(
+    (id: string) => {
+      dragOriginsRef.current = null;
+      // On release, click a security camera onto the nearest wall and turn it to
+      // face into the room. Doing this on drop (not per drag frame) keeps the
+      // drag itself smooth instead of flipping between walls.
+      const item = activeFloor.items.find((entry) => entry.id === id);
+      if (item?.type === 'security-camera' && item.position) {
+        const snapped = snapWallMountedItem({
+          position: item.position,
+          itemWidth: item.width,
+          itemDepth: item.depth,
+          roomWidth: layout.width,
+          roomDepth: layout.height,
+          interiorWalls: activeFloor.interiorWalls ?? [],
+        });
+        // Record the wall's inward-normal yaw so rotation can be locked to the
+        // in/out axis, then re-seat for the camera's current mount style.
+        actions.updateItem(id, { wallRotation: snapped.rotation });
+        if (item.cameraBracket) {
+          const pos = reseatWallMountedItem({
+            position: item.position,
+            itemWidth: item.width,
+            itemDepth: item.depth,
+            roomWidth: layout.width,
+            roomDepth: layout.height,
+            interiorWalls: activeFloor.interiorWalls ?? [],
+            rotation: item.rotation ?? snapped.rotation,
+            bracketArm: CAMERA_BRACKET_ARM,
+          });
+          actions.moveItem(id, pos.x, pos.z);
+        } else {
+          actions.moveItem(id, snapped.position.x, snapped.position.z);
+          if (Math.abs((item.rotation ?? 0) - snapped.rotation) > 1e-3) {
+            actions.setRotation(id, snapped.rotation);
+          }
+        }
+      }
+    },
+    [activeFloor.items, activeFloor.interiorWalls, layout.width, layout.height, actions]
+  );
+
+  // Re-seat a wall-mounted camera against its wall. A flush camera's body moves
+  // to whichever side it faces (so the body + cone start at the wall surface
+  // instead of passing through it); a bracketed camera stands off the wall by a
+  // fixed arm, independent of facing, so it can pan freely. `bracket` overrides
+  // the stored flag for the moment a user toggles the mount style.
+  const reseatCamera = useCallback(
+    (id: string, rotation: number, bracket?: boolean) => {
+      const item = activeFloor.items.find((entry) => entry.id === id);
+      if (item?.type !== 'security-camera' || !item.position) return;
+      const bracketed = bracket ?? item.cameraBracket ?? false;
+      const pos = reseatWallMountedItem({
+        position: item.position,
+        itemWidth: item.width,
+        itemDepth: item.depth,
+        roomWidth: layout.width,
+        roomDepth: layout.height,
+        interiorWalls: activeFloor.interiorWalls ?? [],
+        rotation,
+        ...(bracketed ? { bracketArm: CAMERA_BRACKET_ARM } : {}),
+      });
+      actions.moveItem(id, pos.x, pos.z);
+    },
+    [activeFloor.items, activeFloor.interiorWalls, layout.width, layout.height, actions]
+  );
+
+  const rotateItemHandler = useCallback(
+    (id: string) => {
+      if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
+        actions.rotateSelection(allSelectedIds, Math.PI / 2);
+        return;
+      }
+      const item = activeFloor.items.find((entry) => entry.id === id);
+      if (item?.type === 'security-camera') {
+        // A flush camera can only face into the room or straight out, so Rotate
+        // flips 180° along its wall's in/out axis. A bracketed camera pans freely.
+        const step = item.cameraBracket ? Math.PI / 2 : Math.PI;
+        const next = ((item.rotation ?? 0) + step) % (Math.PI * 2);
+        actions.setRotation(id, next);
+        reseatCamera(id, next);
+        return;
+      }
+      const next = ((item?.rotation ?? 0) + Math.PI / 2) % (Math.PI * 2);
+      actions.setRotation(id, next);
+    },
+    [allSelectedIds, activeFloor.items, actions, reseatCamera]
+  );
+
+  // Toggle a camera's stand-off bracket. Enabling it keeps the current facing
+  // and lifts the camera onto the arm; disabling it snaps the camera back flush
+  // and re-locks facing to the wall's inward normal.
+  const toggleCameraBracket = useCallback(
+    (id: string) => {
+      const item = activeFloor.items.find((entry) => entry.id === id);
+      if (item?.type !== 'security-camera') return;
+      const next = !item.cameraBracket;
+      actions.updateItem(id, { cameraBracket: next });
+      const rotation = next ? item.rotation ?? 0 : item.wallRotation ?? item.rotation ?? 0;
+      if (!next) actions.setRotation(id, rotation);
+      reseatCamera(id, rotation, next);
+    },
+    [activeFloor.items, actions, reseatCamera]
+  );
 
   // Wrap layout actions with the side-effect of clearing the selection when
   // the targeted item disappears.
@@ -413,6 +516,10 @@ export function RoomOrganizer(): JSX.Element {
         return snapped.position;
       }
 
+      // Security cameras follow the cursor freely while dragging (no per-frame
+      // wall-snap — that made them teleport/flip between walls). They snap onto
+      // the nearest wall and orient into the room on release, in handleDragEnd.
+
       if (view.snapToGrid) {
         result = {
           x: snapValueToGrid(result.x, GRID_SIZE_METERS),
@@ -467,6 +574,20 @@ export function RoomOrganizer(): JSX.Element {
         });
         const id = actions.addCatalogItem(catalogItem, snapped.position);
         actions.setRotation(id, snapped.rotation);
+        return id;
+      }
+      if (catalogItem.type === 'security-camera') {
+        const snapped = snapWallMountedItem({
+          position: position ?? { x: 0, z: 0 },
+          itemWidth: catalogItem.width,
+          itemDepth: catalogItem.depth,
+          roomWidth: layout.width,
+          roomDepth: layout.height,
+          interiorWalls: activeFloor.interiorWalls ?? [],
+        });
+        const id = actions.addCatalogItem(catalogItem, snapped.position);
+        actions.setRotation(id, snapped.rotation);
+        actions.updateItem(id, { wallRotation: snapped.rotation });
         return id;
       }
       return actions.addCatalogItem(catalogItem, position);
@@ -530,6 +651,12 @@ export function RoomOrganizer(): JSX.Element {
     roomWidth: layout.width,
     roomDepth: layout.height,
     floorY: activeFloorY,
+  });
+
+  useCameraVision({
+    enabled: isReady && view.showCameraVision && !view.view2D,
+    threeModuleRef,
+    sceneRef,
   });
 
   const { applyPreset, focusOn, fitToRoom } = useCameraPresets({
@@ -613,13 +740,7 @@ export function RoomOrganizer(): JSX.Element {
         const newId = actions.duplicateItem(id);
         setSelectedItemId(newId);
       },
-      rotateItem: (id: string) => {
-        if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
-          actions.rotateSelection(allSelectedIds, Math.PI / 2);
-        } else {
-          actions.rotateItem(id);
-        }
-      },
+      rotateItem: rotateItemHandler,
       rotateItemBy: (id: string, radians: number) => {
         if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
           actions.rotateSelection(allSelectedIds, radians);
@@ -629,6 +750,7 @@ export function RoomOrganizer(): JSX.Element {
         if (!item) return;
         const next = ((item.rotation ?? 0) + radians) % (Math.PI * 2);
         actions.setRotation(id, next);
+        reseatCamera(id, next);
       },
       moveItem: actions.moveItem,
       toggle2D: () => toggle('view2D'),
@@ -671,6 +793,8 @@ export function RoomOrganizer(): JSX.Element {
       history.redo,
       selectedItem,
       focusOn,
+      rotateItemHandler,
+      reseatCamera,
     ]
   );
 
@@ -857,9 +981,10 @@ export function RoomOrganizer(): JSX.Element {
             layout.height
           )}
           onRotate={(id: string) => {
-            actions.rotateItem(id);
+            rotateItemHandler(id);
             playCue('rotate');
           }}
+          onToggleCameraBracket={toggleCameraBracket}
           onDuplicate={(id: string) => {
             const newId = actions.duplicateItem(id);
             setSelectedItemId(newId);
@@ -913,6 +1038,7 @@ export function RoomOrganizer(): JSX.Element {
         onImport={handleImport}
         onExportGlb={handleExportGlb}
         onShareLink={handleShareLink}
+        placeCatalogItem={placeCatalogItem}
       />
     </div>
     </SelectionProvider>

--- a/components/room-organizer/three/builders/builders-electronics.ts
+++ b/components/room-organizer/three/builders/builders-electronics.ts
@@ -1,5 +1,8 @@
 import type * as ThreeNS from 'three';
 import { type BuilderContext, mesh } from '../builder-utils';
+import { CAMERA_MOUNT_HEIGHT } from '../camera-vision';
+import { CAMERA_BRACKET_ARM } from '../../lib/constants';
+import { type CctvModel, getCctvModel } from '../../lib/cctv-models';
 
 export function buildTV({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
@@ -209,4 +212,334 @@ export function buildCCTV({ THREE, item, hasCollision, baseColor, opacity }: Bui
   }
 
   return group;
+}
+
+/**
+ * Wall-mounted security camera. Modelled in a local frame where the wall sits
+ * at the back (−Z) and the lens faces into the room (+Z), so the matching
+ * vision cone (which also fans toward +Z) aligns once the group is rotated.
+ *
+ * The silhouette follows the selected real model (lib/cctv-models): Dome / PTZ
+ * models get a flat base ring + dark half-sphere glass dome; bullet, indoor and
+ * battery models (Reolink, Nest, Ring, Arlo…) get a mount arm + ball joint and
+ * a rounded cylindrical pod. A thin cable runs up the wall so the selection box
+ * (which spans the full mount height) reads as a wall run rather than empty.
+ */
+export function buildSecurityCamera({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
+  const group = new THREE.Group();
+  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.35, metalness: 0.5, transparent: hasCollision, opacity });
+  const trimMat = new THREE.MeshStandardMaterial({ color: 0x0e1116, roughness: 0.3, metalness: 0.65, transparent: hasCollision, opacity });
+  const glassMat = new THREE.MeshStandardMaterial({
+    color: 0x05080d,
+    roughness: 0.05,
+    metalness: 0.2,
+    transparent: true,
+    opacity: hasCollision ? 0.5 : 0.45,
+  });
+  const ledMat = new THREE.MeshStandardMaterial({ color: 0xff3b30, emissive: 0xff3b30, emissiveIntensity: 0.9, transparent: hasCollision, opacity });
+
+  const mountY = CAMERA_MOUNT_HEIGHT;
+  const model = getCctvModel(item.cctvModelId);
+
+  if (item.cameraBracket) {
+    // Stand-off bracket. The group is yawed by item.rotation (the facing); an
+    // anchor counter-rotates so the base plate, conduit and arm stay fixed to
+    // the wall, and a pan pivot at the arm's end re-applies the facing so the
+    // head points where the user aimed — like a real arm-mounted camera that
+    // pans on its joint while the bracket stays bolted to the wall.
+    const facing = item.rotation ?? 0;
+    const wallRot = item.wallRotation ?? facing;
+    const arm = CAMERA_BRACKET_ARM;
+
+    const anchor = new THREE.Group();
+    anchor.rotation.y = wallRot - facing; // anchor's local +Z → world inward normal
+    group.add(anchor);
+
+    // Conduit + base plate flush on the wall, an arm length behind the camera.
+    const conduit = mesh(THREE, new THREE.BoxGeometry(0.03, mountY - 0.1, 0.03), trimMat);
+    conduit.position.set(0, (mountY - 0.1) / 2, -arm);
+    anchor.add(conduit);
+
+    const plate = mesh(THREE, new THREE.BoxGeometry(0.12, 0.12, 0.025), trimMat);
+    plate.position.set(0, mountY, -arm + 0.012);
+    anchor.add(plate);
+
+    const armMesh = mesh(THREE, new THREE.CylinderGeometry(0.022, 0.022, arm, 16), bodyMat);
+    armMesh.rotation.x = Math.PI / 2;
+    armMesh.position.set(0, mountY, -arm / 2);
+    anchor.add(armMesh);
+
+    const knuckle = mesh(THREE, new THREE.SphereGeometry(0.045, 16, 16), trimMat);
+    knuckle.position.set(0, mountY, 0);
+    anchor.add(knuckle);
+
+    const pivot = new THREE.Group();
+    pivot.rotation.y = facing - wallRot; // undo the anchor so the head faces `facing`
+    anchor.add(pivot);
+    pivot.add(selectCameraHead(model, { THREE, mountY, wallZ: -0.045, bodyMat, trimMat, glassMat, ledMat }));
+
+    return group;
+  }
+
+  // Flush mount: the head sits directly against the wall at the group's back.
+  const wallZ = -item.depth / 2;
+  const cable = mesh(THREE, new THREE.BoxGeometry(0.03, mountY - 0.1, 0.03), trimMat);
+  cable.position.set(0, (mountY - 0.1) / 2, wallZ);
+  group.add(cable);
+
+  group.add(selectCameraHead(model, { THREE, mountY, wallZ, bodyMat, trimMat, glassMat, ledMat }));
+
+  return group;
+}
+
+/** Pick the head silhouette matching the camera's real-world model type. */
+function selectCameraHead(model: CctvModel | undefined, params: HeadParams): ThreeNS.Group {
+  switch (model?.type) {
+    case 'PTZ':
+      return buildPtzHead(params);
+    case 'Bullet':
+      return buildBulletHead(params);
+    case 'Indoor':
+      return buildPodHead(params);
+    case 'Battery':
+      return buildSpotlightHead(params);
+    case 'Dome':
+    default:
+      return buildDomeHead(params);
+  }
+}
+
+interface HeadParams {
+  THREE: typeof import('three');
+  mountY: number;
+  wallZ: number;
+  bodyMat: ThreeNS.Material;
+  trimMat: ThreeNS.Material;
+  glassMat: ThreeNS.Material;
+  ledMat: ThreeNS.Material;
+}
+
+/** Hikvision-style dome: flat base ring + dark half-sphere glass dome facing +Z. */
+function buildDomeHead({ THREE, mountY, wallZ, bodyMat, trimMat, glassMat, ledMat }: HeadParams): ThreeNS.Group {
+  const head = new THREE.Group();
+
+  // Flat base ring flush to the wall (cylinder axis rotated onto Z).
+  const base = mesh(THREE, new THREE.CylinderGeometry(0.14, 0.15, 0.04, 36), bodyMat);
+  base.rotation.x = Math.PI / 2;
+  base.position.set(0, mountY, wallZ + 0.02);
+  head.add(base);
+
+  // Dark semi-transparent glass dome — a sphere cut in half, curve facing +Z.
+  const dome = mesh(THREE, new THREE.SphereGeometry(0.13, 36, 18, 0, Math.PI * 2, 0, Math.PI / 2), glassMat);
+  dome.rotation.x = Math.PI / 2;
+  dome.position.set(0, mountY, wallZ + 0.04);
+  head.add(dome);
+
+  // Lens barrel + glossy element visible through the glass.
+  const barrel = mesh(THREE, new THREE.CylinderGeometry(0.05, 0.055, 0.05, 24), trimMat);
+  barrel.rotation.x = Math.PI / 2;
+  barrel.position.set(0, mountY, wallZ + 0.07);
+  head.add(barrel);
+
+  const element = mesh(
+    THREE,
+    new THREE.SphereGeometry(0.035, 18, 14),
+    new THREE.MeshStandardMaterial({ color: 0x16242e, roughness: 0.05, metalness: 0.9 })
+  );
+  element.position.set(0, mountY, wallZ + 0.1);
+  head.add(element);
+
+  // Status LED on the base rim.
+  const led = mesh(THREE, new THREE.SphereGeometry(0.01, 10, 10), ledMat);
+  led.position.set(0.1, mountY - 0.1, wallZ + 0.04);
+  head.add(led);
+
+  return head;
+}
+
+/** Nest-style indoor pod: short mount arm + ball joint + rounded cylindrical body. */
+function buildPodHead({ THREE, mountY, wallZ, bodyMat, trimMat, glassMat, ledMat }: HeadParams): ThreeNS.Group {
+  const head = new THREE.Group();
+
+  // Wall foot.
+  const foot = mesh(THREE, new THREE.CylinderGeometry(0.05, 0.06, 0.03, 24), bodyMat);
+  foot.rotation.x = Math.PI / 2;
+  foot.position.set(0, mountY, wallZ + 0.015);
+  head.add(foot);
+
+  // Mount arm reaching into the room + ball joint.
+  const arm = mesh(THREE, new THREE.CylinderGeometry(0.02, 0.02, 0.14, 16), trimMat);
+  arm.rotation.x = Math.PI / 2;
+  arm.position.set(0, mountY, wallZ + 0.09);
+  head.add(arm);
+
+  const ball = mesh(THREE, new THREE.SphereGeometry(0.034, 18, 16), trimMat);
+  ball.position.set(0, mountY, wallZ + 0.16);
+  head.add(ball);
+
+  // Rounded cylindrical pod, tilted slightly downward, lens on the +Z face.
+  const pod = new THREE.Group();
+  pod.position.set(0, mountY, wallZ + 0.16);
+  pod.rotation.x = 0.22;
+
+  const body = mesh(THREE, new THREE.CylinderGeometry(0.06, 0.06, 0.17, 28), bodyMat);
+  body.rotation.x = Math.PI / 2;
+  body.position.set(0, 0, 0.11);
+  pod.add(body);
+
+  // Rounded back cap (half sphere) so the cylinder reads as a pod, not a tube.
+  const backCap = mesh(THREE, new THREE.SphereGeometry(0.06, 24, 16, 0, Math.PI * 2, 0, Math.PI / 2), bodyMat);
+  backCap.rotation.x = -Math.PI / 2;
+  backCap.position.set(0, 0, 0.025);
+  pod.add(backCap);
+
+  // Front bezel + glass lens.
+  const bezel = mesh(THREE, new THREE.CylinderGeometry(0.058, 0.055, 0.012, 28), trimMat);
+  bezel.rotation.x = Math.PI / 2;
+  bezel.position.set(0, 0, 0.2);
+  pod.add(bezel);
+
+  const lens = mesh(THREE, new THREE.SphereGeometry(0.04, 20, 16, 0, Math.PI * 2, 0, Math.PI / 2), glassMat);
+  lens.rotation.x = Math.PI / 2;
+  lens.position.set(0, 0, 0.2);
+  pod.add(lens);
+
+  // Recording LED beside the lens.
+  const led = mesh(THREE, new THREE.SphereGeometry(0.008, 10, 10), ledMat);
+  led.position.set(0.035, 0.035, 0.19);
+  pod.add(led);
+
+  head.add(pod);
+  return head;
+}
+
+/** Classic bullet: long horizontal barrel with a sun-shroud visor and a mount knuckle. */
+function buildBulletHead({ THREE, mountY, wallZ, bodyMat, trimMat, glassMat, ledMat }: HeadParams): ThreeNS.Group {
+  const head = new THREE.Group();
+  const barrelLen = 0.34;
+  const barrelZ = wallZ + 0.06 + barrelLen / 2;
+  const frontZ = wallZ + 0.06 + barrelLen;
+
+  // Wall plate + knuckle dropping to the barrel.
+  const plate = mesh(THREE, new THREE.BoxGeometry(0.1, 0.13, 0.03), bodyMat);
+  plate.position.set(0, mountY, wallZ + 0.015);
+  head.add(plate);
+
+  const knuckle = mesh(THREE, new THREE.BoxGeometry(0.04, 0.11, 0.04), trimMat);
+  knuckle.position.set(0, mountY - 0.06, wallZ + 0.12);
+  head.add(knuckle);
+
+  // Long barrel pointing into the room.
+  const barrel = mesh(THREE, new THREE.CylinderGeometry(0.06, 0.06, barrelLen, 28), bodyMat);
+  barrel.rotation.x = Math.PI / 2;
+  barrel.position.set(0, mountY, barrelZ);
+  head.add(barrel);
+
+  // Sun-shroud — an open half-cylinder hood over the top, overhanging the lens.
+  const shroud = mesh(
+    THREE,
+    new THREE.CylinderGeometry(0.075, 0.075, barrelLen * 0.92, 28, 1, true, Math.PI / 2, Math.PI),
+    bodyMat
+  );
+  shroud.rotation.x = Math.PI / 2;
+  shroud.position.set(0, mountY, barrelZ + 0.05);
+  head.add(shroud);
+
+  // Front bezel + dark glass lens.
+  const bezel = mesh(THREE, new THREE.CylinderGeometry(0.063, 0.058, 0.02, 28), trimMat);
+  bezel.rotation.x = Math.PI / 2;
+  bezel.position.set(0, mountY, frontZ);
+  head.add(bezel);
+
+  const lens = mesh(THREE, new THREE.CylinderGeometry(0.05, 0.05, 0.012, 24), glassMat);
+  lens.rotation.x = Math.PI / 2;
+  lens.position.set(0, mountY, frontZ + 0.006);
+  head.add(lens);
+
+  const led = mesh(THREE, new THREE.SphereGeometry(0.008, 10, 10), ledMat);
+  led.position.set(0.045, mountY - 0.045, frontZ - 0.02);
+  head.add(led);
+
+  return head;
+}
+
+/** PTZ speed-dome: bracket arm carrying a chunky pendant housing + tinted glass bubble. */
+function buildPtzHead({ THREE, mountY, wallZ, bodyMat, trimMat, glassMat, ledMat }: HeadParams): ThreeNS.Group {
+  const head = new THREE.Group();
+  const domeZ = wallZ + 0.26;
+
+  // Bracket reaching out from the wall.
+  const bracket = mesh(THREE, new THREE.BoxGeometry(0.07, 0.07, 0.22), bodyMat);
+  bracket.position.set(0, mountY, wallZ + 0.11);
+  head.add(bracket);
+
+  // Top housing collar.
+  const collar = mesh(THREE, new THREE.CylinderGeometry(0.17, 0.17, 0.09, 32), bodyMat);
+  collar.position.set(0, mountY - 0.045, domeZ);
+  head.add(collar);
+
+  // Chunky tinted glass bubble (lower half-sphere) — the speed-dome.
+  const bubble = mesh(THREE, new THREE.SphereGeometry(0.17, 32, 18, 0, Math.PI * 2, Math.PI / 2, Math.PI / 2), glassMat);
+  bubble.position.set(0, mountY - 0.09, domeZ);
+  head.add(bubble);
+
+  // Inner lens module aimed forward-down inside the bubble.
+  const module = mesh(THREE, new THREE.CylinderGeometry(0.05, 0.065, 0.11, 20), trimMat);
+  module.rotation.x = Math.PI / 2 - 0.55;
+  module.position.set(0, mountY - 0.13, domeZ + 0.06);
+  head.add(module);
+
+  const led = mesh(THREE, new THREE.SphereGeometry(0.012, 10, 10), ledMat);
+  led.position.set(0.12, mountY - 0.05, domeZ);
+  head.add(led);
+
+  return head;
+}
+
+/** Battery spotlight cam (Ring/Arlo): wall-flush rounded body flanked by two spotlight lamps. */
+function buildSpotlightHead({ THREE, mountY, wallZ, bodyMat, trimMat, glassMat, ledMat }: HeadParams): ThreeNS.Group {
+  const head = new THREE.Group();
+  const frontZ = wallZ + 0.02 + 0.13;
+  const spotMat = new THREE.MeshStandardMaterial({ color: 0xfff6e0, emissive: 0xfff2cc, emissiveIntensity: 0.85 });
+
+  // Wall plate.
+  const plate = mesh(THREE, new THREE.BoxGeometry(0.16, 0.13, 0.03), bodyMat);
+  plate.position.set(0, mountY, wallZ + 0.015);
+  head.add(plate);
+
+  // Rounded body protruding from the wall (capsule: cylinder + front dome).
+  const body = mesh(THREE, new THREE.CylinderGeometry(0.07, 0.07, 0.13, 28), bodyMat);
+  body.rotation.x = Math.PI / 2;
+  body.position.set(0, mountY, wallZ + 0.02 + 0.065);
+  head.add(body);
+
+  const dome = mesh(THREE, new THREE.SphereGeometry(0.07, 24, 16, 0, Math.PI * 2, 0, Math.PI / 2), bodyMat);
+  dome.rotation.x = Math.PI / 2;
+  dome.position.set(0, mountY, frontZ);
+  head.add(dome);
+
+  // Lens on the front face.
+  const lens = mesh(THREE, new THREE.SphereGeometry(0.035, 18, 14, 0, Math.PI * 2, 0, Math.PI / 2), glassMat);
+  lens.rotation.x = Math.PI / 2;
+  lens.position.set(0, mountY, frontZ + 0.02);
+  head.add(lens);
+
+  // Two spotlight lamps flanking the body, angled into the room.
+  for (const dx of [-0.11, 0.11]) {
+    const lamp = mesh(THREE, new THREE.CylinderGeometry(0.025, 0.03, 0.04, 20), trimMat);
+    lamp.rotation.x = Math.PI / 2;
+    lamp.position.set(dx, mountY - 0.04, wallZ + 0.05);
+    head.add(lamp);
+
+    const glow = mesh(THREE, new THREE.CylinderGeometry(0.022, 0.022, 0.008, 20), spotMat);
+    glow.rotation.x = Math.PI / 2;
+    glow.position.set(dx, mountY - 0.04, wallZ + 0.072);
+    head.add(glow);
+  }
+
+  const led = mesh(THREE, new THREE.SphereGeometry(0.008, 10, 10), ledMat);
+  led.position.set(0, mountY + 0.05, frontZ - 0.02);
+  head.add(led);
+
+  return head;
 }

--- a/components/room-organizer/three/camera-vision.ts
+++ b/components/room-organizer/three/camera-vision.ts
@@ -1,0 +1,168 @@
+import type * as ThreeNS from 'three';
+import type { FurnitureItem } from '../lib/types';
+import { ROOM_OBJECT_TAGS } from './room-builder';
+
+type ThreeModule = typeof import('three');
+
+/**
+ * Height (metres) at which the security camera body — and the apex of its
+ * vision cone — sits above the floor. Shared with the camera builder so the
+ * 3D light volume connects the lens to the floor wedge.
+ */
+export const CAMERA_MOUNT_HEIGHT = 2.3;
+
+/** Desperados-style cyan glow, matching the PlotCraft accent. */
+const CONE_COLOR = 0x38f0ff;
+
+const FLOOR_Y = 0.02;
+const EDGE_Y = 0.035;
+const ARC_SEGMENTS = 40;
+const WEDGE_BASE_OPACITY = 0.16;
+const SCAN_FOV_RATIO = 0.1;
+const SWEEP_SPEED = 1.6;
+
+interface VisionConeUserData {
+  /** The narrow sweeping sector, rotated each frame within the FOV. */
+  scan: ThreeNS.Object3D;
+  /** Max half-angle (radians) the scan sector swings either side of centre. */
+  swing: number;
+  /** Phase offset so multiple cameras don't sweep in lockstep. */
+  phase: number;
+  /** The flat floor wedge, whose opacity gently pulses. */
+  wedge: ThreeNS.Mesh;
+}
+
+/**
+ * Build the floor-wedge / light-volume / scan-line group for every item that
+ * projects a vision cone, and add it to the scene. The group is positioned at
+ * the item and rotated so its local +Z (the camera's forward axis) fans into
+ * the room. Tagged with `ROOM_OBJECT_TAGS.CameraVision` so `removeTagged`
+ * tears it down on rebuild, mirroring the signal-overlay lifecycle.
+ */
+export function addVisionCones(
+  THREE: ThreeModule,
+  scene: ThreeNS.Scene,
+  items: readonly FurnitureItem[],
+  yOffset = 0
+): void {
+  for (const item of items) {
+    if (!item.position || !item.hasVisionCone) continue;
+    const range = item.visionRange ?? 7;
+    const fov = ((item.visionFov ?? 70) * Math.PI) / 180;
+    const group = buildCone(THREE, range, fov);
+    group.position.set(item.position.x, yOffset, item.position.z);
+    group.rotation.y = item.rotation ?? 0;
+    group.userData.type = ROOM_OBJECT_TAGS.CameraVision;
+    scene.add(group);
+  }
+}
+
+/**
+ * Advance every vision cone in the scene by the elapsed time: swing the scan
+ * line back and forth across the field of view and pulse the wedge opacity.
+ * Called once per animation frame; the shared render loop paints the result.
+ */
+export function stepVisionCones(scene: ThreeNS.Scene, elapsedSeconds: number): void {
+  for (const child of scene.children) {
+    if (child.userData.type !== ROOM_OBJECT_TAGS.CameraVision) continue;
+    const data = child.userData.vision as VisionConeUserData | undefined;
+    if (!data) continue;
+    const t = elapsedSeconds * SWEEP_SPEED + data.phase;
+    data.scan.rotation.y = Math.sin(t) * data.swing;
+    const material = data.wedge.material as { opacity: number };
+    material.opacity = WEDGE_BASE_OPACITY + Math.sin(t * 2) * 0.04;
+  }
+}
+
+/** Points along the cone's far arc, fanning symmetrically around local +Z. */
+function arcPoints(range: number, fov: number, y: number): number[] {
+  const points: number[] = [];
+  for (let i = 0; i <= ARC_SEGMENTS; i++) {
+    const angle = -fov / 2 + (fov * i) / ARC_SEGMENTS;
+    points.push(Math.sin(angle) * range, y, Math.cos(angle) * range);
+  }
+  return points;
+}
+
+/** A triangle-fan geometry from an apex to the far arc (flat or volumetric). */
+function fanGeometry(THREE: ThreeModule, apex: [number, number, number], arc: number[]): ThreeNS.BufferGeometry {
+  const positions = [...apex, ...arc];
+  const geometry = new THREE.BufferGeometry();
+  geometry.setAttribute('position', new THREE.Float32BufferAttribute(positions, 3));
+  const indices: number[] = [];
+  const arcCount = arc.length / 3;
+  for (let i = 0; i < arcCount - 1; i++) {
+    indices.push(0, i + 1, i + 2);
+  }
+  geometry.setIndex(indices);
+  return geometry;
+}
+
+function buildCone(THREE: ThreeModule, range: number, fov: number): ThreeNS.Group {
+  const group = new THREE.Group();
+
+  // Flat floor wedge — the primary "this is what the camera sees" footprint.
+  const wedgeGeo = fanGeometry(THREE, [0, FLOOR_Y, 0], arcPoints(range, fov, FLOOR_Y));
+  const wedgeMat = new THREE.MeshBasicMaterial({
+    color: CONE_COLOR,
+    transparent: true,
+    opacity: WEDGE_BASE_OPACITY,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+  const wedge = new THREE.Mesh(wedgeGeo, wedgeMat);
+  wedge.renderOrder = 2;
+  group.add(wedge);
+
+  // Faint volumetric light from the lens down to the floor arc.
+  const volumeGeo = fanGeometry(THREE, [0, CAMERA_MOUNT_HEIGHT, 0], arcPoints(range, fov, FLOOR_Y));
+  const volumeMat = new THREE.MeshBasicMaterial({
+    color: CONE_COLOR,
+    transparent: true,
+    opacity: 0.05,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+  const volume = new THREE.Mesh(volumeGeo, volumeMat);
+  volume.renderOrder = 1;
+  group.add(volume);
+
+  // Bright outline tracing the two edges and the far arc.
+  const arc = arcPoints(range, fov, EDGE_Y);
+  const outlinePositions = [0, EDGE_Y, 0, ...arc, 0, EDGE_Y, 0];
+  const outlineGeo = new THREE.BufferGeometry();
+  outlineGeo.setAttribute('position', new THREE.Float32BufferAttribute(outlinePositions, 3));
+  const outline = new THREE.Line(
+    outlineGeo,
+    new THREE.LineBasicMaterial({ color: CONE_COLOR, transparent: true, opacity: 0.7, depthWrite: false })
+  );
+  outline.renderOrder = 3;
+  group.add(outline);
+
+  // Narrow sweeping scan line — the animated "radar" pass.
+  const scanFov = Math.max(fov * SCAN_FOV_RATIO, 0.04);
+  const scanGeo = fanGeometry(THREE, [0, EDGE_Y, 0], arcPoints(range, scanFov, EDGE_Y));
+  const scanMat = new THREE.MeshBasicMaterial({
+    color: CONE_COLOR,
+    transparent: true,
+    opacity: 0.5,
+    side: THREE.DoubleSide,
+    depthWrite: false,
+    blending: THREE.AdditiveBlending,
+  });
+  const scan = new THREE.Mesh(scanGeo, scanMat);
+  scan.renderOrder = 4;
+  group.add(scan);
+
+  const userData: VisionConeUserData = {
+    scan,
+    swing: Math.max(fov / 2 - scanFov / 2, 0),
+    phase: Math.random() * Math.PI * 2,
+    wedge,
+  };
+  group.userData.vision = userData;
+
+  return group;
+}

--- a/components/room-organizer/three/furniture-builders.ts
+++ b/components/room-organizer/three/furniture-builders.ts
@@ -6,7 +6,7 @@ import { buildTableOrDesk } from './builders/builders-tables';
 import { buildBookshelf, buildCabinet } from './builders/builders-storage';
 import { buildFridge, buildStove, buildSink, buildCounter } from './builders/builders-kitchen';
 import { buildToilet, buildBathtub, buildShower } from './builders/builders-bathroom';
-import { buildTV, buildComputer, buildWiFi, buildRouter, buildCCTV } from './builders/builders-electronics';
+import { buildTV, buildComputer, buildWiFi, buildRouter, buildCCTV, buildSecurityCamera } from './builders/builders-electronics';
 import { buildLamp, buildPendantLight, buildLamppost } from './builders/builders-lighting';
 import {
   buildRug, buildPainting, buildVase, buildMirror, buildCurtains,
@@ -50,6 +50,7 @@ const BUILDERS: Record<string, FurnitureBuilder> = {
   wifi: buildWiFi,
   router: buildRouter,
   cctv: buildCCTV,
+  'security-camera': buildSecurityCamera,
   fridge: buildFridge,
   stove: buildStove,
   dishwasher: buildCabinet,

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -11,6 +11,7 @@ export const ROOM_OBJECT_TAGS = {
   Wall: 'wall',
   Furniture: 'furniture',
   Signal: 'wifi-signal',
+  CameraVision: 'camera-vision',
 } as const;
 
 export type RoomObjectTag = (typeof ROOM_OBJECT_TAGS)[keyof typeof ROOM_OBJECT_TAGS];


### PR DESCRIPTION
## Summary

Introduces a new **Security Camera** furniture item type that mounts against walls and projects an animated Desperados-style vision cone.
The camera's field of view and range are driven by a library of real CCTV models (Hikvision, Axis, Dahua, Hanwha, Reolink, Ubiquiti, Google, Ring, Arlo) with published datasheet specifications.

## Key Changes

### New Files
- **`three/camera-vision.ts`** — Vision cone builder and animator
  - `buildCone()` creates a multi-layer vision cone: translucent floor wedge, faint 3D light volume, glowing outline, and sweeping scan line
  - `addVisionCones()` instantiates cones for all cameras in the scene
  - `stepVisionCones()` animates the scan line sweep and wedge opacity pulse each frame
  - Exports `CAMERA_MOUNT_HEIGHT` (2.3 m) shared with the camera builder

- **`lib/cctv-models.ts`** — Real-world CCTV model library
  - `CctvModel` interface with brand, model, type, FOV, range, resolution, and optional notes
  - `CCTV_MODELS` array with 13 curated models across 5 types (Dome, Bullet, PTZ, Indoor, Battery)
  - `getCctvModel()` lookup function

- **`hooks/use-camera-vision.ts`** — Animation hook
  - Drives vision cone animation via `requestAnimationFrame`
  - Calls `stepVisionCones()` each frame with elapsed time
  - Respects `enabled` flag and cleans up on unmount

### Modified Files
- **`builders/builders-electronics.ts`**
  - New `buildSecurityCamera()` function that dispatches to type-specific builders
  - Five head builders: `buildDomeHead()`, `buildBulletHead()`, `buildPtzHead()`, `buildPodHead()`, `buildSpotlightHead()`
  - Each builder creates a wall-mounted 3D model with appropriate geometry (dome, barrel, bracket, etc.) and materials
  - Thin cable geometry runs up the wall to fill the selection box

- **`panels/item-context-popover.tsx`**
  - New `CameraModelCard` component for camera-specific settings
  - `CctvModelRow` dropdown to select from real models or Custom
  - `VisionSliderRow` for FOV and range adjustment
  - Displays camera brand/model in the item header instead of coordinates
  - Added scrollable container for popover content

- **`lib/types.ts`**
  - New `'security-camera'` furniture type
  - New item properties: `hasVisionCone`, `visionRange`, `visionFov`, `cctvModelId`

- **`lib/opening-snap.ts`**
  - New `isWallMounted()` helper (includes cameras and openings)
  - New `snapWallMountedItem()` function that snaps cameras to walls and insets their centre into the room by half depth

- **`room-organizer.tsx`**
  - Added `useCameraVision` hook integration
  - Security camera snapping logic in `snapPosition()` to use `snapWallMountedItem()`
  - Added `showCameraVision` to `INITIAL_VIEW_SETTINGS`

- **`hooks/use-scene-effects.ts`**
  - Integrated `addVisionCones()` call to build vision cone meshes
  - Tagged cones with `ROOM_OBJECT_TAGS.CameraVision` for cleanup

- **`three/room-builder.ts`**
  - Added `CameraVision` tag to `ROOM_OBJECT_TAGS`

- **`three/furniture-builders.ts`**
  - Imported and wired `buildSecurityCamera` for `'security-camera'` type

- **`panels/mode-panel.tsx`**
  - Added vision cone toggle button (vision icon)
