### PR TITLE
Fix Escape not cancelling an in-progress interior wall draft

### DIFF
--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -902,6 +902,7 @@ export function RoomOrganizer(): JSX.Element {
       focusOn,
       rotateItemHandler,
       reseatCamera,
+      wallDraft,
     ]
   );
 


### PR DESCRIPTION
shortcutHandlers.deselect reads wallDraft, but setting the first wall anchor changed none of the memo's dependencies — so Escape ran with a stale wallDraft = null closure, skipped the draft-cancel branch, and cleared the selection instead. Adding wallDraft to the deps also clears the exhaustive-deps lint warning that was flagging exactly this.

Fixes #27