### PR TITLE
Fix geometry correctness: rotation convention, exterior wall cutouts, opening collisions

### DIFF
--- a/components/room-organizer/canvas-2d/render.ts
+++ b/components/room-organizer/canvas-2d/render.ts
@@ -1,3 +1,4 @@
+import { rotatedHalfExtents } from '../lib/geometry';
 import type { FloorLayout, FurnitureItem, RoomLayout } from '../lib/types';
 
 export interface Render2DOptions {
@@ -161,7 +162,9 @@ function drawFurniture(
 
     ctx.save();
     ctx.translate(cx, cy);
-    ctx.rotate(item.rotation ?? 0);
+    // Canvas rotate() is clockwise while Three's rotateY is CCW; negate so the
+    // 2D footprint matches the 3D scene's orientation.
+    ctx.rotate(-(item.rotation ?? 0));
 
     ctx.fillStyle = collision ? 'rgba(255, 0, 0, 0.7)' : item.color;
     ctx.fillRect(-w / 2, -d / 2, w, d);
@@ -186,11 +189,14 @@ function drawFurniture(
     ctx.restore();
 
     if (options.showMeasurements) {
+      // The label is drawn in screen space (outside the rotated transform), so
+      // offset it by the rotation-aware AABB half-depth to clear the footprint.
+      const { halfD } = rotatedHalfExtents(item);
       ctx.save();
       ctx.fillStyle = '#333';
       ctx.font = '10px Arial';
       ctx.textAlign = 'center';
-      ctx.fillText(`${item.width}m × ${item.depth}m`, cx, cy + d / 2 + 15);
+      ctx.fillText(`${item.width}m × ${item.depth}m`, cx, cy + halfD * scale + 15);
       ctx.restore();
     }
   }
@@ -243,10 +249,13 @@ function drawHeatmap(
     if (itemArea <= 0) continue;
     const pricePerArea = (item.price ?? 0) / itemArea;
 
-    const minX = item.position.x - item.width / 2 + layout.width / 2;
-    const maxX = item.position.x + item.width / 2 + layout.width / 2;
-    const minZ = item.position.z - item.depth / 2 + layout.height / 2;
-    const maxZ = item.position.z + item.depth / 2 + layout.height / 2;
+    // Use the rotation-aware AABB so a rotated item shades the cells its
+    // oriented footprint actually covers.
+    const { halfW, halfD } = rotatedHalfExtents(item);
+    const minX = item.position.x - halfW + layout.width / 2;
+    const maxX = item.position.x + halfW + layout.width / 2;
+    const minZ = item.position.z - halfD + layout.height / 2;
+    const maxZ = item.position.z + halfD + layout.height / 2;
 
     const col0 = Math.max(0, Math.floor(minX / cellWidth));
     const col1 = Math.min(COLS - 1, Math.floor(maxX / cellWidth));

--- a/components/room-organizer/lib/geometry.ts
+++ b/components/room-organizer/lib/geometry.ts
@@ -1,7 +1,24 @@
+import { isOpening } from './opening-snap';
 import type { FurnitureItem, Vec2 } from './types';
 
 export function boundingRadius(item: Pick<FurnitureItem, 'width' | 'depth'>): number {
   return Math.hypot(item.width / 2, item.depth / 2);
+}
+
+/**
+ * Half-extents of an item's axis-aligned bounding box in world space, given
+ * its oriented footprint. Shared by bounds tests, wall snapping, and the 2D
+ * renderer so rotated items report a consistent footprint everywhere.
+ */
+export function rotatedHalfExtents(
+  item: Pick<FurnitureItem, 'width' | 'depth' | 'rotation'>
+): { halfW: number; halfD: number } {
+  const cos = Math.abs(Math.cos(item.rotation ?? 0));
+  const sin = Math.abs(Math.sin(item.rotation ?? 0));
+  return {
+    halfW: (item.width * cos + item.depth * sin) / 2,
+    halfD: (item.width * sin + item.depth * cos) / 2,
+  };
 }
 
 /**
@@ -39,9 +56,11 @@ function toObb(item: FurnitureItem): Obb {
     cz: item.position?.z ?? 0,
     hw: item.width / 2,
     hd: item.depth / 2,
+    // Three's rotY maps the local +X axis to (cosθ, −sinθ) in world XZ, so the
+    // width axis is (cos, −sin) and the depth axis is (sin, cos).
     ax: cos,
-    az: sin,
-    bx: -sin,
+    az: -sin,
+    bx: sin,
     bz: cos,
   };
 }
@@ -70,10 +89,7 @@ function obbOverlap(a: Obb, b: Obb): boolean {
 export function itemInBounds(item: FurnitureItem, roomWidth: number, roomDepth: number): boolean {
   if (!item.position) return false;
   // Rotation-aware AABB of the item's oriented footprint.
-  const cos = Math.abs(Math.cos(item.rotation ?? 0));
-  const sin = Math.abs(Math.sin(item.rotation ?? 0));
-  const halfW = (item.width * cos + item.depth * sin) / 2;
-  const halfD = (item.width * sin + item.depth * cos) / 2;
+  const { halfW, halfD } = rotatedHalfExtents(item);
   return (
     item.position.x - halfW >= -roomWidth / 2 &&
     item.position.x + halfW <= roomWidth / 2 &&
@@ -85,10 +101,7 @@ export function itemInBounds(item: FurnitureItem, roomWidth: number, roomDepth: 
 /** True when the item's rotation-aware AABB is entirely beyond the room rect. */
 export function itemFullyOutside(item: FurnitureItem, roomWidth: number, roomDepth: number): boolean {
   if (!item.position) return false;
-  const cos = Math.abs(Math.cos(item.rotation ?? 0));
-  const sin = Math.abs(Math.sin(item.rotation ?? 0));
-  const halfW = (item.width * cos + item.depth * sin) / 2;
-  const halfD = (item.width * sin + item.depth * cos) / 2;
+  const { halfW, halfD } = rotatedHalfExtents(item);
   return (
     item.position.x + halfW <= -roomWidth / 2 ||
     item.position.x - halfW >= roomWidth / 2 ||
@@ -107,6 +120,12 @@ export function hasCollisions(
   // Security cameras mount on the wall plane and may sit on its exterior side
   // when aimed outward, so the room-bounds test doesn't apply to them.
   if (item.type === 'security-camera') return false;
+  // Openings (doors/windows) live in the wall plane by design, so the
+  // room-bounds test never applies — they'd always poke through the wall and
+  // read as out-of-bounds. They still collide with other items on the wall.
+  if (isOpening(item.type)) {
+    return allItems.some((other) => other.id !== item.id && itemsOverlap(item, other));
+  }
   // Outdoor items belong outside the building footprint — flag them when any
   // part of their footprint pokes into the room. They still collide with
   // other items (e.g. two trees on the same spot).
@@ -194,10 +213,7 @@ export function snapToWall({
   roomDepth,
   threshold = 0.35,
 }: SnapToWallOptions): Vec2 {
-  const cos = Math.abs(Math.cos(item.rotation ?? 0));
-  const sin = Math.abs(Math.sin(item.rotation ?? 0));
-  const halfW = (item.width * cos + item.depth * sin) / 2;
-  const halfD = (item.width * sin + item.depth * cos) / 2;
+  const { halfW, halfD } = rotatedHalfExtents(item);
 
   const minX = -roomWidth / 2 + halfW;
   const maxX = roomWidth / 2 - halfW;

--- a/components/room-organizer/three/wall-openings.ts
+++ b/components/room-organizer/three/wall-openings.ts
@@ -173,15 +173,22 @@ function buildOpening(
 }
 
 function projectAlongWall(position: { x: number; z: number }, wall: WallId): number {
+  // centerAlongWall is measured in each wall's LOCAL frame (origin at the
+  // wall's midpoint, along its local +X). The south and west walls are
+  // rotated relative to world space, so world coords must be flipped to land
+  // the cutout under the slab.
   switch (wall) {
     case 'north':
-    case 'south':
+      // North wall: local +X aligns with world +X.
       return position.x;
+    case 'south':
+      // South wall is rotateY π (local +X → world −X), so flip.
+      return -position.x;
     case 'east':
-    case 'west':
-      // East/west walls run along Z; the inside view's "right" is +z for
-      // the west wall and -z for the east wall, but for centre alignment
-      // we don't care about flip — the cutout is symmetric.
+      // East wall: local +X aligns with world +Z.
       return position.z;
+    case 'west':
+      // West wall is rotateY π/2 (local +X → world −Z), so flip.
+      return -position.z;
   }
 }


### PR DESCRIPTION
## Summary

Three interrelated geometry-correctness bugs were masking each other, so a 45°-rotated item and every exterior door/window read inconsistently across the 3D scene and the 2D top-down view. Fixing only one made flags look wrong in the other view, so they are fixed together.

## Fixes

### Rotation convention mismatch (#58)
The collision OBB and the 2D canvas both mirrored the 3D scene. Three's `rotateY` maps local +X to `(cosθ, −sinθ)` (CCW), but `toObb` used a width axis of `(cos, +sin)` and the 2D canvas rotated clockwise.

- `lib/geometry.ts` — OBB axes fixed to `ax: cos, az: -sin, bx: sin, bz: cos`.
- `canvas-2d/render.ts` — `ctx.rotate(-(item.rotation ?? 0))` so the 2D footprint matches the 3D orientation.
- `canvas-2d/render.ts` — the heatmap footprint and the per-item measurement-label offset now use a shared rotation-aware AABB helper (`rotatedHalfExtents`, extracted from the existing inline math used by `itemInBounds`/`snapToWall`) so rotated items report a consistent footprint everywhere.

### Door/window cutouts mirrored on the south and west exterior walls (#59)
`projectAlongWall` returned raw world coords, but the south wall is `rotateY π` (local +X → world −X) and the west wall `rotateY π/2` (local +X → world −Z). It now returns `−x` for the south wall and `−z` for the west wall so the hole lands under the slab. The interior-wall and floor-opening paths are untouched.

### Exterior doors/windows permanently flagged red (#60)
`hasCollisions` bounds-tested the full AABB and only exempted `security-camera`; openings sit on the wall plane so they always failed the bounds test. Openings (`isOpening(item.type)`) are now exempt from the room-bounds half of the check while keeping the item-vs-item overlap check.

## Verification
- `npm run typecheck` — clean
- lint — clean (the nested worktree double-loads the `@next/next` plugin, so ran the documented fallback `npx eslint --no-eslintrc -c .eslintrc.json --ext .ts,.tsx app components --max-warnings=0`; no config changed)
- `npm run build` — succeeds

Fixes #58
Fixes #59
Fixes #60