### PR TITLE
Stop a freshly opened share link from overwriting the local save

### DIFF
--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -23,6 +23,11 @@ export function useLayoutPersistence({
   debounceMs = AUTOSAVE_DEBOUNCE_MS,
 }: UseLayoutPersistenceOptions): UseLayoutPersistenceResult {
   const hasHydratedRef = useRef(false);
+  // While set, autosave is suppressed until the layout moves past the stored
+  // pre-hydration value — i.e. until the hydration dispatch has landed. This
+  // stops a freshly opened share link (or a plain reload) from overwriting the
+  // local save before the user has actually edited anything.
+  const hydrationBaseRef = useRef<RoomLayout | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -35,6 +40,7 @@ export function useLayoutPersistence({
     if (typeof window !== 'undefined') {
       const shared = decodeShareUrl(window.location.hash);
       if (shared) {
+        hydrationBaseRef.current = layout;
         onHydrate(shared);
         // Clear the hash so reloading after edits doesn't restore the
         // shared version.
@@ -44,11 +50,21 @@ export function useLayoutPersistence({
     }
 
     const saved = loadLayout();
-    if (saved) onHydrate(saved);
+    if (saved) {
+      hydrationBaseRef.current = layout;
+      onHydrate(saved);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot hydration; `layout` is only read as the pre-hydration baseline
   }, [onHydrate]);
 
   useEffect(() => {
-    if (!hasHydratedRef.current) return;
+    if (hydrationBaseRef.current) {
+      if (Object.is(layout, hydrationBaseRef.current)) return;
+      // First layout change after hydration is the hydration dispatch itself,
+      // not a user edit — swallow it and resume normal autosave afterwards.
+      hydrationBaseRef.current = null;
+      return;
+    }
     setSaving(true);
     const handle = window.setTimeout(() => {
       saveLayout(layout);


### PR DESCRIPTION
After hydrating from a share URL, the autosave effect fired 1.5s later with zero edits made and clobbered the user's own saved house in localStorage — unrecoverable, since the hash is cleared on load.

- Autosave now swallows the layout change produced by the hydration dispatch itself and only resumes on the first real edit
- Removes the dead hasHydratedRef guard (the hydrate effect sets it synchronously in the same commit, so it never skipped anything)

Fixes #22