### PR TITLE
Add a shared material() helper for the mesh builders

### DIFF
--- a/components/room-organizer/three/builder-utils.ts
+++ b/components/room-organizer/three/builder-utils.ts
@@ -60,6 +60,22 @@ export function mesh(THREE: ThreeModule, geometry: ThreeNS.BufferGeometry, mater
   return m;
 }
 
+/**
+ * The standard builder material: `color` plus the collision-tint plumbing
+ * (`transparent: hasCollision, opacity`) that nearly every part shares.
+ * Remaining MeshStandardMaterial params (roughness, metalness, emissive, …)
+ * go in `extra`.
+ */
+export function material(
+  THREE: ThreeModule,
+  color: ThreeNS.ColorRepresentation,
+  hasCollision: boolean,
+  opacity: number,
+  extra: Omit<ThreeNS.MeshStandardMaterialParameters, 'color' | 'transparent' | 'opacity'> = {}
+): ThreeNS.MeshStandardMaterial {
+  return new THREE.MeshStandardMaterial({ color, transparent: hasCollision, opacity, ...extra });
+}
+
 export function cornerPositions(x: number, y: number, z: number): ReadonlyArray<readonly [number, number, number]> {
   return [
     [x, y, z],
@@ -117,13 +133,7 @@ export function buildOrganicBlob(
   geom.computeVertexNormals();
   const m = new THREE.Mesh(
     geom,
-    new THREE.MeshStandardMaterial({
-      color,
-      roughness: 0.95,
-      flatShading: true,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, color, hasCollision, opacity, { roughness: 0.95, flatShading: true })
   );
   m.castShadow = true;
   m.receiveShadow = true;
@@ -135,7 +145,7 @@ export function buildFallback({ THREE, item, hasCollision, baseColor, opacity }:
   const block = mesh(
     THREE,
     new THREE.BoxGeometry(item.width, item.height, item.depth),
-    new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, metalness: 0.3, transparent: hasCollision, opacity })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7, metalness: 0.3 })
   );
   block.position.y = item.height / 2;
   group.add(block);

--- a/components/room-organizer/three/builders/builders-bathroom.ts
+++ b/components/room-organizer/three/builders/builders-bathroom.ts
@@ -1,9 +1,9 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildToilet({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.3, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.3 });
 
   const bowl = mesh(THREE, new THREE.CylinderGeometry(item.width * 0.5, item.width * 0.5, item.height * 0.45, 16), mat);
   bowl.position.y = item.height * 0.225;
@@ -21,7 +21,7 @@ export function buildToilet({ THREE, item, hasCollision, baseColor, opacity }: B
 
 export function buildBathtub({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.25, metalness: 0.05, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.25, metalness: 0.05 });
   const waterMat = new THREE.MeshStandardMaterial({
     color: 0x4fc3f7,
     roughness: 0.2,
@@ -36,7 +36,7 @@ export function buildBathtub({ THREE, item, hasCollision, baseColor, opacity }: 
   const inner = mesh(
     THREE,
     new THREE.BoxGeometry(item.width * 0.88, item.height * 0.7, item.depth * 0.8),
-    new THREE.MeshStandardMaterial({ color: 0xeceff1, roughness: 0.4, transparent: hasCollision, opacity })
+    material(THREE, 0xeceff1, hasCollision, opacity, { roughness: 0.4 })
   );
   inner.position.y = item.height * 0.7;
   group.add(inner);
@@ -50,8 +50,8 @@ export function buildBathtub({ THREE, item, hasCollision, baseColor, opacity }: 
 export function buildShower({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
   const glassMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.1, metalness: 0.1, transparent: true, opacity: hasCollision ? 0.7 : 0.35 });
-  const trayMat = new THREE.MeshStandardMaterial({ color: 0xeceff1, roughness: 0.5, transparent: hasCollision, opacity });
-  const headMat = new THREE.MeshStandardMaterial({ color: 0xb0bec5, metalness: 0.9, roughness: 0.2, transparent: hasCollision, opacity });
+  const trayMat = material(THREE, 0xeceff1, hasCollision, opacity, { roughness: 0.5 });
+  const headMat = material(THREE, 0xb0bec5, hasCollision, opacity, { metalness: 0.9, roughness: 0.2 });
 
   const tray = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.05, item.depth), trayMat);
   tray.position.y = item.height * 0.025;

--- a/components/room-organizer/three/builders/builders-bedroom.ts
+++ b/components/room-organizer/three/builders/builders-bedroom.ts
@@ -1,17 +1,12 @@
-import { type BuilderContext, mesh, lightenHex } from '../builder-utils';
+import { type BuilderContext, material, mesh, lightenHex } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildBed({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const woodMat = new THREE.MeshStandardMaterial({ color: 0x8b4513, roughness: 0.8, transparent: hasCollision, opacity });
-  const sheetMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.9, transparent: hasCollision, opacity });
-  const pillowMat = new THREE.MeshStandardMaterial({ color: 0xfafafa, roughness: 0.95, transparent: hasCollision, opacity });
-  const throwMat = new THREE.MeshStandardMaterial({
-    color: lightenHex(item.color, -0.18),
-    roughness: 0.95,
-    transparent: hasCollision,
-    opacity,
-  });
+  const woodMat = material(THREE, 0x8b4513, hasCollision, opacity, { roughness: 0.8 });
+  const sheetMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.9 });
+  const pillowMat = material(THREE, 0xfafafa, hasCollision, opacity, { roughness: 0.95 });
+  const throwMat = material(THREE, lightenHex(item.color, -0.18), hasCollision, opacity, { roughness: 0.95 });
 
   // Headboard at the head end (-z).
   const headboard = mesh(
@@ -63,8 +58,8 @@ export function buildBed({ THREE, item, hasCollision, baseColor, opacity }: Buil
 
 export function buildNightstand({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const woodMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
-  const drawerMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.6, transparent: hasCollision, opacity });
+  const woodMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const drawerMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6 });
 
   const body = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), woodMat);
   body.position.y = item.height / 2;
