### PR TITLE
Persistence robustness: flush autosave on tab close, survive quota errors, fix ghost multi-select ids

### DIFF
--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -23,6 +23,11 @@ export function useLayoutPersistence({
   debounceMs = AUTOSAVE_DEBOUNCE_MS,
 }: UseLayoutPersistenceOptions): UseLayoutPersistenceResult {
   const hasHydratedRef = useRef(false);
+  // While set, autosave is suppressed until the layout moves past the stored
+  // pre-hydration value — i.e. until the hydration dispatch has landed. This
+  // stops a freshly opened share link (or a plain reload) from overwriting the
+  // local save before the user has actually edited anything.
+  const hydrationBaseRef = useRef<RoomLayout | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -35,6 +40,7 @@ export function useLayoutPersistence({
     if (typeof window !== 'undefined') {
       const shared = decodeShareUrl(window.location.hash);
       if (shared) {
+        hydrationBaseRef.current = layout;
         onHydrate(shared);
         // Clear the hash so reloading after edits doesn't restore the
         // shared version.
@@ -44,11 +50,21 @@ export function useLayoutPersistence({
     }
 
     const saved = loadLayout();
-    if (saved) onHydrate(saved);
+    if (saved) {
+      hydrationBaseRef.current = layout;
+      onHydrate(saved);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot hydration; `layout` is only read as the pre-hydration baseline
   }, [onHydrate]);
 
   useEffect(() => {
-    if (!hasHydratedRef.current) return;
+    if (hydrationBaseRef.current) {
+      if (Object.is(layout, hydrationBaseRef.current)) return;
+      // First layout change after hydration is the hydration dispatch itself,
+      // not a user edit — swallow it and resume normal autosave afterwards.
+      hydrationBaseRef.current = null;
+      return;
+    }
     setSaving(true);
     const handle = window.setTimeout(() => {
       saveLayout(layout);

--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -28,6 +28,9 @@ export function useLayoutPersistence({
   // stops a freshly opened share link (or a plain reload) from overwriting the
   // local save before the user has actually edited anything.
   const hydrationBaseRef = useRef<RoomLayout | null>(null);
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
+  const pendingRef = useRef(false);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -66,13 +69,31 @@ export function useLayoutPersistence({
       return;
     }
     setSaving(true);
+    pendingRef.current = true;
     const handle = window.setTimeout(() => {
+      pendingRef.current = false;
       saveLayout(layout);
       setLastSavedAt(Date.now());
       setSaving(false);
     }, debounceMs);
     return () => window.clearTimeout(handle);
   }, [layout, debounceMs]);
+
+  // Flush a still-debouncing save when the editor unmounts or the page goes
+  // away — without this, edits made in the last debounceMs are silently lost
+  // on tab close.
+  useEffect(() => {
+    const flush = () => {
+      if (!pendingRef.current) return;
+      pendingRef.current = false;
+      saveLayout(layoutRef.current);
+    };
+    window.addEventListener('pagehide', flush);
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      flush();
+    };
+  }, []);
 
   return { lastSavedAt, saving };
 }

--- a/components/room-organizer/lib/library.ts
+++ b/components/room-organizer/lib/library.ts
@@ -60,7 +60,13 @@ function totalItemCount(layout: RoomLayout): number {
   return layout.floors.reduce((sum, floor) => sum + floor.items.length, 0);
 }
 
-export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult {
+/**
+ * Returns `null` when localStorage rejects the write (typically
+ * QuotaExceededError — library entries embed the base64 floor-plan image, so
+ * running out of the ~5MB quota is realistic). The layout blob and the index
+ * are kept consistent: if the index write fails, the blob is rolled back.
+ */
+export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult | null {
   const trimmed = name.trim() || layout.name || 'Untitled';
   const id = slugify(trimmed);
   const index = readIndex();
@@ -75,14 +81,25 @@ export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult {
   };
 
   const layoutCopy: RoomLayout = { ...layout, id, name: trimmed };
-  window.localStorage.setItem(layoutKey(id), JSON.stringify(layoutCopy));
+  const previousBlob = window.localStorage.getItem(layoutKey(id));
+  try {
+    window.localStorage.setItem(layoutKey(id), JSON.stringify(layoutCopy));
+  } catch {
+    return null;
+  }
 
   if (existingIndex >= 0) {
     index.entries[existingIndex] = entry;
   } else {
     index.entries.push(entry);
   }
-  writeIndex(index);
+  try {
+    writeIndex(index);
+  } catch {
+    if (previousBlob === null) window.localStorage.removeItem(layoutKey(id));
+    else window.localStorage.setItem(layoutKey(id), previousBlob);
+    return null;
+  }
 
   return { entry, overwrote: existingIndex >= 0 };
 }

--- a/components/room-organizer/panels/library-panel.tsx
+++ b/components/room-organizer/panels/library-panel.tsx
@@ -43,7 +43,13 @@ export function LibraryPanel({ currentLayout, onLoad }: LibraryPanelProps): JSX.
     if (layoutSlugExists(trimmed) && !window.confirm(`Overwrite the existing layout "${trimmed}"?`)) {
       return;
     }
-    saveNamedLayout(currentLayout, trimmed);
+    const result = saveNamedLayout(currentLayout, trimmed);
+    if (!result) {
+      window.alert(
+        'Could not save the layout — browser storage is full. Delete some saved layouts or remove the floor-plan image and try again.'
+      );
+      return;
+    }
     refresh();
   };
 

--- a/components/room-organizer/panels/placed-items-panel.tsx
+++ b/components/room-organizer/panels/placed-items-panel.tsx
@@ -31,7 +31,9 @@ export function PlacedItemsPanel({
     <Card>
       <CardHeader className="space-y-2">
         <CardTitle>Placed Items ({items.length})</CardTitle>
-        {items.length > 4 && (
+        {/* Keep the input visible while a query is set, or deleting items
+            below the threshold would trap the panel in "no items match". */}
+        {(items.length > 4 || query !== '') && (
           <Input
             placeholder="Filter items…"
             value={query}

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -44,6 +44,11 @@ export interface SidebarDrawerProps {
   onShareLink(): void;
   /** Wall-aware placement (snaps doors/windows/cameras to walls) shared with the bottom catalog. */
   placeCatalogItem(catalogItem: CatalogItem, position?: { x: number; z: number }): string;
+  /**
+   * The orchestrator's removeItem — it also clears the id from the
+   * multi-select set, which a local reimplementation here used to miss.
+   */
+  removeItem(id: string): void;
 }
 
 export function SidebarDrawer({
@@ -57,6 +62,7 @@ export function SidebarDrawer({
   onExportGlb,
   onShareLink,
   placeCatalogItem,
+  removeItem,
 }: SidebarDrawerProps): JSX.Element {
   const { layout, activeFloor, actions, view, isReady, playCue, history, catalogQuery, setCatalogQuery } = useRoomEditor();
   const { selectedItem, setSelectedItemId, allSelectedIds } = useSelection();
@@ -68,12 +74,6 @@ export function SidebarDrawer({
   const setSidebarTab = (tab: SidebarTab) => {
     setSidebarTabRaw(tab);
     localStorage.setItem('room-organizer-sidebar-tab', tab);
-  };
-
-  const removeItem = (id: string) => {
-    actions.removeItem(id);
-    playCue('remove');
-    setSelectedItemId((current) => (current === id ? null : current));
   };
 
   const handleFloorPlanUpload = async (file: File) => {

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -1143,6 +1143,7 @@ export function RoomOrganizer(): JSX.Element {
         onExportGlb={handleExportGlb}
         onShareLink={handleShareLink}
         placeCatalogItem={placeCatalogItem}
+        removeItem={removeItem}
       />
     </div>
     </SelectionProvider>


### PR DESCRIPTION
Stacked on #40 (merge that first — this extends the same autosave effect).

- Edits made within the 1.5s autosave debounce were silently lost on tab close or unmount; a pending save is now flushed on unmount and on pagehide.
- saveNamedLayout wrote to localStorage bare; with the base64 floor-plan image embedded, QuotaExceededError is realistic and threw uncaught, potentially leaving an orphaned blob or stale index entry. It now returns null on failure, rolls back on partial writes, and the panel alerts the user.
- The sidebar's local removeItem copy missed the extraSelectedIds cleanup, leaving ghost ids in multi-select after deleting from the placed-items list; the orchestrator's removeItem is passed down instead.
- The placed-items filter input no longer disappears while a query is active, which used to trap the panel in "no items match".

Fixes #30