### PR TITLE
Fix undo after page load reverting the house to the blank default

### DIFF
--- a/components/room-organizer/hooks/use-history.ts
+++ b/components/room-organizer/hooks/use-history.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export interface UseHistoryOptions {
   /** Debounce window for committing a snapshot, in milliseconds. */
@@ -77,17 +77,21 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
     });
   }, [apply]);
 
+  // Call this alongside (or right after) applying a new baseline value, e.g.
+  // hydration. `skipNextRef` makes the commit effect adopt the upcoming value
+  // as the baseline instead of diffing it against the stale one — otherwise
+  // undo right after hydration would revert to the pre-hydration state.
   const clear = useCallback(() => {
     setPast([]);
     setFuture([]);
-    lastCommittedRef.current = value;
-  }, [value]);
+    skipNextRef.current = true;
+  }, []);
 
-  return {
-    canUndo: past.length > 0,
-    canRedo: future.length > 0,
-    undo,
-    redo,
-    clear,
-  };
+  const canUndo = past.length > 0;
+  const canRedo = future.length > 0;
+
+  return useMemo(
+    () => ({ canUndo, canRedo, undo, redo, clear }),
+    [canUndo, canRedo, undo, redo, clear]
+  );
 }


### PR DESCRIPTION
history.clear() captured the stale pre-hydration layout as the undo baseline, so right after every reload Ctrl+Z replaced the loaded house with the empty default — and autosave then persisted the wipe.

- clear() now arms skipNextRef so the commit effect adopts the upcoming hydrated value as the baseline instead of diffing it against the stale one
- The hook's return value is memoised so consumers (RoomEditorContext) get a stable identity — this is also the useHistory half of #31, so merging this branch first is recommended

Fixes #21