### PR TITLE
Remove 13 dead symbols and enable noUnusedLocals/noUnusedParameters

### DIFF
--- a/components/room-organizer/hooks/use-achievements.ts
+++ b/components/room-organizer/hooks/use-achievements.ts
@@ -9,10 +9,6 @@ export interface UseAchievementsResult {
   dismiss(): void;
 }
 
-const EMPTY_SET: ReadonlySet<string> = new Set();
-const EMPTY_ARRAY: readonly Achievement[] = [];
-const NOOP = () => {};
-
 export function useAchievements(layout: RoomLayout): UseAchievementsResult {
   const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => loadUnlocked());
   const [pending, setPending] = useState<readonly Achievement[]>([]);

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -13,7 +13,7 @@ import {
 } from '../three/interior-walls';
 import { clearItemLabels, renderItemLabels } from '../three/item-labels';
 import { applyTimeOfDay } from '../three/lighting';
-import { clearMeasurement, measurementDistance, renderMeasurement } from '../three/measurement';
+import { clearMeasurement, renderMeasurement } from '../three/measurement';
 import { setOutdoorVisible } from '../three/outdoor';
 import { buildRoof, removeRoof } from '../three/roof';
 import { ROOM_OBJECT_TAGS, applyWallDisplay, buildRoom, removeTagged } from '../three/room-builder';

--- a/components/room-organizer/lib/catalog-drag.ts
+++ b/components/room-organizer/lib/catalog-drag.ts
@@ -1,8 +1,1 @@
-import { FURNITURE_CATALOG } from './constants';
-import type { CatalogItem } from './types';
-
 export const CATALOG_DRAG_MIME = 'application/x-room-organizer-catalog-item';
-
-export function findCatalogItem(type: string): CatalogItem | null {
-  return FURNITURE_CATALOG.find((entry) => entry.type === type) ?? null;
-}

--- a/components/room-organizer/lib/cctv-models.ts
+++ b/components/room-organizer/lib/cctv-models.ts
@@ -54,9 +54,6 @@ export const CCTV_MODELS: readonly CctvModel[] = [
   { id: 'blink-outdoor-4', brand: 'Blink', model: 'Outdoor 4', type: 'Battery', fov: 124, range: 8, resolution: '1080p', note: '143° diagonal' },
 ];
 
-/** Default model a freshly-placed Security Camera adopts. */
-export const DEFAULT_CCTV_MODEL_ID = 'hik-2cd2143g2';
-
 export function getCctvModel(id: string | undefined): CctvModel | undefined {
   if (!id) return undefined;
   return CCTV_MODELS.find((entry) => entry.id === id);

--- a/components/room-organizer/lib/persistence.ts
+++ b/components/room-organizer/lib/persistence.ts
@@ -26,12 +26,3 @@ export function saveLayout(layout: RoomLayout): void {
     console.warn('Failed to persist layout to localStorage:', error);
   }
 }
-
-export function clearLayout(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore */
-  }
-}

--- a/components/room-organizer/panels/actions-panel.tsx
+++ b/components/room-organizer/panels/actions-panel.tsx
@@ -9,7 +9,6 @@ import { openBlueprintPrintWindow } from '../lib/blueprint';
 import { downloadLayoutAsJson, downloadInventoryCsv } from '../lib/file-io';
 import { autoOrganize, type AutoOrganizeStrategy } from '../lib/geometry';
 import { isWallMounted } from '../lib/opening-snap';
-import { encodeShareUrl, isShareUrlReasonablySized } from '../lib/share';
 import { surpriseLayout } from '../lib/surprise';
 import type { FurnitureItem } from '../lib/types';
 

--- a/components/room-organizer/panels/item-resize-panel.tsx
+++ b/components/room-organizer/panels/item-resize-panel.tsx
@@ -63,7 +63,7 @@ export interface ItemResizePanelProps {
 }
 
 export function ItemResizePanel(props: ItemResizePanelProps): JSX.Element {
-  const { actions, recentColors, pushColor, layout, activeFloor } = useRoomEditor();
+  const { actions, recentColors, pushColor } = useRoomEditor();
   const { selectedItem } = useSelection();
   if (!selectedItem) return <></>;
   const item = selectedItem;

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
 import { alignSelection, distributeSelection } from '../lib/alignment';
@@ -29,7 +29,7 @@ import { ThemesPanel } from './themes-panel';
 import { TimeOfDayPanel } from './time-of-day-panel';
 import { WallsPanel } from './walls-panel';
 import type { AlignEdge, DistributeAxis } from '../lib/alignment';
-import type { CameraPreset, CatalogItem, RoomLayout } from '../lib/types';
+import type { CameraPreset, CatalogItem } from '../lib/types';
 
 export interface SidebarDrawerProps {
   collapsed: boolean;

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -88,12 +88,6 @@ function zoomCamera(
   controls.update();
 }
 
-function formatClock(hour: number): string {
-  const h = Math.floor(hour);
-  const m = Math.floor((hour - h) * 60);
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-}
-
 const INITIAL_VIEW_SETTINGS: ViewSettings = {
   view2D: false,
   showMeasurements: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Enabling `noUnusedLocals` + `noUnusedParameters` in tsconfig.json surfaced exactly 10 dead locals/imports left behind by earlier refactors — the leftover share-URL import in actions-panel, `formatClock`, `EMPTY_SET`/`EMPTY_ARRAY`/`NOOP`, unused context destructures, and stale imports. All deleted, and the flags now keep this class of rot from returning (CI runs typecheck, so a new unused symbol fails the build).

Also removes three dead **exports** the flags can't see, each re-verified unused by grep after the 1.4.0 merges: `DEFAULT_CCTV_MODEL_ID`, `clearLayout`, `findCatalogItem`.

Net: −34 lines of dead code, +2 lines of tsconfig. Typecheck clean with the new flags, lint clean at `--max-warnings=0`, production build succeeds.

Fixes #35