### PR TITLE
Fix touch drag, click-select regression, and camera-pad zoom direction

### DIFF
--- a/components/room-organizer/hooks/use-item-drag.ts
+++ b/components/room-organizer/hooks/use-item-drag.ts
@@ -37,6 +37,24 @@ export interface UseItemDragResult {
  * positions and becomes one bulkSetPositions on release (which also gives
  * undo a single entry per gesture instead of one per mousemove).
  */
+// True if any entry's latest position differs from its origin. A pure
+// click-select (or any gesture with no net movement) leaves latest === origins,
+// which must not commit state or lock the item.
+function sessionMoved(
+  origins: Map<string, { x: number; z: number }>,
+  latest: Map<string, { x: number; z: number }>
+): boolean {
+  const EPS = 1e-4;
+  for (const [id, origin] of origins) {
+    const now = latest.get(id);
+    if (!now) continue;
+    if (Math.abs(now.x - origin.x) > EPS || Math.abs(now.z - origin.z) > EPS) {
+      return true;
+    }
+  }
+  return false;
+}
+
 export function useItemDrag({
   activeFloor,
   activeFloorIndex,
@@ -147,13 +165,19 @@ export function useItemDrag({
       const session = dragSessionRef.current;
       dragSessionRef.current = null;
       const finalPos = session?.latest.get(id);
-      if (session && finalPos) {
+      // A gesture that never actually moved anything (a stray zero-distance
+      // drag) must not write state or add an undo entry, and must not re-lock
+      // the item — otherwise a click silently blocks the next nudge/delete
+      // (see #65). A real drag always leaves at least one position changed.
+      const moved = session ? sessionMoved(session.origins, session.latest) : false;
+      if (session && finalPos && moved) {
         const primaryGroup = findFurnitureGroup(id);
         if (primaryGroup) setDragCollisionTint(primaryGroup, false);
         // Single dispatch for the whole gesture; the rebuild effect runs once.
         actions.bulkSetPositions(session.latest);
       }
-      // Lock the item after positioning so it can't be accidentally moved.
+      if (!moved) return;
+      // Lock the item after a real drag so it can't be accidentally moved.
       actions.setLocked(id, true);
       // On release, click a security camera onto the nearest wall and turn it to
       // face into the room. Doing this on drop (not per drag frame) keeps the

--- a/components/room-organizer/panels/camera-pad.tsx
+++ b/components/room-organizer/panels/camera-pad.tsx
@@ -199,7 +199,7 @@ export function CameraPad(props: CameraPadProps): JSX.Element {
             // direction. One step per ~8% drag keeps the motion smooth.
             const steps = Math.max(1, Math.round(Math.abs(delta) / 8));
             for (let i = 0; i < steps; i += 1) {
-              props.onZoom(delta > 0 ? '-' : '+');
+              props.onZoom(delta > 0 ? '+' : '-');
             }
             setZoomPos(next);
           }}

--- a/components/room-organizer/panels/touch-mode-toggle.tsx
+++ b/components/room-organizer/panels/touch-mode-toggle.tsx
@@ -6,12 +6,19 @@ import type { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js
 
 type TouchMode = 'orbit' | 'pan';
 
+// THREE.TOUCH enum values, inlined to avoid importing the Three.js runtime into
+// this presentational panel: ROTATE = 0, PAN = 1, DOLLY_PAN = 2.
+const TOUCH_ROTATE = 0;
+const TOUCH_PAN = 1;
+const TOUCH_DOLLY_PAN = 2;
+
 export interface TouchModeToggleProps {
   controlsRef: MutableRefObject<OrbitControls | null>;
+  isReady: boolean;
   onFit(): void;
 }
 
-export function TouchModeToggle({ controlsRef, onFit }: TouchModeToggleProps): JSX.Element {
+export function TouchModeToggle({ controlsRef, isReady, onFit }: TouchModeToggleProps): JSX.Element {
   const [mode, setMode] = useState<TouchMode>('orbit');
   const [isTouchDevice, setIsTouchDevice] = useState(false);
 
@@ -26,26 +33,22 @@ export function TouchModeToggle({ controlsRef, onFit }: TouchModeToggleProps): J
   const applyMode = useCallback((m: TouchMode) => {
     const controls = controlsRef.current;
     if (!controls) return;
-    if (m === 'pan') {
-      controls.mouseButtons = {
-        LEFT: 2 as never,
-        MIDDLE: 1 as never,
-        RIGHT: 0 as never,
-      };
-    } else {
-      controls.mouseButtons = {
-        LEFT: 0 as never,
-        MIDDLE: 1 as never,
-        RIGHT: 2 as never,
-      };
-    }
+    // Touch gestures read controls.touches (not mouseButtons). A one-finger
+    // drag either rotates the camera (orbit) or pans it (center); two fingers
+    // always pinch-dolly + pan. mouseButtons is left at its OrbitControls
+    // defaults so the desktop pointer-drag interaction is unaffected.
+    controls.touches = {
+      ONE: (m === 'pan' ? TOUCH_PAN : TOUCH_ROTATE) as never,
+      TWO: TOUCH_DOLLY_PAN as never,
+    };
   }, [controlsRef]);
 
   useEffect(() => {
+    // Apply once the scene (and therefore controlsRef) is live, rather than
+    // racing the renderer with a fixed setTimeout.
+    if (!isReady) return;
     applyMode(mode);
-    const timer = window.setTimeout(() => applyMode(mode), 1000);
-    return () => window.clearTimeout(timer);
-  }, [mode, applyMode]);
+  }, [mode, isReady, applyMode]);
 
   const handleZoom = (direction: '+' | '-') => {
     const controls = controlsRef.current;

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -821,7 +821,7 @@ export function RoomOrganizer(): JSX.Element {
       />
 
       {/* Touch mode toggle — visible on mobile only */}
-      <TouchModeToggle controlsRef={controlsRef} onFit={fitToRoom} />
+      <TouchModeToggle controlsRef={controlsRef} isReady={isReady} onFit={fitToRoom} />
 
       {/* Welcome modal — auto-shows once, dismissible */}
       <WelcomeBanner />

--- a/components/room-organizer/three/drag-handlers.ts
+++ b/components/room-organizer/three/drag-handlers.ts
@@ -40,10 +40,17 @@ export interface DragHandlersOptions {
   handlersRef: { readonly current: SceneEventHandlers };
 }
 
+// A pointerdown that never travels past this radius (in CSS pixels) is a click,
+// not a drag: it selects the item without opening a drag session, so a plain
+// tap/click never re-locks the item or writes an undo entry. Real drags cross
+// the threshold and behave exactly as before.
+const DRAG_THRESHOLD_PX = 4;
+
 /**
- * Wires the canvas mouse events for select / drag / hover / wall-pick /
- * empty-click. Pure Three.js + DOM — no React. Returns a cleanup that removes
- * every listener.
+ * Wires the canvas pointer events for select / drag / hover / wall-pick /
+ * empty-click. Pointer events unify mouse, touch and pen — the same code path
+ * drives desktop and touch. Pure Three.js + DOM — no React. Returns a cleanup
+ * that removes every listener.
  */
 export function attachDragHandlers({
   THREE,
@@ -59,15 +66,47 @@ export function attachDragHandlers({
   const dragPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   const intersection = new THREE.Vector3();
 
+  // A "pending" drag is a pointerdown that landed on a movable item but hasn't
+  // yet travelled past DRAG_THRESHOLD_PX. Until it does, no drag session is
+  // opened (see #65) — a release while still pending is a select-only click.
   let dragTarget: ThreeNS.Object3D | null = null;
+  let dragStarted = false;
+  let activePointerId: number | null = null;
+  let downClientX = 0;
+  let downClientY = 0;
 
-  const setPointerFromEvent = (event: MouseEvent): void => {
+  const setPointerFromEvent = (event: { clientX: number; clientY: number }): void => {
     const rect = canvas.getBoundingClientRect();
     pointer.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
     pointer.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
   };
 
-  const onMouseDown = (event: MouseEvent): void => {
+  const resetDragState = (): void => {
+    dragTarget = null;
+    dragStarted = false;
+    activePointerId = null;
+  };
+
+  const beginDragSession = (event: PointerEvent): void => {
+    if (!dragTarget) return;
+    dragStarted = true;
+    // Take pointer capture so moves/up keep flowing to us even if the pointer
+    // slides off the canvas mid-drag (important for touch), and stop
+    // OrbitControls from panning/rotating the camera under the drag.
+    try {
+      canvas.setPointerCapture(event.pointerId);
+    } catch {
+      // Capture can throw if the pointer is already gone; safe to ignore.
+    }
+    controls.enabled = false;
+    handlersRef.current.onItemDragStart?.(dragTarget.userData.id as string);
+  };
+
+  const onPointerDown = (event: PointerEvent): void => {
+    // Only track a single primary pointer at a time. A second finger arriving
+    // mid-gesture is ignored here so it can drive OrbitControls' pinch.
+    if (activePointerId !== null) return;
+
     setPointerFromEvent(event);
     raycaster.setFromCamera(pointer, camera);
     const furniture = scene.children.filter((obj) => obj.userData.type === 'furniture');
@@ -114,13 +153,17 @@ export function attachDragHandlers({
 
     if (target.userData.locked === true || mode === 'toggle') return;
 
+    // Arm a potential drag, but don't open the session yet: the drag only
+    // begins once the pointer travels past DRAG_THRESHOLD_PX (see onPointerMove).
     dragTarget = target;
-    controls.enabled = false;
-    handlersRef.current.onItemDragStart?.(itemId);
+    dragStarted = false;
+    activePointerId = event.pointerId;
+    downClientX = event.clientX;
+    downClientY = event.clientY;
   };
 
   let lastHoverId: string | null = null;
-  const updateHover = (event: MouseEvent): void => {
+  const updateHover = (event: PointerEvent): void => {
     const hoverCallback = handlersRef.current.onItemHover;
     if (!hoverCallback) return;
     setPointerFromEvent(event);
@@ -130,7 +173,7 @@ export function attachDragHandlers({
     const target = ascendToFurniture(hits[0]?.object);
     const id = target ? (target.userData.id as string) : null;
 
-    // Only notify on hover changes — a fresh payload per mousemove would
+    // Only notify on hover changes — a fresh payload per move would
     // re-render React for every pixel of travel. The tooltip anchors at the
     // point where the hover began.
     if (id === lastHoverId) return;
@@ -139,9 +182,13 @@ export function attachDragHandlers({
     hoverCallback(id ? { id, clientX: event.clientX, clientY: event.clientY } : null);
   };
 
-  const onMouseMove = (event: MouseEvent): void => {
+  const onPointerMove = (event: PointerEvent): void => {
     if (!dragTarget) {
-      updateHover(event);
+      // Hover + tooltip is a mouse/pen affordance only. Skipping it for touch
+      // avoids per-frame React re-renders while a finger drags.
+      if (event.pointerType !== 'touch') {
+        updateHover(event);
+      }
       if (handlersRef.current.onFloorPointerMove) {
         setPointerFromEvent(event);
         raycaster.setFromCamera(pointer, camera);
@@ -152,6 +199,17 @@ export function attachDragHandlers({
       }
       return;
     }
+
+    // A drag is armed on this item but the session hasn't opened yet: wait for
+    // the pointer to travel past the threshold before treating it as a drag.
+    if (!dragStarted) {
+      if (event.pointerId !== activePointerId) return;
+      const dx = event.clientX - downClientX;
+      const dy = event.clientY - downClientY;
+      if (dx * dx + dy * dy < DRAG_THRESHOLD_PX * DRAG_THRESHOLD_PX) return;
+      beginDragSession(event);
+    }
+
     setPointerFromEvent(event);
     raycaster.setFromCamera(pointer, camera);
     dragPlane.constant = -(handlersRef.current.getDragPlaneY?.() ?? 0);
@@ -166,36 +224,62 @@ export function attachDragHandlers({
     handlersRef.current.onItemDrag(itemId, snapped.x, snapped.z);
   };
 
-  const onMouseUp = (): void => {
-    if (!dragTarget) return;
-    const id = dragTarget.userData.id as string;
-    dragTarget = null;
+  const endGesture = (event: PointerEvent): void => {
+    if (event.pointerId !== activePointerId && activePointerId !== null) return;
+    const started = dragStarted;
+    const target = dragTarget;
+    if (activePointerId !== null) {
+      try {
+        canvas.releasePointerCapture(activePointerId);
+      } catch {
+        // Ignore if capture was never held or already released.
+      }
+    }
+    resetDragState();
+    if (!target) return;
+    // A pointerup that never crossed the drag threshold was a select-only
+    // click: no session was opened, so there is nothing to end (see #65).
+    if (!started) return;
     controls.enabled = true;
-    handlersRef.current.onItemDragEnd?.(id);
+    handlersRef.current.onItemDragEnd?.(target.userData.id as string);
   };
 
-  const onMouseLeave = (): void => {
-    handlersRef.current.onItemHover?.(null);
+  const onPointerUp = (event: PointerEvent): void => {
+    endGesture(event);
+  };
+
+  const onPointerCancel = (event: PointerEvent): void => {
+    endGesture(event);
+  };
+
+  const onPointerLeave = (event: PointerEvent): void => {
+    // Hover teardown is a mouse affordance; touch never sets hover state.
+    if (event.pointerType !== 'touch') {
+      handlersRef.current.onItemHover?.(null);
+      lastHoverId = null;
+      canvas.style.cursor = '';
+    }
     handlersRef.current.onFloorPointerLeave?.();
-    canvas.style.cursor = '';
-    if (dragTarget) {
-      const id = dragTarget.userData.id as string;
-      dragTarget = null;
-      controls.enabled = true;
-      handlersRef.current.onItemDragEnd?.(id);
+    // If a real drag is under way we keep it alive: pointer capture routes the
+    // remaining move/up events back to us even outside the canvas. Only a
+    // still-armed (not yet started) drag is abandoned here.
+    if (dragTarget && !dragStarted) {
+      resetDragState();
     }
   };
 
-  canvas.addEventListener('mousedown', onMouseDown);
-  canvas.addEventListener('mousemove', onMouseMove);
-  canvas.addEventListener('mouseup', onMouseUp);
-  canvas.addEventListener('mouseleave', onMouseLeave);
+  canvas.addEventListener('pointerdown', onPointerDown);
+  canvas.addEventListener('pointermove', onPointerMove);
+  canvas.addEventListener('pointerup', onPointerUp);
+  canvas.addEventListener('pointercancel', onPointerCancel);
+  canvas.addEventListener('pointerleave', onPointerLeave);
 
   return () => {
-    canvas.removeEventListener('mousedown', onMouseDown);
-    canvas.removeEventListener('mousemove', onMouseMove);
-    canvas.removeEventListener('mouseup', onMouseUp);
-    canvas.removeEventListener('mouseleave', onMouseLeave);
+    canvas.removeEventListener('pointerdown', onPointerDown);
+    canvas.removeEventListener('pointermove', onPointerMove);
+    canvas.removeEventListener('pointerup', onPointerUp);
+    canvas.removeEventListener('pointercancel', onPointerCancel);
+    canvas.removeEventListener('pointerleave', onPointerLeave);
   };
 }
 


### PR DESCRIPTION
## Summary

Fixes three input/interaction issues on one branch. The canvas interaction layer is migrated from mouse events to **pointer events** so the mouse, touch, and pen paths are unified.

## Changes

### #64 — touch input was completely broken
- `three/drag-handlers.ts`: migrated from `mousedown/move/up/leave` to `pointerdown/move/up/cancel/leave`. On a furniture pointerdown that becomes a drag, the canvas takes `setPointerCapture(pointerId)` so moves/up keep flowing even off-canvas (needed on touch), and OrbitControls is disabled so the camera doesn't also pan/rotate under the drag.
- Hover (which sets React state) is guarded to `event.pointerType !== 'touch'` to avoid touch re-render churn.
- `panels/touch-mode-toggle.tsx`: sets `controls.touches.ONE` (ROTATE for orbit, PAN for center) with two-finger dolly-pan, instead of `controls.mouseButtons` which touch gestures never read. The mode is applied when the scene `isReady` rather than via a fragile 1s `setTimeout` retry. `mouseButtons` is left at OrbitControls defaults, so desktop is unaffected.

### #65 — click-to-select was treated as a zero-distance drag
- `three/drag-handlers.ts`: a pointerdown on a movable item arms a pending drag but only opens the drag session (and calls `onItemDragStart`) after the pointer travels ~4px. A pointerup below the threshold is select-only — no drag session, no drag-end, so no re-lock, no undo entry, and nudge/delete stay unblocked.
- `hooks/use-item-drag.ts`: belt-and-braces — `handleDragEnd` skips `bulkSetPositions` and `setLocked` when the session's latest positions equal its origins (no net movement). Real drags still auto-lock as before.

### #68 — camera-pad zoom slider was direction-inverted
- `panels/camera-pad.tsx`: flipped `onZoom(delta > 0 ? '-' : '+')` to `onZoom(delta > 0 ? '+' : '-')` so dragging toward the "+" endpoint zooms in.

## Verification
- `npm run typecheck` — clean
- `npm run lint` (via the documented `npx eslint --no-eslintrc -c .eslintrc.json` fallback for the nested-worktree @next/next double-load) `--max-warnings=0` — clean
- `npm run build` — succeeds (exit 0)

Mouse drag behaviour is preserved: select on click, drag on move, one dispatch on drop, auto-lock after real drags.

Fixes #64
Fixes #65
Fixes #68