### PR TITLE
Dedupe repeated UI widgets: color picker, glass-inset chrome, slider rows

### DIFF
--- a/components/room-organizer/hooks/use-achievements.ts
+++ b/components/room-organizer/hooks/use-achievements.ts
@@ -9,10 +9,6 @@ export interface UseAchievementsResult {
   dismiss(): void;
 }
 
-const EMPTY_SET: ReadonlySet<string> = new Set();
-const EMPTY_ARRAY: readonly Achievement[] = [];
-const NOOP = () => {};
-
 export function useAchievements(layout: RoomLayout): UseAchievementsResult {
   const [unlocked, setUnlocked] = useState<ReadonlySet<string>>(() => loadUnlocked());
   const [pending, setPending] = useState<readonly Achievement[]>([]);

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -13,7 +13,7 @@ import {
 } from '../three/interior-walls';
 import { clearItemLabels, renderItemLabels } from '../three/item-labels';
 import { applyTimeOfDay } from '../three/lighting';
-import { clearMeasurement, measurementDistance, renderMeasurement } from '../three/measurement';
+import { clearMeasurement, renderMeasurement } from '../three/measurement';
 import { setOutdoorVisible } from '../three/outdoor';
 import { buildRoof, removeRoof } from '../three/roof';
 import { ROOM_OBJECT_TAGS, applyWallDisplay, buildRoom, removeTagged } from '../three/room-builder';

--- a/components/room-organizer/lib/catalog-drag.ts
+++ b/components/room-organizer/lib/catalog-drag.ts
@@ -1,8 +1,1 @@
-import { FURNITURE_CATALOG } from './constants';
-import type { CatalogItem } from './types';
-
 export const CATALOG_DRAG_MIME = 'application/x-room-organizer-catalog-item';
-
-export function findCatalogItem(type: string): CatalogItem | null {
-  return FURNITURE_CATALOG.find((entry) => entry.type === type) ?? null;
-}

--- a/components/room-organizer/lib/cctv-models.ts
+++ b/components/room-organizer/lib/cctv-models.ts
@@ -54,9 +54,6 @@ export const CCTV_MODELS: readonly CctvModel[] = [
   { id: 'blink-outdoor-4', brand: 'Blink', model: 'Outdoor 4', type: 'Battery', fov: 124, range: 8, resolution: '1080p', note: '143° diagonal' },
 ];
 
-/** Default model a freshly-placed Security Camera adopts. */
-export const DEFAULT_CCTV_MODEL_ID = 'hik-2cd2143g2';
-
 export function getCctvModel(id: string | undefined): CctvModel | undefined {
   if (!id) return undefined;
   return CCTV_MODELS.find((entry) => entry.id === id);

--- a/components/room-organizer/lib/persistence.ts
+++ b/components/room-organizer/lib/persistence.ts
@@ -26,12 +26,3 @@ export function saveLayout(layout: RoomLayout): void {
     console.warn('Failed to persist layout to localStorage:', error);
   }
 }
-
-export function clearLayout(): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.removeItem(STORAGE_KEY);
-  } catch {
-    /* ignore */
-  }
-}

--- a/components/room-organizer/panels/actions-panel.tsx
+++ b/components/room-organizer/panels/actions-panel.tsx
@@ -9,7 +9,6 @@ import { openBlueprintPrintWindow } from '../lib/blueprint';
 import { downloadLayoutAsJson, downloadInventoryCsv } from '../lib/file-io';
 import { autoOrganize, type AutoOrganizeStrategy } from '../lib/geometry';
 import { isWallMounted } from '../lib/opening-snap';
-import { encodeShareUrl, isShareUrlReasonablySized } from '../lib/share';
 import { surpriseLayout } from '../lib/surprise';
 import type { FurnitureItem } from '../lib/types';
 