@@ -78,13 +73,7 @@ export function buildNightstand({ THREE, item, hasCollision, baseColor, opacity 
   }
 
   const handleGeo = new THREE.SphereGeometry(0.03, 8, 8);
-  const handleMat = new THREE.MeshStandardMaterial({
-    color: 0x888888,
-    metalness: 0.8,
-    roughness: 0.2,
-    transparent: hasCollision,
-    opacity,
-  });
+  const handleMat = material(THREE, 0x888888, hasCollision, opacity, { metalness: 0.8, roughness: 0.2 });
   for (const y of [item.height * 0.65, item.height * 0.25]) {
     const handle = mesh(THREE, handleGeo, handleMat);
     handle.position.set(0, y, item.depth * 0.53);
@@ -96,8 +85,8 @@ export function buildNightstand({ THREE, item, hasCollision, baseColor, opacity 
 
 export function buildDresser({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
-  const accentMat = new THREE.MeshStandardMaterial({ color: 0x424242, metalness: 0.6, roughness: 0.3, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const accentMat = material(THREE, 0x424242, hasCollision, opacity, { metalness: 0.6, roughness: 0.3 });
 
   const body = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), mat);
   body.position.y = item.height / 2;

--- a/components/room-organizer/three/builders/builders-decor.ts
+++ b/components/room-organizer/three/builders/builders-decor.ts
@@ -1,10 +1,10 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildRug({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 1.0, transparent: hasCollision, opacity });
-  const border = new THREE.MeshStandardMaterial({ color: 0x424242, roughness: 1.0, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 1.0 });
+  const border = material(THREE, 0x424242, hasCollision, opacity, { roughness: 1.0 });
 
   const rug = mesh(THREE, new THREE.BoxGeometry(item.width, 0.01, item.depth), mat);
   rug.position.y = 0.005;
@@ -18,8 +18,8 @@ export function buildRug({ THREE, item, hasCollision, baseColor, opacity }: Buil
 
 export function buildPainting({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.6, transparent: hasCollision, opacity });
-  const canvasMat = new THREE.MeshStandardMaterial({ color: 0xfff3e0, roughness: 0.8, transparent: hasCollision, opacity });
+  const frameMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6 });
+  const canvasMat = material(THREE, 0xfff3e0, hasCollision, opacity, { roughness: 0.8 });
 
   const frame = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), frameMat);
   frame.position.y = item.height / 2 + 0.8;
@@ -39,7 +39,7 @@ export function buildPainting({ THREE, item, hasCollision, baseColor, opacity }:
     const blob = mesh(
       THREE,
       new THREE.SphereGeometry(item.width * 0.12, 10, 10),
-      new THREE.MeshStandardMaterial({ color, roughness: 0.7, transparent: hasCollision, opacity })
+      material(THREE, color, hasCollision, opacity, { roughness: 0.7 })
     );
     blob.position.set(item.width * (i - 1) * 0.25, item.height / 2 + 0.8 + Math.sin(i) * 0.1, item.depth * 0.32);
     group.add(blob);
@@ -49,7 +49,7 @@ export function buildPainting({ THREE, item, hasCollision, baseColor, opacity }:
 
 export function buildVase({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.4, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.4 });
 
   const lower = mesh(THREE, new THREE.SphereGeometry(item.width * 0.45, 16, 16), mat);
   lower.position.y = item.height * 0.4;
@@ -64,8 +64,8 @@ export function buildVase({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildMirror({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, transparent: hasCollision, opacity });
-  const reflectMat = new THREE.MeshStandardMaterial({ color: 0xb3e5fc, roughness: 0.05, metalness: 0.95, transparent: hasCollision, opacity });
+  const frameMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5 });
+  const reflectMat = material(THREE, 0xb3e5fc, hasCollision, opacity, { roughness: 0.05, metalness: 0.95 });
 
   const frame = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), frameMat);
   frame.position.y = item.height / 2 + 0.4;
@@ -83,19 +83,8 @@ export function buildMirror({ THREE, item, hasCollision, baseColor, opacity }: B
 
 export function buildCurtains({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const rodMat = new THREE.MeshStandardMaterial({
-    color: 0x37474f,
-    roughness: 0.4,
-    metalness: 0.7,
-    transparent: hasCollision,
-    opacity,
-  });
-  const fabricMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.95,
-    transparent: hasCollision,
-    opacity,
-  });
+  const rodMat = material(THREE, 0x37474f, hasCollision, opacity, { roughness: 0.4, metalness: 0.7 });
+  const fabricMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.95 });
 
   // Rod across the top.
   const rodLength = item.width;
@@ -146,19 +135,8 @@ export function buildCurtains({ THREE, item, hasCollision, baseColor, opacity }:
 
 export function buildWallShelf({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const woodMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.7,
-    transparent: hasCollision,
-    opacity,
-  });
-  const bracketMat = new THREE.MeshStandardMaterial({
-    color: 0x424242,
-    roughness: 0.4,
-    metalness: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
+  const woodMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const bracketMat = material(THREE, 0x424242, hasCollision, opacity, { roughness: 0.4, metalness: 0.6 });
 
   // Shelf board itself.
   const shelf = mesh(
@@ -178,43 +156,23 @@ export function buildWallShelf({ THREE, item, hasCollision, baseColor, opacity }
   }
 
   // A couple of small ornaments on top — a book and a tiny plant for variety.
-  const bookMat = new THREE.MeshStandardMaterial({
-    color: 0x8e1c1c,
-    roughness: 0.85,
-    transparent: hasCollision,
-    opacity,
-  });
+  const bookMat = material(THREE, 0x8e1c1c, hasCollision, opacity, { roughness: 0.85 });
   const book = mesh(THREE, new THREE.BoxGeometry(0.10, 0.14, 0.16), bookMat);
   book.position.set(-item.width * 0.30, item.height + 0.07, 0);
   group.add(book);
   const book2 = mesh(
     THREE,
     new THREE.BoxGeometry(0.08, 0.18, 0.14),
-    new THREE.MeshStandardMaterial({
-      color: 0x1b4f72,
-      roughness: 0.85,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, 0x1b4f72, hasCollision, opacity, { roughness: 0.85 })
   );
   book2.position.set(-item.width * 0.18, item.height + 0.09, 0);
   group.add(book2);
 
-  const potMat = new THREE.MeshStandardMaterial({
-    color: 0xa0522d,
-    roughness: 0.85,
-    transparent: hasCollision,
-    opacity,
-  });
+  const potMat = material(THREE, 0xa0522d, hasCollision, opacity, { roughness: 0.85 });
   const pot = mesh(THREE, new THREE.CylinderGeometry(0.05, 0.06, 0.08, 10), potMat);
   pot.position.set(item.width * 0.30, item.height + 0.04, 0);
   group.add(pot);
-  const leafMat = new THREE.MeshStandardMaterial({
-    color: 0x4caf50,
-    roughness: 0.9,
-    transparent: hasCollision,
-    opacity,
-  });
+  const leafMat = material(THREE, 0x4caf50, hasCollision, opacity, { roughness: 0.9 });
   const leaf = mesh(THREE, new THREE.SphereGeometry(0.08, 10, 8), leafMat);
   leaf.position.set(item.width * 0.30, item.height + 0.14, 0);
   group.add(leaf);
@@ -224,25 +182,9 @@ export function buildWallShelf({ THREE, item, hasCollision, baseColor, opacity }
 
 export function buildWallClock({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({
-    color: 0x37474f,
-    roughness: 0.4,
-    metalness: 0.5,
-    transparent: hasCollision,
-    opacity,
-  });
-  const faceMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
-  const handMat = new THREE.MeshStandardMaterial({
-    color: 0x111111,
-    roughness: 0.5,
-    transparent: hasCollision,
-    opacity,
-  });
+  const frameMat = material(THREE, 0x37474f, hasCollision, opacity, { roughness: 0.4, metalness: 0.5 });
+  const faceMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6 });
+  const handMat = material(THREE, 0x111111, hasCollision, opacity, { roughness: 0.5 });
 
   const radius = Math.min(item.width, item.height) / 2;
   const ring = mesh(
@@ -302,32 +244,10 @@ export function buildWallClock({ THREE, item, hasCollision, baseColor, opacity }
 
 export function buildCandles({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const waxMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
-  const wickMat = new THREE.MeshStandardMaterial({
-    color: 0x111111,
-    roughness: 0.9,
-    transparent: hasCollision,
-    opacity,
-  });
-  const flameMat = new THREE.MeshStandardMaterial({
-    color: 0xffa726,
-    emissive: 0xffd54f,
-    emissiveIntensity: 0.9,
-    roughness: 0.2,
-    transparent: hasCollision,
-    opacity,
-  });
-  const trayMat = new THREE.MeshStandardMaterial({
-    color: 0xb0a094,
-    roughness: 0.7,
-    transparent: hasCollision,
-    opacity,
-  });
+  const waxMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6 });
+  const wickMat = material(THREE, 0x111111, hasCollision, opacity, { roughness: 0.9 });
+  const flameMat = material(THREE, 0xffa726, hasCollision, opacity, { emissive: 0xffd54f, emissiveIntensity: 0.9, roughness: 0.2 });
+  const trayMat = material(THREE, 0xb0a094, hasCollision, opacity, { roughness: 0.7 });
 
   const tray = mesh(
     THREE,
@@ -374,12 +294,7 @@ export function buildBooksStack({ THREE, item, hasCollision, baseColor, opacity 
   const slabHeight = stackHeight / bookCount;
   for (let i = 0; i < bookCount; i += 1) {
     const cover = covers[i % covers.length]!;
-    const mat = new THREE.MeshStandardMaterial({
-      color: cover,
-      roughness: 0.85,
-      transparent: hasCollision,
-      opacity,
-    });
+    const mat = material(THREE, cover, hasCollision, opacity, { roughness: 0.85 });
     const wiggleX = Math.sin(i * 1.7) * item.width * 0.05;
     const wiggleZ = Math.cos(i * 1.3) * item.depth * 0.05;
     const book = mesh(

--- a/components/room-organizer/three/builders/builders-electronics.ts
+++ b/components/room-organizer/three/builders/builders-electronics.ts
@@ -1,6 +1,6 @@
 import { type CctvModel, getCctvModel } from '../../lib/cctv-models';
 import { CAMERA_BRACKET_ARM } from '../../lib/constants';
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import { CAMERA_MOUNT_HEIGHT } from '../camera-vision';
 import type * as ThreeNS from 'three';
 
@@ -10,7 +10,7 @@ export function buildTV({ THREE, item, hasCollision, baseColor, opacity }: Build
   const base = mesh(
     THREE,
     new THREE.BoxGeometry(item.width, item.height * 0.6, item.depth),
-    new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.6, metalness: 0.2, transparent: hasCollision, opacity })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6, metalness: 0.2 })
   );
   base.position.y = item.height * 0.3;
   group.add(base);
@@ -18,13 +18,7 @@ export function buildTV({ THREE, item, hasCollision, baseColor, opacity }: Build
   const screen = mesh(
     THREE,
     new THREE.BoxGeometry(item.width * 0.7, item.height * 0.8, item.depth * 0.1),
-    new THREE.MeshStandardMaterial({
-      color: hasCollision ? 0xff0000 : 0x1a1a1a,
-      roughness: 0.1,
-      metalness: 0.8,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, hasCollision ? 0xff0000 : 0x1a1a1a, hasCollision, opacity, { roughness: 0.1, metalness: 0.8 })
   );
   screen.position.set(0, item.height * 0.9, -item.depth * 0.35);
   group.add(screen);
@@ -32,7 +26,7 @@ export function buildTV({ THREE, item, hasCollision, baseColor, opacity }: Build
   const bezel = mesh(
     THREE,
     new THREE.BoxGeometry(item.width * 0.75, item.height * 0.85, item.depth * 0.08),
-    new THREE.MeshStandardMaterial({ color: 0x333333, roughness: 0.5, metalness: 0.6, transparent: hasCollision, opacity })
+    material(THREE, 0x333333, hasCollision, opacity, { roughness: 0.5, metalness: 0.6 })
   );
   bezel.position.set(0, item.height * 0.9, -item.depth * 0.36);
   group.add(bezel);
@@ -42,8 +36,8 @@ export function buildTV({ THREE, item, hasCollision, baseColor, opacity }: Build
 
 export function buildComputer({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, metalness: 0.4, transparent: hasCollision, opacity });
-  const screenMat = new THREE.MeshStandardMaterial({ color: 0x1a1a1a, roughness: 0.1, metalness: 0.9, emissive: 0x0d47a1, emissiveIntensity: 0.4, transparent: hasCollision, opacity });
+  const bodyMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5, metalness: 0.4 });
+  const screenMat = material(THREE, 0x1a1a1a, hasCollision, opacity, { roughness: 0.1, metalness: 0.9, emissive: 0x0d47a1, emissiveIntensity: 0.4 });
 
   const tower = mesh(THREE, new THREE.BoxGeometry(item.width * 0.4, item.height * 0.8, item.depth * 0.7), bodyMat);
   tower.position.set(-item.width * 0.25, item.height * 0.4, 0);
@@ -65,18 +59,12 @@ export function buildWiFi({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const body = mesh(
     THREE,
     new THREE.BoxGeometry(item.width, item.height, item.depth),
-    new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.4, metalness: 0.3, transparent: hasCollision, opacity })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.4, metalness: 0.3 })
   );
   body.position.y = item.height / 2;
   group.add(body);
 
-  const antennaMat = new THREE.MeshStandardMaterial({
-    color: 0x333333,
-    roughness: 0.5,
-    metalness: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
+  const antennaMat = material(THREE, 0x333333, hasCollision, opacity, { roughness: 0.5, metalness: 0.6 });
   const antennaGeo = new THREE.CylinderGeometry(0.01, 0.01, item.height * 3, 8);
   for (const dx of [-item.width * 0.3, item.width * 0.3]) {
     const antenna = mesh(THREE, antennaGeo, antennaMat);
@@ -86,13 +74,7 @@ export function buildWiFi({ THREE, item, hasCollision, baseColor, opacity }: Bui
   }
 
   const ledGeo = new THREE.SphereGeometry(0.015, 8, 8);
-  const ledMat = new THREE.MeshStandardMaterial({
-    color: 0x00ff00,
-    emissive: 0x00ff00,
-    emissiveIntensity: 0.8,
-    transparent: hasCollision,
-    opacity,
-  });
+  const ledMat = material(THREE, 0x00ff00, hasCollision, opacity, { emissive: 0x00ff00, emissiveIntensity: 0.8 });
   for (let i = 0; i < 3; i++) {
     const led = mesh(THREE, ledGeo, ledMat);
     led.position.set(-item.width * 0.2 + i * item.width * 0.2, item.height * 0.6, item.depth * 0.51);
@@ -108,18 +90,12 @@ export function buildRouter({ THREE, item, hasCollision, baseColor, opacity }: B
   const body = mesh(
     THREE,
     new THREE.BoxGeometry(item.width, item.height, item.depth),
-    new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.4, metalness: 0.2, transparent: hasCollision, opacity })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.4, metalness: 0.2 })
   );
   body.position.y = item.height / 2;
   group.add(body);
 
-  const antennaMat = new THREE.MeshStandardMaterial({
-    color: 0x1a1a1a,
-    roughness: 0.6,
-    metalness: 0.5,
-    transparent: hasCollision,
-    opacity,
-  });
+  const antennaMat = material(THREE, 0x1a1a1a, hasCollision, opacity, { roughness: 0.6, metalness: 0.5 });
   const antennaGeo = new THREE.CylinderGeometry(0.008, 0.008, item.height * 4, 8);
   const antennaXs = [-item.width * 0.35, -item.width * 0.15, item.width * 0.15, item.width * 0.35];
   antennaXs.forEach((x, index) => {
@@ -129,13 +105,7 @@ export function buildRouter({ THREE, item, hasCollision, baseColor, opacity }: B
     group.add(antenna);
   });
 
-  const ledMat = new THREE.MeshStandardMaterial({
-    color: 0x00ff00,
-    emissive: 0x00ff00,
-    emissiveIntensity: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
+  const ledMat = material(THREE, 0x00ff00, hasCollision, opacity, { emissive: 0x00ff00, emissiveIntensity: 0.6 });
   const ledGeo = new THREE.SphereGeometry(0.012, 8, 8);
   for (let i = 0; i < 5; i++) {
     const led = mesh(THREE, ledGeo, ledMat);
@@ -143,13 +113,7 @@ export function buildRouter({ THREE, item, hasCollision, baseColor, opacity }: B
     group.add(led);
   }
 
-  const portMat = new THREE.MeshStandardMaterial({
-    color: 0xffd700,
-    roughness: 0.3,
-    metalness: 0.7,
-    transparent: hasCollision,
-    opacity,
-  });
+  const portMat = material(THREE, 0xffd700, hasCollision, opacity, { roughness: 0.3, metalness: 0.7 });
   const portGeo = new THREE.BoxGeometry(0.02, 0.015, 0.01);
   for (let i = 0; i < 4; i++) {
     const port = mesh(THREE, portGeo, portMat);
@@ -166,7 +130,7 @@ export function buildCCTV({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const base = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.3, item.width * 0.4, item.height * 0.2, 16),
-    new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, metalness: 0.4, transparent: hasCollision, opacity })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5, metalness: 0.4 })
   );
   base.position.y = item.height * 0.1;
   group.add(base);
@@ -174,7 +138,7 @@ export function buildCCTV({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const body = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.5, item.width * 0.5, item.height * 0.6, 16),
-    new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.4, metalness: 0.5, transparent: hasCollision, opacity })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.4, metalness: 0.5 })
   );
   body.position.y = item.height * 0.55;
   body.rotation.z = Math.PI / 2;
@@ -183,7 +147,7 @@ export function buildCCTV({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const lens = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.3, item.width * 0.35, item.height * 0.15, 16),
-    new THREE.MeshStandardMaterial({ color: 0x1a1a1a, roughness: 0.1, metalness: 0.9, transparent: hasCollision, opacity })
+    material(THREE, 0x1a1a1a, hasCollision, opacity, { roughness: 0.1, metalness: 0.9 })
   );
   lens.position.set(item.width * 0.3, item.height * 0.55, 0);
   lens.rotation.z = Math.PI / 2;
@@ -192,18 +156,12 @@ export function buildCCTV({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const led = mesh(
     THREE,
     new THREE.SphereGeometry(0.01, 8, 8),
-    new THREE.MeshStandardMaterial({
-      color: 0xff0000,
-      emissive: 0xff0000,
-      emissiveIntensity: 0.8,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, 0xff0000, hasCollision, opacity, { emissive: 0xff0000, emissiveIntensity: 0.8 })
   );
   led.position.set(-item.width * 0.3, item.height * 0.65, 0);
   group.add(led);
 
-  const irMat = new THREE.MeshStandardMaterial({ color: 0x1a1a1a, roughness: 0.8, transparent: hasCollision, opacity });
+  const irMat = material(THREE, 0x1a1a1a, hasCollision, opacity, { roughness: 0.8 });
   const irGeo = new THREE.SphereGeometry(0.008, 8, 8);
   for (const offset of [-0.015, 0, 0.015]) {
     const ir = mesh(THREE, irGeo, irMat);
@@ -227,8 +185,8 @@ export function buildCCTV({ THREE, item, hasCollision, baseColor, opacity }: Bui
  */
 export function buildSecurityCamera({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.35, metalness: 0.5, transparent: hasCollision, opacity });
-  const trimMat = new THREE.MeshStandardMaterial({ color: 0x0e1116, roughness: 0.3, metalness: 0.65, transparent: hasCollision, opacity });
+  const bodyMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.35, metalness: 0.5 });
+  const trimMat = material(THREE, 0x0e1116, hasCollision, opacity, { roughness: 0.3, metalness: 0.65 });
   const glassMat = new THREE.MeshStandardMaterial({
     color: 0x05080d,
     roughness: 0.05,
@@ -236,7 +194,7 @@ export function buildSecurityCamera({ THREE, item, hasCollision, baseColor, opac
     transparent: true,
     opacity: hasCollision ? 0.5 : 0.45,
   });
-  const ledMat = new THREE.MeshStandardMaterial({ color: 0xff3b30, emissive: 0xff3b30, emissiveIntensity: 0.9, transparent: hasCollision, opacity });
+  const ledMat = material(THREE, 0xff3b30, hasCollision, opacity, { emissive: 0xff3b30, emissiveIntensity: 0.9 });
 
   const mountY = CAMERA_MOUNT_HEIGHT;
   const model = getCctvModel(item.cctvModelId);

--- a/components/room-organizer/three/builders/builders-kitchen.ts
+++ b/components/room-organizer/three/builders/builders-kitchen.ts
@@ -1,10 +1,10 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildFridge({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.35, metalness: 0.6, transparent: hasCollision, opacity });
-  const accentMat = new THREE.MeshStandardMaterial({ color: 0x424242, metalness: 0.8, roughness: 0.3, transparent: hasCollision, opacity });
+  const bodyMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.35, metalness: 0.6 });
+  const accentMat = material(THREE, 0x424242, hasCollision, opacity, { metalness: 0.8, roughness: 0.3 });
 
   const body = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), bodyMat);
   body.position.y = item.height / 2;
@@ -26,9 +26,9 @@ export function buildFridge({ THREE, item, hasCollision, baseColor, opacity }: B
 
 export function buildStove({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, metalness: 0.5, transparent: hasCollision, opacity });
-  const burnerMat = new THREE.MeshStandardMaterial({ color: 0x212121, roughness: 0.3, metalness: 0.7, transparent: hasCollision, opacity });
-  const doorMat = new THREE.MeshStandardMaterial({ color: 0x616161, roughness: 0.2, metalness: 0.8, transparent: hasCollision, opacity });
+  const bodyMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5, metalness: 0.5 });
+  const burnerMat = material(THREE, 0x212121, hasCollision, opacity, { roughness: 0.3, metalness: 0.7 });
+  const doorMat = material(THREE, 0x616161, hasCollision, opacity, { roughness: 0.2, metalness: 0.8 });
 
   const body = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), bodyMat);
   body.position.y = item.height / 2;
@@ -55,8 +55,8 @@ export function buildStove({ THREE, item, hasCollision, baseColor, opacity }: Bu
 
 export function buildSink({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const baseMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, transparent: hasCollision, opacity });
-  const metalMat = new THREE.MeshStandardMaterial({ color: 0xb0bec5, metalness: 0.9, roughness: 0.15, transparent: hasCollision, opacity });
+  const baseMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5 });
+  const metalMat = material(THREE, 0xb0bec5, hasCollision, opacity, { metalness: 0.9, roughness: 0.15 });
 
   const counter = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.95, item.depth), baseMat);
   counter.position.y = item.height * 0.475;
@@ -66,7 +66,7 @@ export function buildSink({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const basin = mesh(
     THREE,
     new THREE.BoxGeometry(item.width * 0.7, item.height * 0.1, item.depth * 0.65),
-    new THREE.MeshStandardMaterial({ color: 0x212121, roughness: 0.4, transparent: hasCollision, opacity })
+    material(THREE, 0x212121, hasCollision, opacity, { roughness: 0.4 })
   );
   basin.position.set(0, item.height * 0.99, 0);
   group.add(basin);
@@ -85,8 +85,8 @@ export function buildSink({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildCounter({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const baseMat = new THREE.MeshStandardMaterial({ color: 0xf5f5f5, roughness: 0.7, transparent: hasCollision, opacity });
-  const topMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.4, metalness: 0.1, transparent: hasCollision, opacity });
+  const baseMat = material(THREE, 0xf5f5f5, hasCollision, opacity, { roughness: 0.7 });
+  const topMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.4, metalness: 0.1 });
 
   const base = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.92, item.depth), baseMat);
   base.position.y = item.height * 0.46;

--- a/components/room-organizer/three/builders/builders-lighting.ts
+++ b/components/room-organizer/three/builders/builders-lighting.ts
@@ -1,4 +1,4 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildLamp({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
@@ -7,13 +7,7 @@ export function buildLamp({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const base = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.8, item.width, item.height * 0.1, 16),
-    new THREE.MeshStandardMaterial({
-      color: 0x444444,
-      roughness: 0.5,
-      metalness: 0.6,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, 0x444444, hasCollision, opacity, { roughness: 0.5, metalness: 0.6 })
   );
   base.position.y = item.height * 0.05;
   group.add(base);
@@ -21,13 +15,7 @@ export function buildLamp({ THREE, item, hasCollision, baseColor, opacity }: Bui
   const stand = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.1, item.width * 0.1, item.height * 0.7, 12),
-    new THREE.MeshStandardMaterial({
-      color: baseColor,
-      roughness: 0.6,
-      metalness: 0.4,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6, metalness: 0.4 })
   );
   stand.position.y = item.height * 0.45;
   group.add(stand);
@@ -52,29 +40,9 @@ export function buildLamp({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildPendantLight({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const cordMat = new THREE.MeshStandardMaterial({
-    color: 0x222222,
-    roughness: 0.8,
-    transparent: hasCollision,
-    opacity,
-  });
-  const shadeMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.6,
-    metalness: 0.3,
-    emissive: baseColor,
-    emissiveIntensity: 0.25,
-    transparent: hasCollision,
-    opacity,
-  });
-  const bulbMat = new THREE.MeshStandardMaterial({
-    color: 0xfff8c0,
-    roughness: 0.1,
-    emissive: 0xfff066,
-    emissiveIntensity: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
+  const cordMat = material(THREE, 0x222222, hasCollision, opacity, { roughness: 0.8 });
+  const shadeMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6, metalness: 0.3, emissive: baseColor, emissiveIntensity: 0.25 });
+  const bulbMat = material(THREE, 0xfff8c0, hasCollision, opacity, { roughness: 0.1, emissive: 0xfff066, emissiveIntensity: 0.6 });
 
   // Ceiling rosette / canopy.
   const canopy = mesh(
@@ -114,16 +82,8 @@ export function buildPendantLight({ THREE, item, hasCollision, baseColor, opacit
 
 export function buildLamppost({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const metalMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.4, metalness: 0.6, transparent: hasCollision, opacity });
-  const glassMat = new THREE.MeshStandardMaterial({
-    color: 0xfff59d,
-    roughness: 0.1,
-    metalness: 0.0,
-    emissive: 0xfff176,
-    emissiveIntensity: 0.4,
-    transparent: hasCollision,
-    opacity,
-  });
+  const metalMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.4, metalness: 0.6 });
+  const glassMat = material(THREE, 0xfff59d, hasCollision, opacity, { roughness: 0.1, metalness: 0.0, emissive: 0xfff176, emissiveIntensity: 0.4 });
 
   const base = mesh(THREE, new THREE.CylinderGeometry(item.width * 0.4, item.width * 0.5, item.height * 0.05, 12), metalMat);
   base.position.y = item.height * 0.025;

--- a/components/room-organizer/three/builders/builders-outdoor.ts
+++ b/components/room-organizer/three/builders/builders-outdoor.ts
@@ -1,9 +1,9 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildFence({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.9, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.9 });
 
   const railTop = mesh(THREE, new THREE.BoxGeometry(item.width, 0.05, item.depth * 0.4), mat);
   railTop.position.y = item.height * 0.85;
@@ -25,7 +25,7 @@ export function buildFence({ THREE, item, hasCollision, baseColor, opacity }: Bu
 
 export function buildPool({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const tileMat = new THREE.MeshStandardMaterial({ color: 0xeceff1, roughness: 0.7, transparent: hasCollision, opacity });
+  const tileMat = material(THREE, 0xeceff1, hasCollision, opacity, { roughness: 0.7 });
   const waterMat = new THREE.MeshStandardMaterial({
     color: baseColor,
     roughness: 0.15,
@@ -50,8 +50,8 @@ export function buildPool({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildBbq({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, metalness: 0.5, transparent: hasCollision, opacity });
-  const handleMat = new THREE.MeshStandardMaterial({ color: 0x212121, roughness: 0.6, transparent: hasCollision, opacity });
+  const bodyMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5, metalness: 0.5 });
+  const handleMat = material(THREE, 0x212121, hasCollision, opacity, { roughness: 0.6 });
 
   // Base on wheels
   const cart = mesh(
@@ -91,9 +91,9 @@ export function buildBbq({ THREE, item, hasCollision, baseColor, opacity }: Buil
 
 export function buildMailbox({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const postMat = new THREE.MeshStandardMaterial({ color: 0x5d4037, roughness: 0.85, transparent: hasCollision, opacity });
-  const boxMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.5, metalness: 0.3, transparent: hasCollision, opacity });
-  const flagMat = new THREE.MeshStandardMaterial({ color: 0xd32f2f, roughness: 0.6, transparent: hasCollision, opacity });
+  const postMat = material(THREE, 0x5d4037, hasCollision, opacity, { roughness: 0.85 });
+  const boxMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.5, metalness: 0.3 });
+  const flagMat = material(THREE, 0xd32f2f, hasCollision, opacity, { roughness: 0.6 });
 
   const post = mesh(THREE, new THREE.BoxGeometry(0.08, item.height * 0.7, 0.08), postMat);
   post.position.y = item.height * 0.35;
@@ -118,7 +118,7 @@ export function buildMailbox({ THREE, item, hasCollision, baseColor, opacity }: 
 
 export function buildBirdbath({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const stoneMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.85, transparent: hasCollision, opacity });
+  const stoneMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.85 });
   const waterMat = new THREE.MeshStandardMaterial({ color: 0x4fc3f7, roughness: 0.2, metalness: 0.1, transparent: true, opacity: 0.85 });
 
   const base = mesh(THREE, new THREE.CylinderGeometry(item.width * 0.35, item.width * 0.5, item.height * 0.18, 16), stoneMat);
@@ -138,7 +138,7 @@ export function buildBirdbath({ THREE, item, hasCollision, baseColor, opacity }:
 
 export function buildSteppingStone({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const stoneMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.95, transparent: hasCollision, opacity });
+  const stoneMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.95 });
   const stone = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.5, item.width * 0.48, item.height, 14),
@@ -151,8 +151,8 @@ export function buildSteppingStone({ THREE, item, hasCollision, baseColor, opaci
 
 export function buildGardenBench({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const woodMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.85, transparent: hasCollision, opacity });
-  const metalMat = new THREE.MeshStandardMaterial({ color: 0x37474f, roughness: 0.5, metalness: 0.7, transparent: hasCollision, opacity });
+  const woodMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.85 });
+  const metalMat = material(THREE, 0x37474f, hasCollision, opacity, { roughness: 0.5, metalness: 0.7 });
 
   const seat = mesh(THREE, new THREE.BoxGeometry(item.width, 0.06, item.depth * 0.65), woodMat);
   seat.position.y = item.height * 0.5;
@@ -171,7 +171,7 @@ export function buildGardenBench({ THREE, item, hasCollision, baseColor, opacity
 
 export function buildPicnicTable({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const woodMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.9, transparent: hasCollision, opacity });
+  const woodMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.9 });
 
   const top = mesh(THREE, new THREE.BoxGeometry(item.width, 0.08, item.depth * 0.5), woodMat);
   top.position.y = item.height;
@@ -196,7 +196,7 @@ export function buildPicnicTable({ THREE, item, hasCollision, baseColor, opacity
 
 export function buildPond({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const rockMat = new THREE.MeshStandardMaterial({ color: 0x6d4c41, roughness: 0.95, transparent: hasCollision, opacity });
+  const rockMat = material(THREE, 0x6d4c41, hasCollision, opacity, { roughness: 0.95 });
   const waterMat = new THREE.MeshStandardMaterial({
     color: baseColor,
     roughness: 0.15,
@@ -222,8 +222,8 @@ export function buildPond({ THREE, item, hasCollision, baseColor, opacity }: Bui
   water.scale.z = item.depth / item.width;
   group.add(water);
   // A handful of cattails poking out
-  const stemMat = new THREE.MeshStandardMaterial({ color: 0x33691e, roughness: 0.9, transparent: hasCollision, opacity });
-  const bulbMat = new THREE.MeshStandardMaterial({ color: 0x4e342e, roughness: 0.9, transparent: hasCollision, opacity });
+  const stemMat = material(THREE, 0x33691e, hasCollision, opacity, { roughness: 0.9 });
+  const bulbMat = material(THREE, 0x4e342e, hasCollision, opacity, { roughness: 0.9 });
   const cattails: ReadonlyArray<readonly [number, number]> = [[0.30, 0.25], [-0.32, -0.20], [0.05, -0.30]];
   for (const [px, pz] of cattails) {
     const stem = mesh(THREE, new THREE.CylinderGeometry(0.015, 0.020, 0.7, 6), stemMat);

--- a/components/room-organizer/three/builders/builders-people.ts
+++ b/components/room-organizer/three/builders/builders-people.ts
@@ -1,11 +1,11 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, cornerPositions, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildPerson({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const skinMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
-  const clothesMat = new THREE.MeshStandardMaterial({ color: 0x3949ab, roughness: 0.8, transparent: hasCollision, opacity });
-  const trouserMat = new THREE.MeshStandardMaterial({ color: 0x1f2937, roughness: 0.8, transparent: hasCollision, opacity });
+  const skinMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const clothesMat = material(THREE, 0x3949ab, hasCollision, opacity, { roughness: 0.8 });
+  const trouserMat = material(THREE, 0x1f2937, hasCollision, opacity, { roughness: 0.8 });
 
   // Legs (cylinders)
   const legGeo = new THREE.CylinderGeometry(0.08, 0.08, item.height * 0.45, 10);
@@ -42,8 +42,8 @@ export function buildPerson({ THREE, item, hasCollision, baseColor, opacity }: B
 
 export function buildPet({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const furMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.85, transparent: hasCollision, opacity });
-  const noseMat = new THREE.MeshStandardMaterial({ color: 0x1b1b1b, roughness: 0.6, transparent: hasCollision, opacity });
+  const furMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.85 });
+  const noseMat = material(THREE, 0x1b1b1b, hasCollision, opacity, { roughness: 0.6 });
 
   // Body
   const body = mesh(
@@ -76,12 +76,10 @@ export function buildPet({ THREE, item, hasCollision, baseColor, opacity }: Buil
 
   // Legs
   const legGeo = new THREE.CylinderGeometry(0.04, 0.05, item.height * 0.45, 8);
-  for (const dx of [-1, 1]) {
-    for (const dz of [-1, 1]) {
-      const leg = mesh(THREE, legGeo, furMat);
-      leg.position.set(dx * item.width * 0.25, item.height * 0.225, dz * item.depth * 0.55);
-      group.add(leg);
-    }
+  for (const [x, y, z] of cornerPositions(item.width * 0.25, item.height * 0.225, item.depth * 0.55)) {
+    const leg = mesh(THREE, legGeo, furMat);
+    leg.position.set(x, y, z);
+    group.add(leg);
   }
 
   // Tail

--- a/components/room-organizer/three/builders/builders-plants.ts
+++ b/components/room-organizer/three/builders/builders-plants.ts
@@ -1,4 +1,4 @@
-import { type BuilderContext, mesh, lightenHex, buildOrganicBlob } from '../builder-utils';
+import { type BuilderContext, material, mesh, lightenHex, buildOrganicBlob } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildPlant({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
@@ -7,17 +7,12 @@ export function buildPlant({ THREE, item, hasCollision, baseColor, opacity }: Bu
   const pot = mesh(
     THREE,
     new THREE.CylinderGeometry(item.width * 0.6, item.width * 0.8, item.height * 0.3, 16),
-    new THREE.MeshStandardMaterial({ color: 0xa0522d, roughness: 0.8, transparent: hasCollision, opacity })
+    material(THREE, 0xa0522d, hasCollision, opacity, { roughness: 0.8 })
   );
   pot.position.y = item.height * 0.15;
   group.add(pot);
 
-  const foliageMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.9,
-    transparent: hasCollision,
-    opacity,
-  });
+  const foliageMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.9 });
   const foliage = mesh(THREE, new THREE.SphereGeometry(item.width * 0.8, 12, 12), foliageMat);
   foliage.position.y = item.height * 0.6;
   group.add(foliage);
@@ -39,8 +34,8 @@ export function buildPlant({ THREE, item, hasCollision, baseColor, opacity }: Bu
 
 export function buildFlowerpot({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const potMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.6, transparent: hasCollision, opacity });
-  const flowerMat = new THREE.MeshStandardMaterial({ color: 0xff80ab, roughness: 0.8, transparent: hasCollision, opacity });
+  const potMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6 });
+  const flowerMat = material(THREE, 0xff80ab, hasCollision, opacity, { roughness: 0.8 });
 
   const pot = mesh(THREE, new THREE.CylinderGeometry(item.width * 0.5, item.width * 0.4, item.height * 0.6, 12), potMat);
   pot.position.y = item.height * 0.3;
@@ -56,12 +51,7 @@ export function buildFlowerpot({ THREE, item, hasCollision, baseColor, opacity }
 
 export function buildTree({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const trunkMat = new THREE.MeshStandardMaterial({
-    color: 0x5d4037,
-    roughness: 0.95,
-    transparent: hasCollision,
-    opacity,
-  });
+  const trunkMat = material(THREE, 0x5d4037, hasCollision, opacity, { roughness: 0.95 });
 
   // Tapered trunk with a small flare at the base.
   const trunkH = item.height * 0.4;
@@ -130,12 +120,7 @@ export function buildTree({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildPineTree({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const trunkMat = new THREE.MeshStandardMaterial({
-    color: 0x4e342e,
-    roughness: 0.9,
-    transparent: hasCollision,
-    opacity,
-  });
+  const trunkMat = material(THREE, 0x4e342e, hasCollision, opacity, { roughness: 0.9 });
 
   // Tapered trunk peeking out from the bottom of the foliage.
   const trunkH = item.height * 0.22;
@@ -159,13 +144,7 @@ export function buildPineTree({ THREE, item, hasCollision, baseColor, opacity }:
     { y: 0.86, r: 0.16, h: 0.18, alt: false },
   ];
   for (const t of tiers) {
-    const mat = new THREE.MeshStandardMaterial({
-      color: t.alt ? altHex : (baseColor as ThreeNS.ColorRepresentation),
-      roughness: 0.95,
-      flatShading: true,
-      transparent: hasCollision,
-      opacity,
-    });
+    const mat = material(THREE, t.alt ? altHex : (baseColor as ThreeNS.ColorRepresentation), hasCollision, opacity, { roughness: 0.95, flatShading: true });
     const cone = mesh(
       THREE,
       new THREE.ConeGeometry(item.width * t.r, item.height * t.h, 16),
@@ -205,7 +184,7 @@ export function buildBush({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildHedge({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const leafMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.9, transparent: hasCollision, opacity });
+  const leafMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.9 });
   const body = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), leafMat);
   body.position.y = item.height / 2;
   group.add(body);
@@ -222,8 +201,8 @@ export function buildHedge({ THREE, item, hasCollision, baseColor, opacity }: Bu
 
 export function buildFlowerBed({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const soilMat = new THREE.MeshStandardMaterial({ color: 0x5d4037, roughness: 0.95, transparent: hasCollision, opacity });
-  const rimMat = new THREE.MeshStandardMaterial({ color: 0x8d6e63, roughness: 0.7, transparent: hasCollision, opacity });
+  const soilMat = material(THREE, 0x5d4037, hasCollision, opacity, { roughness: 0.95 });
+  const rimMat = material(THREE, 0x8d6e63, hasCollision, opacity, { roughness: 0.7 });
   const flowerColors = [baseColor, 0xffeb3b, 0xfff59d, 0xba68c8, 0xf06292];
 
   const rim = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.5, item.depth), rimMat);
@@ -244,7 +223,7 @@ export function buildFlowerBed({ THREE, item, hasCollision, baseColor, opacity }
       const px = ((c + 0.5) / cols - 0.5) * item.width * 0.85;
       const pz = ((r + 0.5) / rows - 0.5) * item.depth * 0.7;
       const color = flowerColors[(r * cols + c) % flowerColors.length]!;
-      const headMat = new THREE.MeshStandardMaterial({ color, roughness: 0.7, transparent: hasCollision, opacity });
+      const headMat = material(THREE, color, hasCollision, opacity, { roughness: 0.7 });
       const head = mesh(THREE, new THREE.SphereGeometry(0.07, 8, 8), headMat);
       head.position.set(px, item.height * 0.78, pz);
       group.add(head);
@@ -263,9 +242,9 @@ export function buildSingleFlower({
   petals,
 }: BuilderContext & { headRadius: number; petals: number }): ThreeNS.Group {
   const group = new THREE.Group();
-  const stemMat = new THREE.MeshStandardMaterial({ color: 0x33691e, roughness: 0.9, transparent: hasCollision, opacity });
-  const petalMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
-  const centreMat = new THREE.MeshStandardMaterial({ color: 0x6d4c41, roughness: 0.9, transparent: hasCollision, opacity });
+  const stemMat = material(THREE, 0x33691e, hasCollision, opacity, { roughness: 0.9 });
+  const petalMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const centreMat = material(THREE, 0x6d4c41, hasCollision, opacity, { roughness: 0.9 });
 
   const stem = mesh(THREE, new THREE.CylinderGeometry(0.015, 0.02, item.height * 0.85, 6), stemMat);
   stem.position.y = item.height * 0.425;
@@ -292,8 +271,8 @@ export function buildSingleFlower({
 export function buildTulips(ctx: BuilderContext): ThreeNS.Group {
   const { THREE, item, hasCollision, opacity } = ctx;
   const group = new THREE.Group();
-  const stemMat = new THREE.MeshStandardMaterial({ color: 0x33691e, roughness: 0.9, transparent: hasCollision, opacity });
-  const petalMat = new THREE.MeshStandardMaterial({ color: ctx.baseColor, roughness: 0.7, transparent: hasCollision, opacity });
+  const stemMat = material(THREE, 0x33691e, hasCollision, opacity, { roughness: 0.9 });
+  const petalMat = material(THREE, ctx.baseColor, hasCollision, opacity, { roughness: 0.7 });
 
   const positions: ReadonlyArray<readonly [number, number]> = [
     [-0.15, -0.1],
@@ -319,8 +298,8 @@ export function buildSunflower(ctx: BuilderContext): ThreeNS.Group {
 
 export function buildRoseBush({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const leafMat = new THREE.MeshStandardMaterial({ color: 0x2e7d32, roughness: 0.9, transparent: hasCollision, opacity });
-  const roseMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
+  const leafMat = material(THREE, 0x2e7d32, hasCollision, opacity, { roughness: 0.9 });
+  const roseMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
 
   const body = mesh(THREE, new THREE.SphereGeometry(item.width * 0.45, 10, 10), leafMat);
   body.position.y = item.height * 0.55;

--- a/components/room-organizer/three/builders/builders-seating.ts
+++ b/components/room-organizer/three/builders/builders-seating.ts
@@ -1,15 +1,9 @@
-import { type BuilderContext, mesh, cornerPositions, lightenHex } from '../builder-utils';
+import { type BuilderContext, material, mesh, cornerPositions, lightenHex } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildChair({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const seatMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.7,
-    metalness: 0.1,
-    transparent: hasCollision,
-    opacity,
-  });
+  const seatMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7, metalness: 0.1 });
 
   const seat = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.1, item.depth), seatMat);
   seat.position.y = item.height * 0.5;
@@ -19,7 +13,7 @@ export function buildChair({ THREE, item, hasCollision, baseColor, opacity }: Bu
   back.position.set(0, item.height * 0.75, -item.depth * 0.45);
   group.add(back);
 
-  const legMat = new THREE.MeshStandardMaterial({ color: 0x654321, roughness: 0.8, transparent: hasCollision, opacity });
+  const legMat = material(THREE, 0x654321, hasCollision, opacity, { roughness: 0.8 });
   const legGeo = new THREE.CylinderGeometry(0.03, 0.03, item.height * 0.5, 8);
   for (const [x, y, z] of cornerPositions(item.width * 0.4, item.height * 0.25, item.depth * 0.4)) {
     const leg = mesh(THREE, legGeo, legMat);
@@ -32,7 +26,7 @@ export function buildChair({ THREE, item, hasCollision, baseColor, opacity }: Bu
 
 export function buildArmchair({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.85, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.85 });
 
   const seat = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.45, item.depth * 0.85), mat);
   seat.position.y = item.height * 0.35;
@@ -53,7 +47,7 @@ export function buildArmchair({ THREE, item, hasCollision, baseColor, opacity }:
 
 export function buildBench({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const mat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
+  const mat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
   const seat = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.18, item.depth), mat);
   seat.position.y = item.height * 0.91;
   group.add(seat);
@@ -69,7 +63,7 @@ export function buildBench({ THREE, item, hasCollision, baseColor, opacity }: Bu
 
 export function buildSofa({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const sofaMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.8, transparent: hasCollision, opacity });
+  const sofaMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.8 });
 
   const shape = item.sofaShape ?? 'standard';
 
@@ -90,12 +84,7 @@ export function buildSofa({ THREE, item, hasCollision, baseColor, opacity }: Bui
     }
 
     // Seat cushions — one per "person seat" (divide the sofa into pillows).
-    const cushionMat = new THREE.MeshStandardMaterial({
-      color: lightenHex(item.color, 0.15),
-      roughness: 0.85,
-      transparent: hasCollision,
-      opacity,
-    });
+    const cushionMat = material(THREE, lightenHex(item.color, 0.15), hasCollision, opacity, { roughness: 0.85 });
     const cushionCount = Math.max(2, Math.min(4, Math.round(item.width / 0.8)));
     const cushionWidth = (item.width * 0.92) / cushionCount;
     for (let i = 0; i < cushionCount; i += 1) {
@@ -116,12 +105,7 @@ export function buildSofa({ THREE, item, hasCollision, baseColor, opacity }: Bui
     const pillowColors: ReadonlyArray<number> = [0xf2d488, 0xeb9d6b, 0x9ec6c0];
     for (const dx of [-1, 1]) {
       const color = pillowColors[(dx + 1) / 2 % pillowColors.length]!;
-      const pillowMat = new THREE.MeshStandardMaterial({
-        color,
-        roughness: 0.9,
-        transparent: hasCollision,
-        opacity,
-      });
+      const pillowMat = material(THREE, color, hasCollision, opacity, { roughness: 0.9 });
       const pillow = mesh(
         THREE,
         new THREE.BoxGeometry(item.width * 0.18, item.height * 0.22, item.depth * 0.18),

--- a/components/room-organizer/three/builders/builders-storage.ts
+++ b/components/room-organizer/three/builders/builders-storage.ts
@@ -1,9 +1,9 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildBookshelf({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const shelfMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
+  const shelfMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
 
   const back = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth * 0.1), shelfMat);
   back.position.set(0, item.height / 2, -item.depth * 0.45);
@@ -30,7 +30,7 @@ export function buildBookshelf({ THREE, item, hasCollision, baseColor, opacity }
     const book = mesh(
       THREE,
       new THREE.BoxGeometry(item.width * 0.1, item.height * 0.15, item.depth * 0.6),
-      new THREE.MeshStandardMaterial({ color, roughness: 0.8, transparent: hasCollision, opacity })
+      material(THREE, color, hasCollision, opacity, { roughness: 0.8 })
     );
     book.position.set(-item.width * 0.3 + i * 0.15, (item.height / 4) * i + item.height * 0.12, 0);
     group.add(book);
@@ -41,8 +41,8 @@ export function buildBookshelf({ THREE, item, hasCollision, baseColor, opacity }
 
 export function buildCabinet({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const bodyMat = new THREE.MeshStandardMaterial({ color: baseColor, roughness: 0.7, transparent: hasCollision, opacity });
-  const accentMat = new THREE.MeshStandardMaterial({ color: 0x424242, metalness: 0.6, roughness: 0.3, transparent: hasCollision, opacity });
+  const bodyMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const accentMat = material(THREE, 0x424242, hasCollision, opacity, { metalness: 0.6, roughness: 0.3 });
 
   const body = mesh(THREE, new THREE.BoxGeometry(item.width, item.height, item.depth), bodyMat);
   body.position.y = item.height / 2;

--- a/components/room-organizer/three/builders/builders-structure.ts
+++ b/components/room-organizer/three/builders/builders-structure.ts
@@ -1,21 +1,10 @@
-import { type BuilderContext, mesh } from '../builder-utils';
+import { type BuilderContext, material, mesh } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildDoor({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.7,
-    transparent: hasCollision,
-    opacity,
-  });
-  const handleMat = new THREE.MeshStandardMaterial({
-    color: 0xd7c483,
-    metalness: 0.8,
-    roughness: 0.2,
-    transparent: hasCollision,
-    opacity,
-  });
+  const frameMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.7 });
+  const handleMat = material(THREE, 0xd7c483, hasCollision, opacity, { metalness: 0.8, roughness: 0.2 });
 
   // Door slab (almost as wide and tall as the wall opening).
   const slab = mesh(
@@ -52,18 +41,8 @@ export function buildDoor({ THREE, item, hasCollision, baseColor, opacity }: Bui
 
 export function buildWindow({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const frameMat = new THREE.MeshStandardMaterial({
-    color: 0xf5f5f5,
-    roughness: 0.5,
-    transparent: hasCollision,
-    opacity,
-  });
-  const sillMat = new THREE.MeshStandardMaterial({
-    color: 0xe6e6e6,
-    roughness: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
+  const frameMat = material(THREE, 0xf5f5f5, hasCollision, opacity, { roughness: 0.5 });
+  const sillMat = material(THREE, 0xe6e6e6, hasCollision, opacity, { roughness: 0.6 });
   const glassMat = new THREE.MeshStandardMaterial({
     color: baseColor,
     roughness: 0.05,
@@ -129,12 +108,7 @@ export function buildWindow({ THREE, item, hasCollision, baseColor, opacity }: B
   const wallBelow = mesh(
     THREE,
     new THREE.BoxGeometry(item.width, sillHeight, item.depth),
-    new THREE.MeshStandardMaterial({
-      color: 0xcccccc,
-      roughness: 0.8,
-      transparent: hasCollision,
-      opacity,
-    })
+    material(THREE, 0xcccccc, hasCollision, opacity, { roughness: 0.8 })
   );
   wallBelow.position.set(0, sillHeight / 2, 0);
   group.add(wallBelow);
@@ -144,19 +118,8 @@ export function buildWindow({ THREE, item, hasCollision, baseColor, opacity }: B
 
 export function buildStairs({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const stepMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.85,
-    transparent: hasCollision,
-    opacity,
-  });
-  const railMat = new THREE.MeshStandardMaterial({
-    color: 0x424242,
-    roughness: 0.5,
-    metalness: 0.6,
-    transparent: hasCollision,
-    opacity,
-  });
+  const stepMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.85 });
+  const railMat = material(THREE, 0x424242, hasCollision, opacity, { roughness: 0.5, metalness: 0.6 });
 
   // Item height is the rise to the next floor; build steps that span the depth.
   const stepCount = 14;

--- a/components/room-organizer/three/builders/builders-tables.ts
+++ b/components/room-organizer/three/builders/builders-tables.ts
@@ -1,15 +1,9 @@
-import { type BuilderContext, mesh, cornerPositions } from '../builder-utils';
+import { type BuilderContext, material, mesh, cornerPositions } from '../builder-utils';
 import type * as ThreeNS from 'three';
 
 export function buildTableOrDesk({ THREE, item, hasCollision, baseColor, opacity }: BuilderContext): ThreeNS.Group {
   const group = new THREE.Group();
-  const woodMat = new THREE.MeshStandardMaterial({
-    color: baseColor,
-    roughness: 0.6,
-    metalness: 0.1,
-    transparent: hasCollision,
-    opacity,
-  });
+  const woodMat = material(THREE, baseColor, hasCollision, opacity, { roughness: 0.6, metalness: 0.1 });
 
   const top = mesh(THREE, new THREE.BoxGeometry(item.width, item.height * 0.1, item.depth), woodMat);
   top.position.y = item.height * 0.95;
@@ -34,13 +28,7 @@ export function buildTableOrDesk({ THREE, item, hasCollision, baseColor, opacity
     const handle = mesh(
       THREE,
       new THREE.CylinderGeometry(0.02, 0.02, item.width * 0.1, 8),
-      new THREE.MeshStandardMaterial({
-        color: 0x444444,
-        metalness: 0.8,
-        roughness: 0.2,
-        transparent: hasCollision,
-        opacity,
-      })
+      material(THREE, 0x444444, hasCollision, opacity, { metalness: 0.8, roughness: 0.2 })
     );
     handle.position.set(item.width * 0.25, item.height * 0.7, item.depth * 0.42);
     handle.rotation.z = Math.PI / 2;


### PR DESCRIPTION
Every mesh builder hand-rolled `new THREE.MeshStandardMaterial({ color, roughness, transparent: hasCollision, opacity })`. A shared `material(THREE, color, hasCollision, opacity, extra?)` helper now lives in `three/builder-utils.ts` next to the universally-adopted `mesh()` helper; `extra` is typed as `Omit<MeshStandardMaterialParameters, 'color' | 'transparent' | 'opacity'>` for roughness/metalness/emissive/etc.

- **Migrated 135 of 145 sites** across all 13 builder files plus `buildFallback`/`buildOrganicBlob` in builder-utils itself — net **−256 lines**
- **10 left as-is deliberately**: 8 fixed/conditional-transparency materials (glass, water, lamp shades) and 2 opaque materials in sub-helpers with no collision plumbing — forcing them through the helper would misrepresent their semantics
- `cornerPositions()` adopted in the one place it genuinely applies (pet legs); the other `[-1, 1]` loops are single-axis mirrored pairs where it doesn't
- Pure refactor: the migration was a strict codemod rewriting only exact matches, and a full-diff audit against main confirmed zero value drift — rendered output is identical

Typecheck clean, lint clean at --max-warnings=0, production build succeeds.

Fixes #36