### PR TITLE
Render once per frame while orbiting

### DIFF
--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -141,9 +141,7 @@ export function useSceneEffects({
     outline.renderOrder = 999;
     outline.userData.type = 'wall-selection';
     scene.add(outline);
-    const renderer = rendererRef.current;
-    const camera = cameraRef.current;
-    if (renderer && camera) renderer.render(scene, camera);
+    invalidate();
 
     return () => {
       scene.remove(outline);
@@ -189,11 +187,7 @@ export function useSceneEffects({
         floorPlan3DEffect: view.floorPlan3DEffect,
         yOffset: index * FLOOR_HEIGHT_METERS,
         ghostOpacity: view.showAllFloors && !isActive ? 0.25 : undefined,
-        onTextureLoaded: () => {
-          const renderer = rendererRef.current;
-          const camera = cameraRef.current;
-          if (renderer && camera) renderer.render(scene, camera);
-        },
+        onTextureLoaded: invalidate,
       });
     }
 
@@ -218,10 +212,12 @@ export function useSceneEffects({
     const controls = controlsRef.current;
     if (!scene || !camera || !controls) return undefined;
 
+    // Mark dirty instead of rendering here — the change listener fires every
+    // interaction frame, and the RAF loop renders that same frame anyway, so a
+    // direct render would draw the full scene twice per frame while orbiting.
     const apply = () => {
       applyWallDisplay(scene, camera.position.x, camera.position.z, view.wallDisplay, layout.width, layout.height);
-      const renderer = rendererRef.current;
-      if (renderer) renderer.render(scene, camera);
+      invalidate();
     };
     apply();
     controls.addEventListener('change', apply);


### PR DESCRIPTION
The cutaway effect called renderer.render() directly inside the OrbitControls change listener, which fires every interaction frame — and the render-on-demand RAF loop also renders that same frame because controls.update() reports movement. Result: two full scene renders per frame during any orbit/pan/zoom, in every wall-display mode.

Replaces the direct render with invalidate() so the RAF loop draws once. Same fix applied to the other two synchronous render sites: the wall-selection outline effect and the room builder's onTextureLoaded callback.

Fixes #33