--- a/components/room-organizer/panels/color-swatch-picker.tsx
+++ b/components/room-organizer/panels/color-swatch-picker.tsx
@@ -1,0 +1,192 @@
+'use client';
+
+import { useId } from 'react';
+import { Label } from '@/components/ui/label';
+
+/** Preset colours offered by the item colour pickers. */
+export const COLOR_SWATCHES: readonly string[] = [
+  '#8B4513',
+  '#4A5568',
+  '#E8E8E8',
+  '#2C3E50',
+  '#C62828',
+  '#1976D2',
+  '#388E3C',
+  '#FFB300',
+  '#6A1B9A',
+  '#5D4037',
+  '#0D47A1',
+  '#FAFAFA',
+];
+
+export interface ColorSwatchPickerProps {
+  value: string;
+  /** Preset swatches to offer (pre-sliced by the caller). */
+  swatches: readonly string[];
+  /** Recently used colours from the editor context (pre-sliced by the caller). */
+  recent: readonly string[];
+  onChange(color: string): void;
+  onCommit(color: string): void;
+  /**
+   * 'glass' — compact inline row styled for the plotcraft HUD popover.
+   * 'card'  — shadcn-styled block for the sidebar resize panel.
+   */
+  variant: 'glass' | 'card';
+}
+
+/**
+ * Colour input + preset swatches + recent colours. One widget, two skins:
+ * both variants share the same structure and behaviour (commit on blur,
+ * selected-swatch highlight, recent-colour reuse) but keep the styling of
+ * the design system they sit in.
+ */
+export function ColorSwatchPicker(props: ColorSwatchPickerProps): JSX.Element {
+  return props.variant === 'glass' ? <GlassSkin {...props} /> : <CardSkin {...props} />;
+}
+
+function isSelected(value: string, swatch: string): boolean {
+  return value.toLowerCase() === swatch.toLowerCase();
+}
+
+function GlassSkin({ value, swatches, recent, onChange, onCommit }: ColorSwatchPickerProps): JSX.Element {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+        <span
+          style={{
+            width: 48,
+            fontFamily: 'var(--pc-font-display)',
+            fontWeight: 600,
+            fontSize: 10,
+            letterSpacing: 'var(--pc-tr-caps)',
+            textTransform: 'uppercase',
+            color: 'var(--pc-paper-soft)',
+          }}
+        >
+          Colour
+        </span>
+        <input
+          type="color"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onBlur={(event) => onCommit(event.target.value)}
+          style={{
+            width: 30,
+            height: 26,
+            borderRadius: 6,
+            border: '1px solid var(--pc-glass-stroke)',
+            background: 'transparent',
+            cursor: 'pointer',
+            padding: 0,
+          }}
+        />
+        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, flex: 1 }}>
+          {swatches.map((swatch) => {
+            const selected = isSelected(value, swatch);
+            return (
+              <button
+                key={swatch}
+                type="button"
+                aria-label={`Use color ${swatch}`}
+                onClick={() => onChange(swatch)}
+                style={{
+                  height: 16,
+                  width: 16,
+                  borderRadius: 999,
+                  border: '1px solid var(--pc-glass-stroke)',
+                  backgroundColor: swatch,
+                  cursor: 'pointer',
+                  boxShadow: selected ? 'var(--pc-halo-cyan-soft)' : 'none',
+                  outline: selected ? '1px solid var(--pc-cyan-glow)' : 'none',
+                  padding: 0,
+                }}
+              />
+            );
+          })}
+        </div>
+      </div>
+      {recent.length > 0 && (
+        <div
+          style={{ display: 'flex', flexWrap: 'wrap', gap: 4, paddingLeft: 56 }}
+        >
+          {recent.map((swatch) => {
+            const selected = isSelected(value, swatch);
+            return (
+              <button
+                key={swatch}
+                type="button"
+                aria-label={`Reuse colour ${swatch}`}
+                onClick={() => onChange(swatch)}
+                style={{
+                  height: 14,
+                  width: 14,
+                  borderRadius: 4,
+                  border: '1px solid var(--pc-glass-stroke)',
+                  backgroundColor: swatch,
+                  cursor: 'pointer',
+                  boxShadow: selected ? 'var(--pc-halo-cyan-soft)' : 'none',
+                  outline: selected ? '1px solid var(--pc-cyan-glow)' : 'none',
+                  padding: 0,
+                }}
+              />
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function CardSkin({ value, swatches, recent, onChange, onCommit }: ColorSwatchPickerProps): JSX.Element {
+  const inputId = useId();
+  return (
+    <div className="space-y-2">
+      <Label htmlFor={inputId} className="text-xs">
+        Color
+      </Label>
+      <div className="flex items-center gap-2">
+        <input
+          id={inputId}
+          type="color"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+          onBlur={(event) => onCommit(event.target.value)}
+          className="h-8 w-10 rounded border cursor-pointer"
+        />
+        <div className="flex flex-wrap gap-1">
+          {swatches.map((swatch) => (
+            <button
+              key={swatch}
+              type="button"
+              aria-label={`Use color ${swatch}`}
+              onClick={() => onChange(swatch)}
+              className={`h-5 w-5 rounded-full border ${
+                isSelected(value, swatch) ? 'ring-2 ring-primary' : ''
+              }`}
+              style={{ backgroundColor: swatch }}
+            />
+          ))}
+        </div>
+      </div>
+      {recent.length > 0 && (
+        <div>
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Recent</p>
+          <div className="flex flex-wrap gap-1 mt-1">
+            {recent.map((swatch) => (
+              <button
+                key={swatch}
+                type="button"
+                aria-label={`Reuse colour ${swatch}`}
+                onClick={() => onChange(swatch)}
+                className={`h-5 w-5 rounded border ${
+                  isSelected(value, swatch) ? 'ring-2 ring-primary' : ''
+                }`}
+                style={{ backgroundColor: swatch }}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/room-organizer/panels/item-context-popover.tsx
+++ b/components/room-organizer/panels/item-context-popover.tsx
@@ -5,22 +5,9 @@ import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
 import { CCTV_MODELS, getCctvModel } from '../lib/cctv-models';
 import { Icon, iconForItem, type PlotcraftIconName } from '../plotcraft/icon';
+import { COLOR_SWATCHES, ColorSwatchPicker } from './color-swatch-picker';
+import { SliderRow } from './slider-row';
 import type { SofaShape } from '../lib/types';
-
-const COLOR_SWATCHES = [
-  '#8B4513',
-  '#4A5568',
-  '#E8E8E8',
-  '#2C3E50',
-  '#C62828',
-  '#1976D2',
-  '#388E3C',
-  '#FFB300',
-  '#6A1B9A',
-  '#5D4037',
-  '#0D47A1',
-  '#FAFAFA',
-];
 
 type ResizableDimension = 'width' | 'depth' | 'height';
 
@@ -246,11 +233,17 @@ export function ItemContextPopover(props: ItemContextPopoverProps): JSX.Element 
 
         <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
           {DIMENSIONS.map((dimension) => (
-            <DimensionRow
+            <SliderRow
               key={dimension.key}
-              dimension={dimension}
+              label={dimension.label}
+              min={dimension.min}
+              max={dimension.max}
+              step={0.1}
               value={item[dimension.key]}
+              format={(v) => `${v.toFixed(2)} m`}
               onChange={(value) => actions.resizeItem(item.id, dimension.key, value)}
+              labelWidth={14}
+              uppercaseLabel={false}
             />
           ))}
         </div>
@@ -263,18 +256,22 @@ export function ItemContextPopover(props: ItemContextPopoverProps): JSX.Element 
         )}
 
         {(item.isWiFiAccessPoint || item.isCCTV) && (
-          <SignalRangeRow
+          <SliderRow
             label={item.isWiFiAccessPoint ? 'Signal' : 'Coverage'}
             value={item.signalRange ?? (item.isWiFiAccessPoint ? 10 : 8)}
             min={2}
             max={item.isWiFiAccessPoint ? 20 : 15}
+            step={0.5}
+            format={(v) => `${v.toFixed(1)} m`}
             onChange={(value) => actions.setSignalRange(item.id, value)}
           />
         )}
 
-        <CompactColorPicker
+        <ColorSwatchPicker
+          variant="glass"
           value={item.color}
-          recent={recentColors}
+          swatches={COLOR_SWATCHES.slice(0, 8)}
+          recent={recentColors.slice(0, 6)}
           onChange={(color) => actions.setColor(item.id, color)}
           onCommit={(color) => pushColor(color)}
         />
@@ -350,55 +347,6 @@ function ActionTile({ icon, label, onClick, active }: ActionTileProps): JSX.Elem
   );
 }
 
-interface DimensionRowProps {
-  dimension: DimensionConfig;
-  value: number;
-  onChange(value: number): void;
-}
-
-function DimensionRow({ dimension, value, onChange }: DimensionRowProps): JSX.Element {
-  const id = useId();
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      <label
-        htmlFor={id}
-        style={{
-          width: 14,
-          fontFamily: 'var(--pc-font-display)',
-          fontWeight: 700,
-          fontSize: 10,
-          color: 'var(--pc-paper-soft)',
-        }}
-      >
-        {dimension.label}
-      </label>
-      <input
-        id={id}
-        type="range"
-        min={dimension.min}
-        max={dimension.max}
-        step="0.1"
-        value={value}
-        onChange={(event) => onChange(parseFloat(event.target.value))}
-        style={{ flex: 1, accentColor: 'var(--pc-cyan-glow)' }}
-      />
-      <span
-        style={{
-          width: 48,
-          textAlign: 'right',
-          fontFamily: 'var(--pc-font-display)',
-          fontWeight: 600,
-          fontSize: 10,
-          fontVariantNumeric: 'tabular-nums',
-          color: 'var(--pc-paper)',
-        }}
-      >
-        {value.toFixed(2)} m
-      </span>
-    </div>
-  );
-}
-
 interface SofaShapeSegmentedProps {
   value: SofaShape;
   onChange(value: SofaShape): void;
@@ -450,59 +398,6 @@ function SofaShapeSegmented({ value, onChange }: SofaShapeSegmentedProps): JSX.E
   );
 }
 
-interface SignalRangeRowProps {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  onChange(value: number): void;
-}
-
-function SignalRangeRow({ label, value, min, max, onChange }: SignalRangeRowProps): JSX.Element {
-  const id = useId();
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      <label
-        htmlFor={id}
-        style={{
-          width: 48,
-          fontFamily: 'var(--pc-font-display)',
-          fontWeight: 600,
-          fontSize: 10,
-          letterSpacing: 'var(--pc-tr-caps)',
-          textTransform: 'uppercase',
-          color: 'var(--pc-paper-soft)',
-        }}
-      >
-        {label}
-      </label>
-      <input
-        id={id}
-        type="range"
-        min={min}
-        max={max}
-        step="0.5"
-        value={value}
-        onChange={(event) => onChange(parseFloat(event.target.value))}
-        style={{ flex: 1, accentColor: 'var(--pc-cyan-glow)' }}
-      />
-      <span
-        style={{
-          width: 48,
-          textAlign: 'right',
-          fontFamily: 'var(--pc-font-display)',
-          fontWeight: 600,
-          fontSize: 10,
-          fontVariantNumeric: 'tabular-nums',
-          color: 'var(--pc-paper)',
-        }}
-      >
-        {value.toFixed(1)} m
-      </span>
-    </div>
-  );
-}
-
 interface CameraModelCardProps {
   modelId: string;
   fov: number;
@@ -542,7 +437,7 @@ function CameraModelCard({ modelId, fov, range, onPickModel, onSetFov, onSetRang
         </span>
       </div>
       <CctvModelRow value={modelId} onChange={onPickModel} />
-      <VisionSliderRow
+      <SliderRow
         label="FOV"
         value={fov}
         min={20}
@@ -551,7 +446,7 @@ function CameraModelCard({ modelId, fov, range, onPickModel, onSetFov, onSetRang
         format={(v) => `${Math.round(v)}°`}
         onChange={onSetFov}
       />
-      <VisionSliderRow
+      <SliderRow
         label="Range"
         value={range}
         min={2}
@@ -636,158 +531,3 @@ function CctvModelRow({ value, onChange }: CctvModelRowProps): JSX.Element {
   );
 }
 
-interface VisionSliderRowProps {
-  label: string;
-  value: number;
-  min: number;
-  max: number;
-  step: number;
-  format(value: number): string;
-  onChange(value: number): void;
-}
-
-function VisionSliderRow({ label, value, min, max, step, format, onChange }: VisionSliderRowProps): JSX.Element {
-  const id = useId();
-  return (
-    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-      <label
-        htmlFor={id}
-        style={{
-          width: 48,
-          fontFamily: 'var(--pc-font-display)',
-          fontWeight: 600,
-          fontSize: 10,
-          letterSpacing: 'var(--pc-tr-caps)',
-          textTransform: 'uppercase',
-          color: 'var(--pc-paper-soft)',
-        }}
-      >
-        {label}
-      </label>
-      <input
-        id={id}
-        type="range"
-        min={min}
-        max={max}
-        step={step}
-        value={value}
-        onChange={(event) => onChange(parseFloat(event.target.value))}
-        style={{ flex: 1, accentColor: 'var(--pc-cyan-glow)' }}
-      />
-      <span
-        style={{
-          width: 48,
-          textAlign: 'right',
-          fontFamily: 'var(--pc-font-display)',
-          fontWeight: 600,
-          fontSize: 10,
-          fontVariantNumeric: 'tabular-nums',
-          color: 'var(--pc-paper)',
-        }}
-      >
-        {format(value)}
-      </span>
-    </div>
-  );
-}
-
-interface CompactColorPickerProps {
-  value: string;
-  recent: readonly string[];
-  onChange(color: string): void;
-  onCommit(color: string): void;
-}
-
-function CompactColorPicker({
-  value,
-  recent,
-  onChange,
-  onCommit,
-}: CompactColorPickerProps): JSX.Element {
-  return (
-    <div style={{ display: 'flex', flexDirection: 'column', gap: 6 }}>
-      <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
-        <span
-          style={{
-            width: 48,
-            fontFamily: 'var(--pc-font-display)',
-            fontWeight: 600,
-            fontSize: 10,
-            letterSpacing: 'var(--pc-tr-caps)',
-            textTransform: 'uppercase',
-            color: 'var(--pc-paper-soft)',
-          }}
-        >
-          Colour
-        </span>
-        <input
-          type="color"
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onBlur={(event) => onCommit(event.target.value)}
-          style={{
-            width: 30,
-            height: 26,
-            borderRadius: 6,
-            border: '1px solid var(--pc-glass-stroke)',
-            background: 'transparent',
-            cursor: 'pointer',
-            padding: 0,
-          }}
-        />
-        <div style={{ display: 'flex', flexWrap: 'wrap', gap: 4, flex: 1 }}>
-          {COLOR_SWATCHES.slice(0, 8).map((swatch) => {
-            const selected = value.toLowerCase() === swatch.toLowerCase();
-            return (
-              <button
-                key={swatch}
-                type="button"
-                aria-label={`Use color ${swatch}`}
-                onClick={() => onChange(swatch)}
-                style={{
-                  height: 16,
-                  width: 16,
-                  borderRadius: 999,
-                  border: '1px solid var(--pc-glass-stroke)',
-                  backgroundColor: swatch,
-                  cursor: 'pointer',
-                  boxShadow: selected ? 'var(--pc-halo-cyan-soft)' : 'none',
-                  outline: selected ? '1px solid var(--pc-cyan-glow)' : 'none',
-                  padding: 0,
-                }}
-              />
-            );
-          })}
-        </div>
-      </div>
-      {recent.length > 0 && (
-        <div
-          style={{ display: 'flex', flexWrap: 'wrap', gap: 4, paddingLeft: 56 }}
-        >
-          {recent.slice(0, 6).map((swatch) => {
-            const selected = value.toLowerCase() === swatch.toLowerCase();
-            return (
-              <button
-                key={swatch}
-                type="button"
-                aria-label={`Reuse colour ${swatch}`}
-                onClick={() => onChange(swatch)}
-                style={{
-                  height: 14,
-                  width: 14,
-                  borderRadius: 4,
-                  border: '1px solid var(--pc-glass-stroke)',
-                  backgroundColor: swatch,
-                  cursor: 'pointer',
-                  boxShadow: selected ? 'var(--pc-halo-cyan-soft)' : 'none',
-                  outline: selected ? '1px solid var(--pc-cyan-glow)' : 'none',
-                  padding: 0,
-                }}
-              />
-            );
-          })}
-        </div>
-      )}
-    </div>
-  );
-}

--- a/components/room-organizer/panels/item-resize-panel.tsx
+++ b/components/room-organizer/panels/item-resize-panel.tsx
@@ -8,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
+import { COLOR_SWATCHES, ColorSwatchPicker } from './color-swatch-picker';
 import type { FurnitureItem, SofaShape } from '../lib/types';
 
 type ResizableDimension = 'width' | 'depth' | 'height';
@@ -41,21 +42,6 @@ function hslToHex(h: number, s: number, l: number): string {
   const toHex = (value: number) => Math.round(value * 255).toString(16).padStart(2, '0');
   return `#${toHex(f(0))}${toHex(f(8))}${toHex(f(4))}`;
 }
-
-const COLOR_SWATCHES = [
-  '#8B4513',
-  '#4A5568',
-  '#E8E8E8',
-  '#2C3E50',
-  '#C62828',
-  '#1976D2',
-  '#388E3C',
-  '#FFB300',
-  '#6A1B9A',
-  '#5D4037',
-  '#0D47A1',
-  '#FAFAFA',
-];
 
 export interface ItemResizePanelProps {
   hasCollision: boolean;
@@ -119,8 +105,10 @@ export function ItemResizePanel(props: ItemResizePanelProps): JSX.Element {
           🎯 Centre in room
         </Button>
 
-        <ColorPicker
+        <ColorSwatchPicker
+          variant="card"
           value={item.color}
+          swatches={COLOR_SWATCHES}
           recent={recentColors}
           onChange={(color) => actions.setColor(item.id, color)}
           onCommit={(color) => pushColor(color)}
@@ -247,67 +235,6 @@ function RotationInput({ value, onChange }: RotationInputProps): JSX.Element {
           if (Number.isFinite(parsed)) onChange(((parsed % 360) + 360) % 360);
         }}
       />
-    </div>
-  );
-}
-
-interface ColorPickerProps {
-  value: string;
-  recent: readonly string[];
-  onChange(color: string): void;
-  onCommit(color: string): void;
-}
-
-function ColorPicker({ value, recent, onChange, onCommit }: ColorPickerProps): JSX.Element {
-  const inputId = useId();
-  return (
-    <div className="space-y-2">
-      <Label htmlFor={inputId} className="text-xs">
-        Color
-      </Label>
-      <div className="flex items-center gap-2">
-        <input
-          id={inputId}
-          type="color"
-          value={value}
-          onChange={(event) => onChange(event.target.value)}
-          onBlur={(event) => onCommit(event.target.value)}
-          className="h-8 w-10 rounded border cursor-pointer"
-        />
-        <div className="flex flex-wrap gap-1">
-          {COLOR_SWATCHES.map((swatch) => (
-            <button
-              key={swatch}
-              type="button"
-              aria-label={`Use color ${swatch}`}
-              onClick={() => onChange(swatch)}
-              className={`h-5 w-5 rounded-full border ${
-                value.toLowerCase() === swatch.toLowerCase() ? 'ring-2 ring-primary' : ''
-              }`}
-              style={{ backgroundColor: swatch }}
-            />
-          ))}
-        </div>
-      </div>
-      {recent.length > 0 && (
-        <div>
-          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Recent</p>
-          <div className="flex flex-wrap gap-1 mt-1">
-            {recent.map((swatch) => (
-              <button
-                key={swatch}
-                type="button"
-                aria-label={`Reuse colour ${swatch}`}
-                onClick={() => onChange(swatch)}
-                className={`h-5 w-5 rounded border ${
-                  value.toLowerCase() === swatch.toLowerCase() ? 'ring-2 ring-primary' : ''
-                }`}
-                style={{ backgroundColor: swatch }}
-              />
-            ))}
-          </div>
-        </div>
-      )}
     </div>
   );
 }

--- a/components/room-organizer/panels/item-resize-panel.tsx
+++ b/components/room-organizer/panels/item-resize-panel.tsx
@@ -63,7 +63,7 @@ export interface ItemResizePanelProps {
 }
 
 export function ItemResizePanel(props: ItemResizePanelProps): JSX.Element {
-  const { actions, recentColors, pushColor, layout, activeFloor } = useRoomEditor();
+  const { actions, recentColors, pushColor } = useRoomEditor();
   const { selectedItem } = useSelection();
   if (!selectedItem) return <></>;
   const item = selectedItem;

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRoomEditor } from '../contexts';
 import { useSelection } from '../contexts';
 import { alignSelection, distributeSelection } from '../lib/alignment';
@@ -29,7 +29,7 @@ import { ThemesPanel } from './themes-panel';
 import { TimeOfDayPanel } from './time-of-day-panel';
 import { WallsPanel } from './walls-panel';
 import type { AlignEdge, DistributeAxis } from '../lib/alignment';
-import type { CameraPreset, CatalogItem, RoomLayout } from '../lib/types';
+import type { CameraPreset, CatalogItem } from '../lib/types';
 
 export interface SidebarDrawerProps {
   collapsed: boolean;

--- a/components/room-organizer/panels/slider-row.tsx
+++ b/components/room-organizer/panels/slider-row.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { useId } from 'react';
+
+export interface SliderRowProps {
+  label: string;
+  min: number;
+  max: number;
+  step: number;
+  value: number;
+  format(value: number): string;
+  onChange(value: number): void;
+  /** Width of the label column in px (default 48). */
+  labelWidth?: number;
+  /**
+   * Spaced-caps label (default). Set false for the plain bold label style
+   * used by the compact dimension rows.
+   */
+  uppercaseLabel?: boolean;
+}
+
+/**
+ * Label + range input + value readout row, styled for the plotcraft HUD
+ * (display font, cyan accent, tabular-nums readout).
+ */
+export function SliderRow(props: SliderRowProps): JSX.Element {
+  const {
+    label,
+    min,
+    max,
+    step,
+    value,
+    format,
+    onChange,
+    labelWidth = 48,
+    uppercaseLabel = true,
+  } = props;
+  const id = useId();
+  return (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+      <label
+        htmlFor={id}
+        style={{
+          width: labelWidth,
+          fontFamily: 'var(--pc-font-display)',
+          fontWeight: uppercaseLabel ? 600 : 700,
+          fontSize: 10,
+          ...(uppercaseLabel
+            ? {
+                letterSpacing: 'var(--pc-tr-caps)',
+                textTransform: 'uppercase' as const,
+              }
+            : {}),
+          color: 'var(--pc-paper-soft)',
+        }}
+      >
+        {label}
+      </label>
+      <input
+        id={id}
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(event) => onChange(parseFloat(event.target.value))}
+        style={{ flex: 1, accentColor: 'var(--pc-cyan-glow)' }}
+      />
+      <span
+        style={{
+          width: 48,
+          textAlign: 'right',
+          fontFamily: 'var(--pc-font-display)',
+          fontWeight: 600,
+          fontSize: 10,
+          fontVariantNumeric: 'tabular-nums',
+          color: 'var(--pc-paper)',
+        }}
+      >
+        {format(value)}
+      </span>
+    </div>
+  );
+}

--- a/components/room-organizer/panels/wall-paint-panel.tsx
+++ b/components/room-organizer/panels/wall-paint-panel.tsx
@@ -311,14 +311,10 @@ function SurfaceTabs({ surface, onChange }: SurfaceTabsProps): JSX.Element {
   return (
     <div
       role="tablist"
+      className="pc-glass--inset"
       style={{
         display: 'inline-flex',
         gap: 3,
-        background: 'rgba(0,0,0,0.20)',
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: 8,
-        padding: 3,
-        boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.30)',
       }}
     >
       {tabs.map((t) => {
@@ -360,14 +356,10 @@ function ApplyToggle({ value, onChange }: ApplyToggleProps): JSX.Element {
     <div
       role="radiogroup"
       aria-label="Apply paint to"
+      className="pc-glass--inset"
       style={{
         display: 'flex',
         gap: 3,
-        background: 'rgba(0,0,0,0.20)',
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: 8,
-        padding: 3,
-        boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.30)',
       }}
     >
       {APPLY_TARGETS.map((target) => {
@@ -417,14 +409,10 @@ function WallVisibilityToggle({ hiddenWalls, onToggle }: WallVisibilityTogglePro
     <div
       role="group"
       aria-label="Wall visibility"
+      className="pc-glass--inset"
       style={{
         display: 'flex',
         gap: 3,
-        background: 'rgba(0,0,0,0.20)',
-        border: '1px solid rgba(255,255,255,0.08)',
-        borderRadius: 8,
-        padding: 3,
-        boxShadow: 'inset 0 2px 4px rgba(0,0,0,0.30)',
       }}
     >
       {VISIBILITY_WALLS.map((wall) => {
@@ -524,9 +512,8 @@ function SectionLabel({ children }: { children: React.ReactNode }): JSX.Element 
 function PatternGrid({ children }: { children: React.ReactNode }): JSX.Element {
   return (
     <div
+      className="pc-glass--inset"
       style={{
-        background: 'rgba(0,0,0,0.20)',
-        border: '1px solid rgba(255,255,255,0.08)',
         borderRadius: 10,
         padding: 4,
         boxShadow: 'inset 0 2px 6px rgba(0,0,0,0.35)',
@@ -680,9 +667,8 @@ function SwatchGrid({ swatches, value, onChange, onCustomChange }: SwatchGridPro
   const normalized = (value ?? '').toLowerCase();
   return (
     <div
+      className="pc-glass--inset"
       style={{
-        background: 'rgba(0,0,0,0.20)',
-        border: '1px solid rgba(255,255,255,0.08)',
         borderRadius: 10,
         padding: 4,
         boxShadow: 'inset 0 2px 6px rgba(0,0,0,0.35)',

--- a/components/room-organizer/plotcraft/tokens.css
+++ b/components/room-organizer/plotcraft/tokens.css
@@ -100,6 +100,17 @@
 }
 .pc-glass--dark { background-color: var(--pc-glass-tint-dark); }
 
+/* Recessed well inside a glass panel — dark inset chrome shared by toggle
+   rows and swatch/pattern grids. Grid sites override radius, padding and
+   shadow depth inline where they differ. */
+.pc-glass--inset {
+  background: rgba(0, 0, 0, 0.20);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 8px;
+  padding: 3px;
+  box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.30);
+}
+
 /* ===========================================================
    Typography helpers (scoped — don't fight Tailwind defaults)
    =========================================================== */

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -88,12 +88,6 @@ function zoomCamera(
   controls.update();
 }
 
-function formatClock(hour: number): string {
-  const h = Math.floor(hour);
-  const m = Math.floor((hour - h) * 60);
-  return `${String(h).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
-}
-
 const INITIAL_VIEW_SETTINGS: ViewSettings = {
   view2D: false,
   showMeasurements: true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,8 @@
     "allowJs": false,
     "skipLibCheck": true,
     "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
     "noUncheckedIndexedAccess": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
Stacked on #54 (merge that first — both touch item-resize-panel.tsx).

Three families of copy-pasted widgets, deduplicated where the duplication was real — and left alone where it wasn't:

- **Color pickers:** new `ColorSwatchPicker` (+ a single exported `COLOR_SWATCHES` — the 12-color array was duplicated verbatim) unifies the popover's `CompactColorPicker` and the resize panel's picker behind one props contract, with `variant: 'glass' | 'card'` skins since the two sites live in different design systems. Wall-paint's `SwatchGrid` was left alone — the issue's premise was wrong there: it has no recent colors or label row and is structurally a different widget.
- **Glass chrome:** new `.pc-glass--inset` token class next to `.pc-glass--dark`; all 5 wall-paint-panel sites use it (the 2 grid sites keep their genuinely different radius/padding as overrides, preserving exact pixels).
- **Slider rows:** new `SliderRow` component; migrated the three near-identical rows in item-context-popover (5 render sites). The 4 shadcn-styled sliders elsewhere use a structurally different label-above pattern and were left alone rather than faking the dedup with per-site style props.

Net **−60 lines** across 6 files. Pixel-identical refactor: typecheck clean, lint clean at --max-warnings=0, production build succeeds.

Fixes #38