### PR TITLE
Re-enable achievements

### DIFF
--- a/components/room-organizer/hooks/use-achievements.ts
+++ b/components/room-organizer/hooks/use-achievements.ts
@@ -13,14 +13,12 @@ const EMPTY_SET: ReadonlySet<string> = new Set();
 const EMPTY_ARRAY: readonly Achievement[] = [];
 const NOOP = () => {};
 
-export function useAchievements(layout: RoomLayout, enabled = false): UseAchievementsResult {
-  const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => enabled ? loadUnlocked() : new Set());
+export function useAchievements(layout: RoomLayout): UseAchievementsResult {
+  const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => loadUnlocked());
   const [pending, setPending] = useState<readonly Achievement[]>([]);
   const initialisedRef = useRef(false);
 
   useEffect(() => {
-    if (!enabled) return;
-
     const next: Achievement[] = [];
     let mutated = false;
     const newUnlocked = new Set(unlocked);
@@ -44,7 +42,7 @@ export function useAchievements(layout: RoomLayout, enabled = false): UseAchieve
       return;
     }
     setPending((current) => [...current, ...next]);
-  }, [layout, unlocked, enabled]);
+  }, [layout, unlocked]);
 
   // Mark initialised after the first paint so the very first user-driven
   // change still triggers a toast even on a fresh slate.


### PR DESCRIPTION
The architecture refactor added an `enabled = false` parameter to useAchievements but the call site was never updated, so unlock detection and loadUnlocked() never ran — no toasts, panel always fully locked. Removes the parameter entirely; the hook is unconditional again.

Fixes #23