### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [1.4.0] - 2026-08-05
+
+Bug-fix release resolving all twelve confirmed findings from the August 2026 code audit.
+
+### Fixed
+- Undo immediately after page load no longer reverts the house to the blank default and auto-saves the wipe ([#21](https://github.com/ch-bas/threejs-sims-house-builder/issues/21))
+- Opening a share link no longer overwrites the locally saved house ([#22](https://github.com/ch-bas/threejs-sims-house-builder/issues/22))
+- Achievements re-enabled — unlock detection had been silently disabled since the architecture refactor ([#23](https://github.com/ch-bas/threejs-sims-house-builder/issues/23))
+- Layout schema validation hardened: corrupt share URLs or localStorage entries can no longer crash the app or produce NaN-corrupted items ([#24](https://github.com/ch-bas/threejs-sims-house-builder/issues/24))
+- Single-key shortcuts no longer hijack browser shortcuts like Ctrl+R and Cmd+F; Delete and arrow-nudge respect locked items ([#25](https://github.com/ch-bas/threejs-sims-house-builder/issues/25))
+- Removing or reordering floors keeps the same floor active instead of silently switching the edit target; undo no longer jumps to the ground floor ([#26](https://github.com/ch-bas/threejs-sims-house-builder/issues/26))
+- Escape now cancels an in-progress interior wall draft ([#27](https://github.com/ch-bas/threejs-sims-house-builder/issues/27))
+- Undo within the debounce window reverts the pending edit instead of discarding it; undo/redo stacks are StrictMode-safe ([#28](https://github.com/ch-bas/threejs-sims-house-builder/issues/28))
+- Auto-organize leaves doors, windows, security cameras, and outdoor items anchored instead of tearing them off walls ([#29](https://github.com/ch-bas/threejs-sims-house-builder/issues/29))
+- Pending auto-saves flush on tab close; library saves survive storage-quota errors with rollback and feedback; sidebar delete no longer leaves ghost ids in multi-select ([#30](https://github.com/ch-bas/threejs-sims-house-builder/issues/30))
+
+### Performance
+- Mousemove over the canvas no longer re-renders the whole React tree; editor context identity is stable ([#31](https://github.com/ch-bas/threejs-sims-house-builder/issues/31))
+- One render per frame while orbiting instead of two ([#33](https://github.com/ch-bas/threejs-sims-house-builder/issues/33))
+
 ## [1.3.1] - 2026-06-10
 
 ### Added

--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -326,9 +326,13 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
     case 'removeFloor': {
       if (state.layout.floors.length <= 1) return state;
       const floors = state.layout.floors.filter((_, index) => index !== action.index);
+      // Removing a floor below the active one shifts the active floor down a
+      // slot; without the adjustment the editor silently switches floors.
+      const nextActive =
+        action.index < state.activeFloorIndex ? state.activeFloorIndex - 1 : state.activeFloorIndex;
       return {
         layout: { ...state.layout, floors },
-        activeFloorIndex: clampActiveIndex(state.activeFloorIndex, floors.length),
+        activeFloorIndex: clampActiveIndex(nextActive, floors.length),
       };
     }
 
@@ -346,15 +350,29 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
       const floors = [...state.layout.floors];
       const [moved] = floors.splice(from, 1);
       if (moved !== undefined) floors.splice(to, 0, moved);
+      // The same floor stays active through the move — reordering a different
+      // floor must not jump the editor to it.
+      let active = state.activeFloorIndex;
+      if (from === active) {
+        active = to;
+      } else {
+        if (from < active) active -= 1;
+        if (to <= active) active += 1;
+      }
       return {
         layout: { ...state.layout, floors },
-        activeFloorIndex: clampActiveIndex(to, floors.length),
+        activeFloorIndex: clampActiveIndex(active, floors.length),
       };
     }
 
     case 'applyLayout': {
       const layout = normaliseLayout(action.layout);
-      return { layout, activeFloorIndex: 0 };
+      // Clamp instead of resetting to 0 so undo/redo of an edit made on an
+      // upper floor doesn't jump the view back to the ground floor.
+      return {
+        layout,
+        activeFloorIndex: clampActiveIndex(state.activeFloorIndex, layout.floors.length),
+      };
     }
 
     default:

--- a/components/room-organizer/hooks/use-achievements.ts
+++ b/components/room-organizer/hooks/use-achievements.ts
@@ -13,14 +13,12 @@ const EMPTY_SET: ReadonlySet<string> = new Set();
 const EMPTY_ARRAY: readonly Achievement[] = [];
 const NOOP = () => {};
 
-export function useAchievements(layout: RoomLayout, enabled = false): UseAchievementsResult {
-  const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => enabled ? loadUnlocked() : new Set());
+export function useAchievements(layout: RoomLayout): UseAchievementsResult {
+  const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => loadUnlocked());
   const [pending, setPending] = useState<readonly Achievement[]>([]);
   const initialisedRef = useRef(false);
 
   useEffect(() => {
-    if (!enabled) return;
-
     const next: Achievement[] = [];
     let mutated = false;
     const newUnlocked = new Set(unlocked);
@@ -44,7 +42,7 @@ export function useAchievements(layout: RoomLayout, enabled = false): UseAchieve
       return;
     }
     setPending((current) => [...current, ...next]);
-  }, [layout, unlocked, enabled]);
+  }, [layout, unlocked]);
 
   // Mark initialised after the first paint so the very first user-driven
   // change still triggers a toast even on a fresh slate.

--- a/components/room-organizer/hooks/use-history.ts
+++ b/components/room-organizer/hooks/use-history.ts
@@ -15,6 +15,11 @@ export interface UseHistoryResult {
   clear(): void;
 }
 
+interface HistoryStacks<T> {
+  readonly past: readonly T[];
+  readonly future: readonly T[];
+}
+
 /**
  * Snapshot-based undo/redo. Watches `value`, and when it settles (no further
  * changes for `debounceMs`), commits a snapshot to the past stack. `undo`
@@ -22,12 +27,21 @@ export interface UseHistoryResult {
  *
  * The hook is "external state" friendly — it doesn't own the state, the
  * caller does. That keeps it composable with reducers, contexts, etc.
+ *
+ * Both stacks live in one state value, and undo/redo compute the next stacks
+ * outside the setState updater — StrictMode double-invokes updaters, so side
+ * effects inside them (apply, ref writes) would corrupt the stacks in dev.
  */
 export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: UseHistoryOptions = {}): UseHistoryResult {
   const { debounceMs = 600, maxEntries = 50 } = options;
 
-  const [past, setPast] = useState<T[]>([]);
-  const [future, setFuture] = useState<T[]>([]);
+  const [stacks, setStacks] = useState<HistoryStacks<T>>({ past: [], future: [] });
+  // Mirrors so event handlers read the current state without going through an
+  // updater function; kept in sync both on render and on every manual write.
+  const stacksRef = useRef(stacks);
+  stacksRef.current = stacks;
+  const valueRef = useRef(value);
+  valueRef.current = value;
   const lastCommittedRef = useRef<T>(value);
   const skipNextRef = useRef(false);
 
@@ -40,11 +54,10 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
     if (Object.is(value, lastCommittedRef.current)) return undefined;
 
     const timer = window.setTimeout(() => {
-      setPast((prev) => {
-        const next = [...prev, lastCommittedRef.current];
-        return next.length > maxEntries ? next.slice(next.length - maxEntries) : next;
-      });
-      setFuture([]);
+      const past = [...stacksRef.current.past, lastCommittedRef.current];
+      const trimmed = past.length > maxEntries ? past.slice(past.length - maxEntries) : past;
+      stacksRef.current = { past: trimmed, future: [] };
+      setStacks(stacksRef.current);
       lastCommittedRef.current = value;
     }, debounceMs);
 
@@ -52,29 +65,41 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
   }, [value, debounceMs, maxEntries]);
 
   const undo = useCallback(() => {
-    setPast((prev) => {
-      if (prev.length === 0) return prev;
-      const last = prev[prev.length - 1];
-      if (last === undefined) return prev;
-      setFuture((nextFuture) => [...nextFuture, lastCommittedRef.current]);
+    const { past, future } = stacksRef.current;
+
+    // An edit still inside the debounce window hasn't been committed yet.
+    // Undo it back to the last committed snapshot — without this, the pending
+    // edit would be discarded and undo would jump one step too far. While
+    // skipNextRef is armed the divergence is a not-yet-adopted baseline
+    // (hydration, undo/redo), not a pending edit.
+    if (!skipNextRef.current && !Object.is(valueRef.current, lastCommittedRef.current)) {
+      stacksRef.current = { past, future: [...future, valueRef.current] };
+      setStacks(stacksRef.current);
       skipNextRef.current = true;
-      lastCommittedRef.current = last;
-      apply(last);
-      return prev.slice(0, -1);
-    });
+      apply(lastCommittedRef.current);
+      return;
+    }
+
+    if (past.length === 0) return;
+    const last = past[past.length - 1];
+    if (last === undefined) return;
+    stacksRef.current = { past: past.slice(0, -1), future: [...future, lastCommittedRef.current] };
+    setStacks(stacksRef.current);
+    skipNextRef.current = true;
+    lastCommittedRef.current = last;
+    apply(last);
   }, [apply]);
 
   const redo = useCallback(() => {
-    setFuture((prev) => {
-      if (prev.length === 0) return prev;
-      const next = prev[prev.length - 1];
-      if (next === undefined) return prev;
-      setPast((nextPast) => [...nextPast, lastCommittedRef.current]);
-      skipNextRef.current = true;
-      lastCommittedRef.current = next;
-      apply(next);
-      return prev.slice(0, -1);
-    });
+    const { past, future } = stacksRef.current;
+    if (future.length === 0) return;
+    const next = future[future.length - 1];
+    if (next === undefined) return;
+    stacksRef.current = { past: [...past, lastCommittedRef.current], future: future.slice(0, -1) };
+    setStacks(stacksRef.current);
+    skipNextRef.current = true;
+    lastCommittedRef.current = next;
+    apply(next);
   }, [apply]);
 
   // Call this alongside (or right after) applying a new baseline value, e.g.
@@ -82,13 +107,16 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
   // as the baseline instead of diffing it against the stale one — otherwise
   // undo right after hydration would revert to the pre-hydration state.
   const clear = useCallback(() => {
-    setPast([]);
-    setFuture([]);
+    stacksRef.current = { past: [], future: [] };
+    setStacks(stacksRef.current);
     skipNextRef.current = true;
   }, []);
 
-  const canUndo = past.length > 0;
-  const canRedo = future.length > 0;
+  // A pending uncommitted edit is undoable too (back to the last committed
+  // snapshot), so canUndo can't rely on the past stack alone.
+  const canUndo =
+    stacks.past.length > 0 || (!skipNextRef.current && !Object.is(value, lastCommittedRef.current));
+  const canRedo = stacks.future.length > 0;
 
   return useMemo(
     () => ({ canUndo, canRedo, undo, redo, clear }),

--- a/components/room-organizer/hooks/use-history.ts
+++ b/components/room-organizer/hooks/use-history.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 export interface UseHistoryOptions {
   /** Debounce window for committing a snapshot, in milliseconds. */
@@ -77,17 +77,21 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
     });
   }, [apply]);
 
+  // Call this alongside (or right after) applying a new baseline value, e.g.
+  // hydration. `skipNextRef` makes the commit effect adopt the upcoming value
+  // as the baseline instead of diffing it against the stale one — otherwise
+  // undo right after hydration would revert to the pre-hydration state.
   const clear = useCallback(() => {
     setPast([]);
     setFuture([]);
-    lastCommittedRef.current = value;
-  }, [value]);
+    skipNextRef.current = true;
+  }, []);
 
-  return {
-    canUndo: past.length > 0,
-    canRedo: future.length > 0,
-    undo,
-    redo,
-    clear,
-  };
+  const canUndo = past.length > 0;
+  const canRedo = future.length > 0;
+
+  return useMemo(
+    () => ({ canUndo, canRedo, undo, redo, clear }),
+    [canUndo, canRedo, undo, redo, clear]
+  );
 }

--- a/components/room-organizer/hooks/use-keyboard-shortcuts.ts
+++ b/components/room-organizer/hooks/use-keyboard-shortcuts.ts
@@ -59,11 +59,21 @@ export function useKeyboardShortcuts({
         return;
       }
 
+      if (ctrlOrCmd && event.key.toLowerCase() === 'd' && selectedItem) {
+        event.preventDefault();
+        handlers.duplicateItem(selectedItem.id);
+        return;
+      }
+
       if (event.key === 'Escape') {
         event.preventDefault();
         handlers.deselect();
         return;
       }
+
+      // Everything below is a bare single-key shortcut. Never swallow browser
+      // shortcuts like Cmd/Ctrl+F (find), Ctrl+R (reload), or Cmd+M.
+      if (ctrlOrCmd || event.altKey) return;
 
       if (event.key === 'f' && selectedItem) {
         event.preventDefault();
@@ -73,7 +83,8 @@ export function useKeyboardShortcuts({
 
       if ((event.key === 'Delete' || event.key === 'Backspace') && selectedItem) {
         event.preventDefault();
-        handlers.removeItem(selectedItem.id);
+        // Locked items can't be deleted from the keyboard, matching 3D drag.
+        if (!selectedItem.locked) handlers.removeItem(selectedItem.id);
         return;
       }
 
@@ -84,12 +95,6 @@ export function useKeyboardShortcuts({
         } else {
           handlers.toggleExteriorWall(selectedWall.id);
         }
-        return;
-      }
-
-      if ((event.ctrlKey || event.metaKey) && event.key === 'd' && selectedItem) {
-        event.preventDefault();
-        handlers.duplicateItem(selectedItem.id);
         return;
       }
 
@@ -150,14 +155,14 @@ export function useKeyboardShortcuts({
         return;
       }
 
-      if (event.key === 'p' && !ctrlOrCmd) {
+      if (event.key === 'p') {
         event.preventDefault();
         handlers.toggleSidebar();
         return;
       }
 
       const delta = ARROW_DELTAS[event.key];
-      if (delta && selectedItem?.position) {
+      if (delta && selectedItem?.position && !selectedItem.locked) {
         event.preventDefault();
         const step = event.shiftKey ? 1.0 : 0.1;
         const [dx, dz] = delta;
@@ -175,5 +180,11 @@ export function useKeyboardShortcuts({
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {
-  return target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement;
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target instanceof HTMLSelectElement ||
+    target.isContentEditable
+  );
 }

--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -23,6 +23,11 @@ export function useLayoutPersistence({
   debounceMs = AUTOSAVE_DEBOUNCE_MS,
 }: UseLayoutPersistenceOptions): UseLayoutPersistenceResult {
   const hasHydratedRef = useRef(false);
+  // While set, autosave is suppressed until the layout moves past the stored
+  // pre-hydration value — i.e. until the hydration dispatch has landed. This
+  // stops a freshly opened share link (or a plain reload) from overwriting the
+  // local save before the user has actually edited anything.
+  const hydrationBaseRef = useRef<RoomLayout | null>(null);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -35,6 +40,7 @@ export function useLayoutPersistence({
     if (typeof window !== 'undefined') {
       const shared = decodeShareUrl(window.location.hash);
       if (shared) {
+        hydrationBaseRef.current = layout;
         onHydrate(shared);
         // Clear the hash so reloading after edits doesn't restore the
         // shared version.
@@ -44,11 +50,21 @@ export function useLayoutPersistence({
     }
 
     const saved = loadLayout();
-    if (saved) onHydrate(saved);
+    if (saved) {
+      hydrationBaseRef.current = layout;
+      onHydrate(saved);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot hydration; `layout` is only read as the pre-hydration baseline
   }, [onHydrate]);
 
   useEffect(() => {
-    if (!hasHydratedRef.current) return;
+    if (hydrationBaseRef.current) {
+      if (Object.is(layout, hydrationBaseRef.current)) return;
+      // First layout change after hydration is the hydration dispatch itself,
+      // not a user edit — swallow it and resume normal autosave afterwards.
+      hydrationBaseRef.current = null;
+      return;
+    }
     setSaving(true);
     const handle = window.setTimeout(() => {
       saveLayout(layout);

--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -28,6 +28,9 @@ export function useLayoutPersistence({
   // stops a freshly opened share link (or a plain reload) from overwriting the
   // local save before the user has actually edited anything.
   const hydrationBaseRef = useRef<RoomLayout | null>(null);
+  const layoutRef = useRef(layout);
+  layoutRef.current = layout;
+  const pendingRef = useRef(false);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
 
@@ -66,13 +69,31 @@ export function useLayoutPersistence({
       return;
     }
     setSaving(true);
+    pendingRef.current = true;
     const handle = window.setTimeout(() => {
+      pendingRef.current = false;
       saveLayout(layout);
       setLastSavedAt(Date.now());
       setSaving(false);
     }, debounceMs);
     return () => window.clearTimeout(handle);
   }, [layout, debounceMs]);
+
+  // Flush a still-debouncing save when the editor unmounts or the page goes
+  // away — without this, edits made in the last debounceMs are silently lost
+  // on tab close.
+  useEffect(() => {
+    const flush = () => {
+      if (!pendingRef.current) return;
+      pendingRef.current = false;
+      saveLayout(layoutRef.current);
+    };
+    window.addEventListener('pagehide', flush);
+    return () => {
+      window.removeEventListener('pagehide', flush);
+      flush();
+    };
+  }, []);
 
   return { lastSavedAt, saving };
 }

--- a/components/room-organizer/lib/library.ts
+++ b/components/room-organizer/lib/library.ts
@@ -60,7 +60,13 @@ function totalItemCount(layout: RoomLayout): number {
   return layout.floors.reduce((sum, floor) => sum + floor.items.length, 0);
 }
 
-export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult {
+/**
+ * Returns `null` when localStorage rejects the write (typically
+ * QuotaExceededError — library entries embed the base64 floor-plan image, so
+ * running out of the ~5MB quota is realistic). The layout blob and the index
+ * are kept consistent: if the index write fails, the blob is rolled back.
+ */
+export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult | null {
   const trimmed = name.trim() || layout.name || 'Untitled';
   const id = slugify(trimmed);
   const index = readIndex();
@@ -75,14 +81,25 @@ export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult {
   };
 
   const layoutCopy: RoomLayout = { ...layout, id, name: trimmed };
-  window.localStorage.setItem(layoutKey(id), JSON.stringify(layoutCopy));
+  const previousBlob = window.localStorage.getItem(layoutKey(id));
+  try {
+    window.localStorage.setItem(layoutKey(id), JSON.stringify(layoutCopy));
+  } catch {
+    return null;
+  }
 
   if (existingIndex >= 0) {
     index.entries[existingIndex] = entry;
   } else {
     index.entries.push(entry);
   }
-  writeIndex(index);
+  try {
+    writeIndex(index);
+  } catch {
+    if (previousBlob === null) window.localStorage.removeItem(layoutKey(id));
+    else window.localStorage.setItem(layoutKey(id), previousBlob);
+    return null;
+  }
 
   return { entry, overwrote: existingIndex >= 0 };
 }

--- a/components/room-organizer/lib/schema.ts
+++ b/components/room-organizer/lib/schema.ts
@@ -6,8 +6,16 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
+function isPositiveNumber(value: unknown): value is number {
+  return isFiniteNumber(value) && value > 0;
+}
+
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isVec2(value: unknown): boolean {
+  return isPlainObject(value) && isFiniteNumber(value.x) && isFiniteNumber(value.z);
 }
 
 export function isFurnitureItem(value: unknown): value is FurnitureItem {
@@ -17,9 +25,9 @@ export function isFurnitureItem(value: unknown): value is FurnitureItem {
     typeof v.id !== 'string' ||
     typeof v.type !== 'string' ||
     typeof v.name !== 'string' ||
-    !isFiniteNumber(v.width) ||
-    !isFiniteNumber(v.depth) ||
-    !isFiniteNumber(v.height) ||
+    !isPositiveNumber(v.width) ||
+    !isPositiveNumber(v.depth) ||
+    !isPositiveNumber(v.height) ||
     typeof v.color !== 'string' ||
     typeof v.icon !== 'string'
   ) {
@@ -27,6 +35,12 @@ export function isFurnitureItem(value: unknown): value is FurnitureItem {
   }
   if (v.price !== undefined && !isFiniteNumber(v.price)) return false;
   if (v.category !== undefined && typeof v.category !== 'string') return false;
+  if (v.position !== undefined && !isVec2(v.position)) return false;
+  if (v.rotation !== undefined && !isFiniteNumber(v.rotation)) return false;
+  if (v.signalRange !== undefined && !isFiniteNumber(v.signalRange)) return false;
+  if (v.visionRange !== undefined && !isFiniteNumber(v.visionRange)) return false;
+  if (v.visionFov !== undefined && !isFiniteNumber(v.visionFov)) return false;
+  if (v.wallRotation !== undefined && !isFiniteNumber(v.wallRotation)) return false;
   return true;
 }
 
@@ -39,7 +53,14 @@ export function isFloorLayout(value: unknown): value is FloorLayout {
   if (!Array.isArray(v.items) || !v.items.every(isFurnitureItem)) return false;
   if (v.floorPattern !== undefined && typeof v.floorPattern !== 'string') return false;
   if (v.wallPattern !== undefined && typeof v.wallPattern !== 'string') return false;
-  if (v.wallColors !== undefined && !isPlainObject(v.wallColors)) return false;
+  if (v.wallColors !== undefined) {
+    if (!isPlainObject(v.wallColors)) return false;
+    if (!Object.values(v.wallColors).every((color) => typeof color === 'string')) return false;
+  }
+  if (v.hiddenWalls !== undefined) {
+    if (!Array.isArray(v.hiddenWalls)) return false;
+    if (!v.hiddenWalls.every((wall) => typeof wall === 'string')) return false;
+  }
   if (v.interiorWalls !== undefined) {
     if (!Array.isArray(v.interiorWalls)) return false;
     for (const wall of v.interiorWalls) {
@@ -125,6 +146,9 @@ function isLegacySingleFloorLayout(value: unknown): value is LegacySingleFloorLa
     typeof v.floorColor === 'string' &&
     Array.isArray(v.items) &&
     v.items.every(isFurnitureItem) &&
+    (v.wallColors === undefined ||
+      (isPlainObject(v.wallColors) &&
+        Object.values(v.wallColors).every((color) => typeof color === 'string'))) &&
     !('floors' in v)
   );
 }

--- a/components/room-organizer/panels/actions-panel.tsx
+++ b/components/room-organizer/panels/actions-panel.tsx
@@ -7,9 +7,11 @@ import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
 import { openBlueprintPrintWindow } from '../lib/blueprint';
 import { downloadLayoutAsJson, downloadInventoryCsv } from '../lib/file-io';
-import { autoOrganize } from '../lib/geometry';
+import { autoOrganize, type AutoOrganizeStrategy } from '../lib/geometry';
+import { isWallMounted } from '../lib/opening-snap';
 import { encodeShareUrl, isShareUrlReasonablySized } from '../lib/share';
 import { surpriseLayout } from '../lib/surprise';
+import type { FurnitureItem } from '../lib/types';
 
 export interface ActionsPanelProps {
   onImport(file: File): void;
@@ -25,6 +27,19 @@ export function ActionsPanel(props: ActionsPanelProps): JSX.Element {
   const hasItems = activeFloor.items.length > 0;
   const allLocked = hasItems && activeFloor.items.every((item) => item.locked === true);
 
+  // Doors/windows/cameras must stay on their walls and outdoor items must stay
+  // outside the building — organizing them into the room grid tears openings
+  // off their cutouts and drags garden items indoors as permanent collisions.
+  const organize = (strategy: AutoOrganizeStrategy) => {
+    const anchored: FurnitureItem[] = [];
+    const movable: FurnitureItem[] = [];
+    for (const item of activeFloor.items) {
+      if (isWallMounted(item.type) || item.category === 'outdoor') anchored.push(item);
+      else movable.push(item);
+    }
+    actions.replaceItems([...anchored, ...autoOrganize(movable, layout.width, layout.height, strategy)]);
+  };
+
   const handleFile = (event: React.ChangeEvent<HTMLInputElement>) => {
     const file = event.target.files?.[0];
     if (file) props.onImport(file);
@@ -39,20 +54,11 @@ export function ActionsPanel(props: ActionsPanelProps): JSX.Element {
       <CardContent className="space-y-3">
         <Section title="Arrange">
           <div className="grid grid-cols-3 gap-1">
-            <Button
-              onClick={() =>
-                actions.replaceItems(autoOrganize(activeFloor.items, layout.width, layout.height, 'shelf'))
-              }
-              disabled={!hasItems}
-              size="sm"
-              className="text-xs"
-            >
+            <Button onClick={() => organize('shelf')} disabled={!hasItems} size="sm" className="text-xs">
               🎯 Pack
             </Button>
             <Button
-              onClick={() =>
-                actions.replaceItems(autoOrganize(activeFloor.items, layout.width, layout.height, 'by-category'))
-              }
+              onClick={() => organize('by-category')}
               variant="outline"
               disabled={!hasItems}
               size="sm"
@@ -61,9 +67,7 @@ export function ActionsPanel(props: ActionsPanelProps): JSX.Element {
               🏷 By cat
             </Button>
             <Button
-              onClick={() =>
-                actions.replaceItems(autoOrganize(activeFloor.items, layout.width, layout.height, 'by-size'))
-              }
+              onClick={() => organize('by-size')}
               variant="outline"
               disabled={!hasItems}
               size="sm"

--- a/components/room-organizer/panels/library-panel.tsx
+++ b/components/room-organizer/panels/library-panel.tsx
@@ -43,7 +43,13 @@ export function LibraryPanel({ currentLayout, onLoad }: LibraryPanelProps): JSX.
     if (layoutSlugExists(trimmed) && !window.confirm(`Overwrite the existing layout "${trimmed}"?`)) {
       return;
     }
-    saveNamedLayout(currentLayout, trimmed);
+    const result = saveNamedLayout(currentLayout, trimmed);
+    if (!result) {
+      window.alert(
+        'Could not save the layout — browser storage is full. Delete some saved layouts or remove the floor-plan image and try again.'
+      );
+      return;
+    }
     refresh();
   };
 

--- a/components/room-organizer/panels/placed-items-panel.tsx
+++ b/components/room-organizer/panels/placed-items-panel.tsx
@@ -31,7 +31,9 @@ export function PlacedItemsPanel({
     <Card>
       <CardHeader className="space-y-2">
         <CardTitle>Placed Items ({items.length})</CardTitle>
-        {items.length > 4 && (
+        {/* Keep the input visible while a query is set, or deleting items
+            below the threshold would trap the panel in "no items match". */}
+        {(items.length > 4 || query !== '') && (
           <Input
             placeholder="Filter items…"
             value={query}

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -44,6 +44,11 @@ export interface SidebarDrawerProps {
   onShareLink(): void;
   /** Wall-aware placement (snaps doors/windows/cameras to walls) shared with the bottom catalog. */
   placeCatalogItem(catalogItem: CatalogItem, position?: { x: number; z: number }): string;
+  /**
+   * The orchestrator's removeItem — it also clears the id from the
+   * multi-select set, which a local reimplementation here used to miss.
+   */
+  removeItem(id: string): void;
 }
 
 export function SidebarDrawer({
@@ -57,6 +62,7 @@ export function SidebarDrawer({
   onExportGlb,
   onShareLink,
   placeCatalogItem,
+  removeItem,
 }: SidebarDrawerProps): JSX.Element {
   const { layout, activeFloor, actions, view, isReady, playCue, history, catalogQuery, setCatalogQuery } = useRoomEditor();
   const { selectedItem, setSelectedItemId, allSelectedIds } = useSelection();
@@ -68,12 +74,6 @@ export function SidebarDrawer({
   const setSidebarTab = (tab: SidebarTab) => {
     setSidebarTabRaw(tab);
     localStorage.setItem('room-organizer-sidebar-tab', tab);
-  };
-
-  const removeItem = (id: string) => {
-    actions.removeItem(id);
-    playCue('remove');
-    setSelectedItemId((current) => (current === id ? null : current));
   };
 
   const handleFloorPlanUpload = async (file: File) => {

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -1143,6 +1143,7 @@ export function RoomOrganizer(): JSX.Element {
         onExportGlb={handleExportGlb}
         onShareLink={handleShareLink}
         placeCatalogItem={placeCatalogItem}
+        removeItem={removeItem}
       />
     </div>
     </SelectionProvider>

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -902,6 +902,7 @@ export function RoomOrganizer(): JSX.Element {
       focusOn,
       rotateItemHandler,
       reseatCamera,
+      wallDraft,
     ]
   );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "threejs-sims-house-builder",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "A lightweight, open-source Sims-like house builder built entirely in the browser using Three.js.",
   "author": "Bassem Chagra",
   "license": "MIT",


### PR DESCRIPTION
Bug-fix release from the August 2026 code audit. Merges ten fixes (PRs #39–#42, #45–#50); together with #43/#44 already on main, this resolves all twelve confirmed audit bugs.

## Data-loss & corruption fixes
- Undo right after page load no longer reverts the house to the blank default (with autosave persisting the wipe) — #21
- Opening a share link no longer overwrites the locally saved house — #22
- Corrupt/crafted share URLs and localStorage entries can no longer crash the app or NaN-corrupt the layout (schema validation hardened) — #24
- Edits made in the last 1.5s before tab close are no longer lost; library saves survive storage-quota errors with rollback and user feedback — #30

## Regressions & behaviour fixes
- Achievements re-enabled (silently dead since the architecture refactor) — #23
- Ctrl+R / Cmd+F and other browser shortcuts are no longer hijacked; locked items can't be deleted/nudged from the keyboard — #25
- Removing or reordering floors no longer silently switches which floor is being edited; undo no longer jumps to the ground floor — #26
- Escape now cancels an in-progress interior wall draft — #27
- Undo within the debounce window no longer discards the pending edit; undo/redo stacks are StrictMode-safe — #28
- Auto-organize leaves doors, windows, cameras, and outdoor items anchored — #29
- Deleting a multi-selected item from the sidebar no longer leaves ghost ids in the selection — #30

## Performance
- Mousemove over the canvas no longer re-renders the whole React tree (with the stable-context half from #21's fix) — #31

## Verification
Typecheck clean, lint at 33 warnings (one below the pre-release baseline, none introduced), production build succeeds.

Closes #21, closes #22, closes #23, closes #24, closes #25, closes #26, closes #27, closes #28, closes #29, closes #30