### PR TITLE
Stop mousemove over the canvas from re-rendering the whole React tree

### DIFF
--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -451,15 +451,13 @@ function attachDragHandlers({
     const target = ascendToFurniture(hits[0]?.object);
     const id = target ? (target.userData.id as string) : null;
 
-    if (id !== lastHoverId) {
-      lastHoverId = id;
-      canvas.style.cursor = id ? 'pointer' : '';
-    }
-    if (id) {
-      hoverCallback({ id, clientX: event.clientX, clientY: event.clientY });
-    } else {
-      hoverCallback(null);
-    }
+    // Only notify on hover changes — a fresh payload per mousemove would
+    // re-render React for every pixel of travel. The tooltip anchors at the
+    // point where the hover began.
+    if (id === lastHoverId) return;
+    lastHoverId = id;
+    canvas.style.cursor = id ? 'pointer' : '';
+    hoverCallback(id ? { id, clientX: event.clientX, clientY: event.clientY } : null);
   };
 
   const onMouseMove = (event: MouseEvent): void => {

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -245,6 +245,7 @@ export function RoomOrganizer(): JSX.Element {
     if (!view.drawWallMode) {
       setWallDraft(null);
       setSelectedWall(null);
+      setPointerWorld(null);
     }
   }, [view.drawWallMode]);
 
@@ -689,7 +690,10 @@ export function RoomOrganizer(): JSX.Element {
       onWallSelect: ({ wallId, kind }) => {
         setSelectedWall({ id: wallId, kind });
       },
-      onFloorPointerMove: handleFloorPointerMove,
+      // Only track the floor pointer while wall-draw mode consumes it — the
+      // handler writes React state per mousemove, re-rendering the whole tree,
+      // and the hook skips the floor raycast when the handler is absent.
+      onFloorPointerMove: view.drawWallMode ? handleFloorPointerMove : undefined,
       onFloorPointerLeave: handleFloorPointerLeave,
       snapPosition,
       getDragPlaneY,


### PR DESCRIPTION
Two unconditional per-mousemove state writes caused a render storm even while idle:

- setPointerWorld ran on every pointer move with a fresh object, though the value is only consumed by wall-draw snapping. The handler is now only passed to useThreeScene while drawWallMode is on, which also skips the floor-plane raycast entirely otherwise; the stale pointer is cleared when draw mode flips off.
- onItemHover fired a fresh payload per pixel while hovering furniture. updateHover now only notifies when the hovered item actually changes; the tooltip anchors where the hover began.

Note: the other half of #31 — memoising useHistory's return value so the RoomEditorContext identity is stable — rides with the #21 fix on fix/undo-after-hydration.

Fixes #31