### PR TITLE
fix: auto-lock items after placement and drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+- Elements should be locked after they were [positioned](https://github.com/ch-bas/threejs-sims-house-builder/issues/11).
+
 ## [1.2.0] - 2026-06-01
 
 ### Added

--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -152,6 +152,7 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
       const newItem: FurnitureItem = {
         ...action.catalogItem,
         id: action.id,
+        locked: true,
         position: action.position ?? { x: 0, z: 0 },
         rotation: 0,
         ...(action.catalogItem.type === 'sofa' ? { sofaShape: 'standard' as const } : {}),

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -341,6 +341,8 @@ export function RoomOrganizer(): JSX.Element {
   const handleDragEnd = useCallback(
     (id: string) => {
       dragOriginsRef.current = null;
+      // Lock the item after positioning so it can't be accidentally moved.  
+      actions.setLocked(id, true); 
       // On release, click a security camera onto the nearest wall and turn it to
       // face into the room. Doing this on drop (not per drag frame) keeps the
       // drag itself smooth instead of flipping between walls.


### PR DESCRIPTION
## Description

<!-- What does this PR do? Why is it needed? -->

## Type of Change

- [x] Bug fix

## Screenshots / Recordings

<!-- If this changes the UI or 3D scene, include before/after screenshots or a short recording. -->

## How to Test

1. `npm install && npm run dev`
2. Open `http://localhost:3000`
3. Place an element
4. Reselect the same element.
5. The element should not move from its own position.

## Checklist

- [x] Code compiles without errors (`npm run typecheck`)
- [x] Tested in Chrome
- [x] No console warnings or errors introduced
- [x] Existing features still work (placement, drag, undo/redo, save/load)
- [x] Mobile viewport checked if UI was changed
