### PR TITLE
Fix state/robustness: error boundaries, save failures, redo debounce

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+// Route-level error boundary. A saved layout that crashes the renderer would
+// otherwise white-screen the app on every reload, with no way out but
+// devtools. This gives a friendly recovery path: clear the persisted layout
+// and retry. The storage key literal mirrors STORAGE_KEY in
+// components/room-organizer/lib/constants.ts.
+const STORAGE_KEY = 'standalone-room-organizer-layout';
+
+export default function Error({ reset }: { error: Error & { digest?: string }; reset: () => void }): JSX.Element {
+  const resetSavedLayout = () => {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore — worst case the reset button just reloads without clearing.
+    }
+    reset();
+  };
+
+  return (
+    <div
+      className="pc-world"
+      style={{ position: 'fixed', inset: 0, display: 'grid', placeItems: 'center', padding: 24 }}
+    >
+      <div
+        className="pc-glass pc-glass--dark"
+        style={{ padding: '28px 32px', textAlign: 'center', maxWidth: 420 }}
+      >
+        <p
+          style={{
+            margin: '0 0 8px',
+            fontFamily: 'var(--pc-font-display)',
+            fontWeight: 700,
+            color: 'var(--pc-paper)',
+            letterSpacing: 'var(--pc-tr-caps)',
+            textTransform: 'uppercase',
+            fontSize: 16,
+          }}
+        >
+          Something went sideways
+        </p>
+        <p
+          style={{
+            margin: '0 0 20px',
+            fontFamily: 'var(--pc-font-body)',
+            color: 'var(--pc-paper-soft)',
+            fontSize: 13,
+            lineHeight: 1.5,
+          }}
+        >
+          The saved layout couldn’t be rendered. Resetting it clears the stored
+          layout and starts fresh.
+        </p>
+        <button
+          type="button"
+          onClick={resetSavedLayout}
+          style={{
+            appearance: 'none',
+            cursor: 'pointer',
+            border: '1px solid rgba(255, 255, 255, 0.18)',
+            borderRadius: 8,
+            padding: '10px 18px',
+            background: 'var(--pc-cyan-glow, #22d3ee)',
+            color: '#0f172a',
+            fontFamily: 'var(--pc-font-display)',
+            fontWeight: 700,
+            letterSpacing: 'var(--pc-tr-caps)',
+            textTransform: 'uppercase',
+            fontSize: 12,
+          }}
+        >
+          Reset saved layout
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+// Global error boundary — catches errors thrown in the root layout itself, so
+// it must render its own <html>/<body>. Same recovery path as app/error.tsx:
+// clear the persisted layout that crashed the renderer, then reload. The
+// storage key literal mirrors STORAGE_KEY in
+// components/room-organizer/lib/constants.ts.
+const STORAGE_KEY = 'standalone-room-organizer-layout';
+
+export default function GlobalError({ reset }: { error: Error & { digest?: string }; reset: () => void }): JSX.Element {
+  const resetSavedLayout = () => {
+    try {
+      window.localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Ignore — fall through to reload/reset even if storage is unavailable.
+    }
+    reset();
+  };
+
+  return (
+    <html lang="en">
+      <body
+        style={{
+          margin: 0,
+          minHeight: '100vh',
+          display: 'grid',
+          placeItems: 'center',
+          padding: 24,
+          background: '#0f172a',
+          color: '#e2e8f0',
+          fontFamily: 'system-ui, -apple-system, "Segoe UI", sans-serif',
+        }}
+      >
+        <div
+          style={{
+            maxWidth: 420,
+            textAlign: 'center',
+            padding: '28px 32px',
+            borderRadius: 14,
+            border: '1px solid rgba(148, 163, 184, 0.24)',
+            background: 'rgba(30, 41, 59, 0.72)',
+          }}
+        >
+          <p style={{ margin: '0 0 8px', fontWeight: 700, textTransform: 'uppercase', letterSpacing: '0.08em', fontSize: 16 }}>
+            Something went sideways
+          </p>
+          <p style={{ margin: '0 0 20px', color: '#94a3b8', fontSize: 13, lineHeight: 1.5 }}>
+            The saved layout couldn’t be rendered. Resetting it clears the
+            stored layout and starts fresh.
+          </p>
+          <button
+            type="button"
+            onClick={resetSavedLayout}
+            style={{
+              appearance: 'none',
+              cursor: 'pointer',
+              border: '1px solid rgba(255, 255, 255, 0.18)',
+              borderRadius: 8,
+              padding: '10px 18px',
+              background: '#22d3ee',
+              color: '#0f172a',
+              fontWeight: 700,
+              textTransform: 'uppercase',
+              letterSpacing: '0.08em',
+              fontSize: 12,
+            }}
+          >
+            Reset saved layout
+          </button>
+        </div>
+      </body>
+    </html>
+  );
+}

--- a/components/room-organizer/hooks/use-history.ts
+++ b/components/room-organizer/hooks/use-history.ts
@@ -92,6 +92,21 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
 
   const redo = useCallback(() => {
     const { past, future } = stacksRef.current;
+
+    // A fresh edit still inside the debounce window hasn't been committed yet,
+    // and it will clear `future` when it commits. Redoing now would apply a
+    // stale snapshot and destroy that pending edit. Mirror the undo-side
+    // guard: while a pending edit exists, drop the stale future and treat redo
+    // as a no-op. While skipNextRef is armed the divergence is a
+    // not-yet-adopted baseline (hydration, undo/redo), not a pending edit.
+    if (!skipNextRef.current && !Object.is(valueRef.current, lastCommittedRef.current)) {
+      if (future.length > 0) {
+        stacksRef.current = { past, future: [] };
+        setStacks(stacksRef.current);
+      }
+      return;
+    }
+
     if (future.length === 0) return;
     const next = future[future.length - 1];
     if (next === undefined) return;
@@ -114,9 +129,11 @@ export function useHistory<T>(value: T, apply: (snapshot: T) => void, options: U
 
   // A pending uncommitted edit is undoable too (back to the last committed
   // snapshot), so canUndo can't rely on the past stack alone.
-  const canUndo =
-    stacks.past.length > 0 || (!skipNextRef.current && !Object.is(value, lastCommittedRef.current));
-  const canRedo = stacks.future.length > 0;
+  const pendingEdit = !skipNextRef.current && !Object.is(value, lastCommittedRef.current);
+  const canUndo = stacks.past.length > 0 || pendingEdit;
+  // Symmetric to redo()'s guard: a pending edit invalidates the (stale) future
+  // stack, so redo must report disabled until that edit commits.
+  const canRedo = stacks.future.length > 0 && !pendingEdit;
 
   return useMemo(
     () => ({ canUndo, canRedo, undo, redo, clear }),

--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -15,6 +15,12 @@ export interface UseLayoutPersistenceResult {
   lastSavedAt: number | null;
   /** True while the debounce window is pending — the next save is on the way. */
   saving: boolean;
+  /**
+   * True when the most recent save attempt failed (e.g. QuotaExceededError from
+   * an oversized floor-plan image). The HUD uses this to avoid falsely showing
+   * "Saved" when the layout never actually made it to localStorage.
+   */
+  saveError: boolean;
 }
 
 export function useLayoutPersistence({
@@ -33,6 +39,7 @@ export function useLayoutPersistence({
   const pendingRef = useRef(false);
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState(false);
 
   useEffect(() => {
     if (hasHydratedRef.current) return;
@@ -44,7 +51,15 @@ export function useLayoutPersistence({
       const shared = decodeShareUrl(window.location.hash);
       if (shared) {
         hydrationBaseRef.current = layout;
-        onHydrate(shared);
+        // A corrupt-but-parseable layout can still throw while it's applied to
+        // the scene. Guard the dispatch so a bad share link doesn't crash the
+        // whole mount — the error boundary's reset path is the recovery.
+        try {
+          onHydrate(shared);
+        } catch (error) {
+          console.warn('Failed to apply shared layout:', error);
+          hydrationBaseRef.current = null;
+        }
         // Clear the hash so reloading after edits doesn't restore the
         // shared version.
         window.history.replaceState(null, '', window.location.pathname + window.location.search);
@@ -55,7 +70,14 @@ export function useLayoutPersistence({
     const saved = loadLayout();
     if (saved) {
       hydrationBaseRef.current = layout;
-      onHydrate(saved);
+      // As above: a stored layout that parses but throws on apply must not
+      // white-screen mount.
+      try {
+        onHydrate(saved);
+      } catch (error) {
+        console.warn('Failed to apply saved layout:', error);
+        hydrationBaseRef.current = null;
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot hydration; `layout` is only read as the pre-hydration baseline
   }, [onHydrate]);
@@ -71,10 +93,20 @@ export function useLayoutPersistence({
     setSaving(true);
     pendingRef.current = true;
     const handle = window.setTimeout(() => {
-      pendingRef.current = false;
-      saveLayout(layout);
-      setLastSavedAt(Date.now());
-      setSaving(false);
+      const ok = saveLayout(layout);
+      if (ok) {
+        // Only mark the edit persisted on a real success — otherwise the HUD
+        // would show "Saved" for a layout that never reached localStorage.
+        pendingRef.current = false;
+        setLastSavedAt(Date.now());
+        setSaving(false);
+        setSaveError(false);
+      } else {
+        // Keep `saving`/pending truthy and flag the error so the HUD reports
+        // the failure instead of a false "Saved". A later successful edit
+        // clears the flag.
+        setSaveError(true);
+      }
     }, debounceMs);
     return () => window.clearTimeout(handle);
   }, [layout, debounceMs]);
@@ -95,5 +127,5 @@ export function useLayoutPersistence({
     };
   }, []);
 
-  return { lastSavedAt, saving };
+  return { lastSavedAt, saving, saveError };
 }

--- a/components/room-organizer/lib/file-io.ts
+++ b/components/room-organizer/lib/file-io.ts
@@ -24,15 +24,52 @@ export async function readLayoutFromFile(file: File): Promise<RoomLayout> {
   return layout;
 }
 
+/** Longest-edge cap for a stored floor plan, in pixels. */
+const MAX_IMAGE_EDGE = 1500;
+
 export async function readImageAsDataUrl(file: File): Promise<string> {
   if (!file.type.startsWith('image/')) {
     throw new Error('Please upload an image file (PNG, JPG, etc.)');
   }
-  return new Promise((resolve, reject) => {
+  const rawDataUrl = await new Promise<string>((resolve, reject) => {
     const reader = new FileReader();
     reader.onload = () => resolve(reader.result as string);
     reader.onerror = () => reject(reader.error ?? new Error('Failed to read image'));
     reader.readAsDataURL(file);
+  });
+
+  // A full-resolution floor plan can easily be several MB of base64, which
+  // exhausts the ~5MB localStorage budget and makes every save fail. Downscale
+  // anything larger than MAX_IMAGE_EDGE on its long edge and re-encode as JPEG
+  // so the stored layout stays well within budget.
+  return downscaleDataUrl(rawDataUrl);
+}
+
+function downscaleDataUrl(dataUrl: string): Promise<string> {
+  return new Promise((resolve) => {
+    const image = new Image();
+    image.onload = () => {
+      const longEdge = Math.max(image.width, image.height);
+      if (longEdge <= MAX_IMAGE_EDGE || longEdge === 0) {
+        resolve(dataUrl);
+        return;
+      }
+      const scale = MAX_IMAGE_EDGE / longEdge;
+      const canvas = document.createElement('canvas');
+      canvas.width = Math.round(image.width * scale);
+      canvas.height = Math.round(image.height * scale);
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        resolve(dataUrl);
+        return;
+      }
+      ctx.drawImage(image, 0, 0, canvas.width, canvas.height);
+      resolve(canvas.toDataURL('image/jpeg', 0.85));
+    };
+    // On decode failure, fall back to the original data URL rather than losing
+    // the upload entirely.
+    image.onerror = () => resolve(dataUrl);
+    image.src = dataUrl;
   });
 }
 

--- a/components/room-organizer/lib/persistence.ts
+++ b/components/room-organizer/lib/persistence.ts
@@ -15,14 +15,18 @@ export function loadLayout(): RoomLayout | null {
   }
 }
 
-export function saveLayout(layout: RoomLayout): void {
-  if (typeof window === 'undefined') return;
+/** Returns true when the layout was persisted, false on any storage failure. */
+export function saveLayout(layout: RoomLayout): boolean {
+  if (typeof window === 'undefined') return false;
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(layout));
+    return true;
   } catch (error) {
     // The most common failure here is QuotaExceededError when a large base64
     // floor-plan image pushes us past the ~5MB localStorage budget. Surface it
-    // as a warning rather than crashing the auto-save loop.
+    // as a warning rather than crashing the auto-save loop, and report the
+    // failure to the caller so the HUD doesn't falsely show "Saved".
     console.warn('Failed to persist layout to localStorage:', error);
+    return false;
   }
 }

--- a/components/room-organizer/panels/header-stats.tsx
+++ b/components/room-organizer/panels/header-stats.tsx
@@ -9,11 +9,13 @@ import { Icon, type PlotcraftIconName } from '../plotcraft/icon';
 export interface HeaderStatsProps {
   lastSavedAt?: number | null;
   saving?: boolean;
+  saveError?: boolean;
 }
 
 export function HeaderStats({
   lastSavedAt = null,
   saving = false,
+  saveError = false,
 }: HeaderStatsProps): JSX.Element {
   const { layout } = useRoomEditor();
   const budget = DEFAULT_BUDGET;
@@ -33,7 +35,7 @@ export function HeaderStats({
         value={`${CURRENCY_SYMBOL}${cost.toLocaleString()} / ${CURRENCY_SYMBOL}${budget.toLocaleString()}`}
         intent={overBudget ? 'danger' : ratio > 0.85 ? 'warning' : 'normal'}
       />
-      <SaveIndicator lastSavedAt={lastSavedAt} saving={saving} />
+      <SaveIndicator lastSavedAt={lastSavedAt} saving={saving} saveError={saveError} />
     </div>
   );
 }
@@ -41,18 +43,29 @@ export function HeaderStats({
 interface SaveIndicatorProps {
   lastSavedAt: number | null;
   saving: boolean;
+  saveError: boolean;
 }
 
-function SaveIndicator({ lastSavedAt, saving }: SaveIndicatorProps): JSX.Element {
+function SaveIndicator({ lastSavedAt, saving, saveError }: SaveIndicatorProps): JSX.Element {
   const [, force] = useState(0);
   useEffect(() => {
     const id = window.setInterval(() => force((n) => n + 1), 10_000);
     return () => window.clearInterval(id);
   }, []);
 
+  // A failed save (typically an oversized floor-plan blowing the localStorage
+  // budget) takes precedence — never claim "Saved" for a layout that didn't
+  // actually persist.
   let label = 'Auto-save on';
-  if (saving) label = 'Saving…';
+  if (saveError) label = 'Save failed — storage full';
+  else if (saving) label = 'Saving…';
   else if (lastSavedAt) label = `Saved ${formatRelative(Date.now() - lastSavedAt)}`;
+
+  const iconColor = saveError
+    ? 'var(--pc-danger, #f87171)'
+    : saving
+      ? 'var(--pc-cyan-glow)'
+      : 'var(--pc-paper-soft)';
 
   return (
     <div
@@ -61,7 +74,7 @@ function SaveIndicator({ lastSavedAt, saving }: SaveIndicatorProps): JSX.Element
         alignItems: 'center',
         gap: 6,
         padding: '4px 10px',
-        color: 'var(--pc-paper-soft)',
+        color: saveError ? 'var(--pc-danger, #f87171)' : 'var(--pc-paper-soft)',
         fontFamily: 'var(--pc-font-body)',
         fontSize: 11,
         fontWeight: 600,
@@ -70,9 +83,9 @@ function SaveIndicator({ lastSavedAt, saving }: SaveIndicatorProps): JSX.Element
       <span
         aria-hidden
         style={{
-          color: saving ? 'var(--pc-cyan-glow)' : 'var(--pc-paper-soft)',
+          color: iconColor,
           display: 'inline-flex',
-          animation: saving ? 'pcHaloPulse 1.6s ease-in-out infinite' : undefined,
+          animation: saving && !saveError ? 'pcHaloPulse 1.6s ease-in-out infinite' : undefined,
         }}
       >
         <Icon name="save" size={14} />

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -389,7 +389,7 @@ export function RoomOrganizer(): JSX.Element {
     [actions]
   ));
 
-  const { lastSavedAt, saving: isSaving } = useLayoutPersistence({
+  const { lastSavedAt, saving: isSaving, saveError } = useLayoutPersistence({
     layout,
     onHydrate: useCallback(
       (saved: RoomLayout) => {
@@ -753,6 +753,7 @@ export function RoomOrganizer(): JSX.Element {
           <HeaderStats
             lastSavedAt={lastSavedAt}
             saving={isSaving}
+            saveError={saveError}
           />
         </div>
       </div>


### PR DESCRIPTION
## Summary

Three state/robustness fixes on one branch.

### #70 — crash recovery / no error boundary
- Added `app/error.tsx` (route error boundary) and `app/global-error.tsx` (renders its own `<html>/<body>`). Both show a friendly dark-slate message and a **Reset saved layout** button that clears the persisted layout (`standalone-room-organizer-layout`) then resets, so a layout that crashes the renderer is recoverable without devtools.
- Wrapped the hydration dispatch in `use-layout-persistence.ts` (both share-URL and local-save paths) in try/catch so a corrupt-but-parseable layout that throws during apply doesn't white-screen mount.

### #71 — silent save failures
- `readImageAsDataUrl` now downscales any floor-plan larger than ~1500px on its long edge to a canvas and re-encodes as JPEG (quality 0.85), keeping uploads well under the ~5MB localStorage budget. Signature/return type unchanged (`Promise<string>`).
- `saveLayout` now returns a boolean (false on QuotaExceededError etc.). The persistence hook only sets `lastSavedAt` / clears the pending flag on success and exposes a `saveError` flag; the HUD shows "Save failed — storage full" instead of a false "Saved".

### #74 — redo destroys a fresh edit inside the debounce window
- `redo()` now applies the same pending-edit guard as `undo()`: while an uncommitted edit exists (`!skipNextRef.current && !Object.is(valueRef.current, lastCommittedRef.current)`) it drops the stale `future` and no-ops instead of applying a stale snapshot. `canRedo` reflects this (false while a pending edit exists). Undo path and StrictMode-safety unchanged.

## Verification
- `npm run typecheck` — clean
- `npx eslint --no-eslintrc -c .eslintrc.json --ext .ts,.tsx app components --max-warnings=0` — clean (plain `npm run lint` hits the known @next/next double-load from the nested worktree)
- `npm run build` — succeeds

Fixes #70
Fixes #71
Fixes #74