### PR TITLE
Fix opening drag rotation, placement bounds, and CSV injection

### DIFF
--- a/components/room-organizer/hooks/use-item-drag.ts
+++ b/components/room-organizer/hooks/use-item-drag.ts
@@ -1,7 +1,7 @@
 import { useCallback, useRef, type MutableRefObject } from 'react';
 import { CAMERA_BRACKET_ARM } from '../lib/constants';
 import { hasCollisions } from '../lib/geometry';
-import { reseatWallMountedItem, snapWallMountedItem } from '../lib/opening-snap';
+import { isOpening, reseatWallMountedItem, snapOpeningToWall, snapWallMountedItem } from '../lib/opening-snap';
 import type { LayoutActions } from './use-layout-state';
 import type { FloorLayout } from '../lib/types';
 import type * as ThreeNS from 'three';
@@ -185,6 +185,25 @@ export function useItemDrag({
       // position from the drag session — state is one dispatch behind here.
       const item = activeFloor.items.find((entry) => entry.id === id);
       const releasePos = finalPos ?? item?.position;
+      // Doors/windows: snapPosition force-snaps only the POSITION each drag
+      // frame, so an opening dragged from one wall to another keeps its stale
+      // rotation (slab perpendicular, sticking through the new wall — #62).
+      // Re-derive the wall-aligned rotation (and settle the snapped position)
+      // on drop, the same way the camera path does.
+      if (item && isOpening(item.type) && releasePos) {
+        const snapped = snapOpeningToWall({
+          position: releasePos,
+          itemWidth: item.width,
+          roomWidth,
+          roomDepth,
+          interiorWalls: activeFloor.interiorWalls ?? [],
+        });
+        actions.moveItem(id, snapped.position.x, snapped.position.z);
+        if (Math.abs((item.rotation ?? 0) - snapped.rotation) > 1e-3) {
+          actions.setRotation(id, snapped.rotation);
+        }
+        return;
+      }
       if (item?.type === 'security-camera' && releasePos) {
         const snapped = snapWallMountedItem({
           position: releasePos,

--- a/components/room-organizer/hooks/use-item-placement.ts
+++ b/components/room-organizer/hooks/use-item-placement.ts
@@ -127,6 +127,16 @@ export function useItemPlacement({
         actions.updateItem(id, { wallRotation: snapped.rotation });
         return id;
       }
+      // Outdoor items belong outside the building on the ground. `addCatalogItem`
+      // targets the ACTIVE floor, so placing one while an upper floor is active
+      // lands it on that floor's ring hovering mid-air past the wall (#73c).
+      // The drag-plane Y is 0 only on the ground floor, so a non-zero Y means an
+      // upper floor is active — block the placement rather than float the item.
+      // (Re-homing it onto the ground floor would need a reducer change, which a
+      // sibling branch owns, so we no-op instead.)
+      if (catalogItem.category === 'outdoor' && activeFloorY > 0) {
+        return '';
+      }
       // Outdoor items belong outside the building — default them just past
       // the south wall instead of the room centre when no position is given.
       if (catalogItem.category === 'outdoor' && !position) {
@@ -135,7 +145,7 @@ export function useItemPlacement({
       }
       return actions.addCatalogItem(catalogItem, position);
     },
-    [actions, activeFloor.interiorWalls, roomWidth, roomDepth]
+    [actions, activeFloor.interiorWalls, activeFloorY, roomWidth, roomDepth]
   );
 
   return { snapPosition, getDragPlaneY, placeCatalogItem };

--- a/components/room-organizer/lib/file-io.ts
+++ b/components/room-organizer/lib/file-io.ts
@@ -105,8 +105,13 @@ export function downloadInventoryCsv(layout: RoomLayout): void {
 }
 
 function csvField(value: string): string {
-  if (/[",\n]/.test(value)) return `"${value.replace(/"/g, '""')}"`;
-  return value;
+  // Neutralize spreadsheet formula injection: a value beginning with =, +, -,
+  // @, or a tab is interpreted as a formula by Excel/Sheets, so an imported
+  // layout with an item named `=HYPERLINK(...)` would execute on export.
+  // Prefix a single quote to force it to a literal string.
+  const safe = /^[=+\-@\t]/.test(value) ? `'${value}` : value;
+  if (/[",\n\r]/.test(safe)) return `"${safe.replace(/"/g, '""')}"`;
+  return safe;
 }
 
 export async function downloadSceneAsGlb(scene: import('three').Object3D, baseName: string): Promise<void> {

--- a/components/room-organizer/lib/furniture-sets.ts
+++ b/components/room-organizer/lib/furniture-sets.ts
@@ -76,21 +76,86 @@ export const FURNITURE_SETS: readonly FurnitureSet[] = [
 interface BuildSetOptions {
   center?: Vec2;
   idPrefix?: string;
+  /** Interior room width (m). When given, the set is scaled to fit. */
+  roomWidth?: number;
+  /** Interior room depth (m). When given, the set is scaled to fit. */
+  roomDepth?: number;
+}
+
+interface ResolvedSpec {
+  spec: FurnitureSet['items'][number];
+  catalog: CatalogItem;
+}
+
+/**
+ * Compute the shrink factor (≤ 1) needed for the set's overall footprint —
+ * item centres AND their half-extents — to fit inside the room with a small
+ * margin. The set is laid out around (0,0), so its extent is symmetric; we
+ * measure the farthest reach along each axis and scale offsets (not item
+ * sizes) uniformly so items never poke through the walls. Rooms can be as
+ * small as 2×2 m while the sets assume up to ~4.4 m, so without this clamp
+ * items land through the walls (#73).
+ */
+function fitScale(specs: readonly ResolvedSpec[], roomWidth: number, roomDepth: number): number {
+  const MARGIN = 0.1;
+  const usableHalfW = Math.max(0, roomWidth / 2 - MARGIN);
+  const usableHalfD = Math.max(0, roomDepth / 2 - MARGIN);
+  // Scale only the offsets: the item half-extents are fixed, so solve
+  // s·|offset| + half ≤ usable for the tightest item on each axis.
+  let scale = 1;
+  for (const { spec, catalog } of specs) {
+    const rotated = Math.abs(Math.round(((spec.rotation ?? 0) / (Math.PI / 2)) % 2)) === 1;
+    const halfW = (rotated ? catalog.depth : catalog.width) / 2;
+    const halfD = (rotated ? catalog.width : catalog.depth) / 2;
+    if (spec.offset.x !== 0) {
+      scale = Math.min(scale, (usableHalfW - halfW) / Math.abs(spec.offset.x));
+    }
+    if (spec.offset.z !== 0) {
+      scale = Math.min(scale, (usableHalfD - halfD) / Math.abs(spec.offset.z));
+    }
+  }
+  return Math.max(0, Math.min(1, scale));
+}
+
+/**
+ * The largest item in a set must itself fit the room even at zero offset;
+ * if it doesn't, the set can't be placed here at all.
+ */
+export function setFitsRoom(set: FurnitureSet, roomWidth: number, roomDepth: number): boolean {
+  const MARGIN = 0.1;
+  for (const spec of set.items) {
+    const catalog = FURNITURE_CATALOG.find((entry) => entry.type === spec.type);
+    if (!catalog) continue;
+    const rotated = Math.abs(Math.round(((spec.rotation ?? 0) / (Math.PI / 2)) % 2)) === 1;
+    const w = rotated ? catalog.depth : catalog.width;
+    const d = rotated ? catalog.width : catalog.depth;
+    if (w > roomWidth - 2 * MARGIN || d > roomDepth - 2 * MARGIN) return false;
+  }
+  return true;
 }
 
 export function buildFurnitureSet(set: FurnitureSet, options: BuildSetOptions = {}): FurnitureItem[] {
-  const { center = { x: 0, z: 0 }, idPrefix = `${set.key}-${Date.now()}` } = options;
+  const { center = { x: 0, z: 0 }, idPrefix = `${set.key}-${Date.now()}`, roomWidth, roomDepth } = options;
 
-  const items: FurnitureItem[] = [];
-  set.items.forEach((spec, index) => {
+  const specs: ResolvedSpec[] = [];
+  set.items.forEach((spec) => {
     const catalog = FURNITURE_CATALOG.find((entry) => entry.type === spec.type) as CatalogItem | undefined;
     if (!catalog) return;
-    items.push({
-      ...catalog,
-      id: `${idPrefix}-${index}`,
-      position: { x: center.x + spec.offset.x, z: center.z + spec.offset.z },
-      rotation: spec.rotation ?? 0,
-    });
+    specs.push({ spec, catalog });
   });
-  return items;
+
+  // If the room is known and even a single item can't fit, refuse the set
+  // rather than drop pieces through the walls.
+  if (roomWidth != null && roomDepth != null && !setFitsRoom(set, roomWidth, roomDepth)) {
+    return [];
+  }
+
+  const scale = roomWidth != null && roomDepth != null ? fitScale(specs, roomWidth, roomDepth) : 1;
+
+  return specs.map(({ spec, catalog }, index) => ({
+    ...catalog,
+    id: `${idPrefix}-${index}`,
+    position: { x: center.x + spec.offset.x * scale, z: center.z + spec.offset.z * scale },
+    rotation: spec.rotation ?? 0,
+  }));
 }

--- a/components/room-organizer/lib/surprise.ts
+++ b/components/room-organizer/lib/surprise.ts
@@ -1,5 +1,5 @@
 import { FURNITURE_CATALOG } from './constants';
-import { buildFurnitureSet, FURNITURE_SETS } from './furniture-sets';
+import { buildFurnitureSet, FURNITURE_SETS, setFitsRoom, type FurnitureSet } from './furniture-sets';
 import type { CatalogItem, FurnitureItem } from './types';
 
 const DECOR_TYPES = ['plant', 'flowerpot', 'rug', 'painting', 'vase', 'lamp', 'floor-lamp', 'mirror'] as const;
@@ -27,7 +27,11 @@ export function surpriseLayout(options: SurpriseOptions): FurnitureItem[] {
   const rng = mulberry32(seed >>> 0);
 
   const set = chooseSet(roomWidth, roomDepth, rng);
-  const setItems = buildFurnitureSet(set, { center: { x: 0, z: 0 }, idPrefix: `surprise-set-${seed}` });
+  // A set is only chosen when at least one fits, but pass the room dims so
+  // buildFurnitureSet also scales its offsets in to keep pieces off the walls.
+  const setItems = set
+    ? buildFurnitureSet(set, { center: { x: 0, z: 0 }, idPrefix: `surprise-set-${seed}`, roomWidth, roomDepth })
+    : [];
 
   const decor: FurnitureItem[] = [];
   const decorCount = 3 + Math.floor(rng() * 4);
@@ -61,16 +65,22 @@ function chooseSet(width: number, depth: number, rng: () => number) {
     ['kitchen-line', width >= 4 ? 2 : 0.5],
   ];
 
-  const totalWeight = weighted.reduce((sum, [, w]) => sum + w, 0);
+  // Drop any candidate whose largest item can't fit the room, so a small
+  // room never gets a set that would drop pieces through the walls (#73).
+  const eligible = weighted
+    .map(([key, weight]) => ({ set: FURNITURE_SETS.find((set) => set.key === key), weight }))
+    .filter((entry): entry is { set: FurnitureSet; weight: number } =>
+      entry.set != null && entry.weight > 0 && setFitsRoom(entry.set, width, depth)
+    );
+  if (eligible.length === 0) return null;
+
+  const totalWeight = eligible.reduce((sum, { weight }) => sum + weight, 0);
   let pick = rng() * totalWeight;
-  for (const [key, weight] of weighted) {
+  for (const { set, weight } of eligible) {
     pick -= weight;
-    if (pick <= 0) {
-      const found = FURNITURE_SETS.find((set) => set.key === key);
-      if (found) return found;
-    }
+    if (pick <= 0) return set;
   }
-  return FURNITURE_SETS[0]!;
+  return eligible[eligible.length - 1]!.set;
 }
 
 function eligibleDecor(budget: number): readonly CatalogItem[] {

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -190,7 +190,14 @@ export function SidebarDrawer({
 
               <SetsPanel
                 onAddSet={(set) => {
-                  const items = buildFurnitureSet(set);
+                  // Scale/refuse the set to the current room so pieces don't
+                  // land through the walls in small rooms (#73). An empty
+                  // result means the set can't fit here.
+                  const items = buildFurnitureSet(set, {
+                    roomWidth: layout.width,
+                    roomDepth: layout.height,
+                  });
+                  if (items.length === 0) return;
                   actions.addItems(items);
                   const last = items[items.length - 1];
                   if (last) setSelectedItemId(last.id);


### PR DESCRIPTION
## Summary

Three fixes on one branch.

### #62 — dragging a door/window to a different wall keeps its stale rotation
`snapPosition` force-snaps only an opening's position each drag frame; rotation was previously only re-derived on drop for security cameras. A door placed on the north wall (rotation 0) then dragged to the east wall stayed at rotation 0 — slab perpendicular, sticking through the wall. `handleDragEnd` now runs `snapOpeningToWall` for `isOpening(type)` items on drop and applies the snapped position and rotation, the same way the camera path already does.

### #73 — placement bounds
- `buildFurnitureSet` now accepts room dimensions, scales its offsets inward to fit the room, and refuses a set whose largest item can't fit (returns an empty array). Callers in `sidebar-drawer.tsx` and `surprise.ts` pass the room size.
- `surpriseLayout`'s set selection (`chooseSet`) filters out candidates whose largest item exceeds the room, so a 2×2 m room never gets an oversized set.
- Outdoor items on upper floors: `placeCatalogItem` blocks outdoor-category placement while an upper floor is active (drag-plane `Y > 0`) instead of dropping the item onto the active floor's ring hovering mid-air past the wall.

### #72 — CSV formula injection via item/floor names
`csvField` now prefixes a single quote when a value begins with `=`, `+`, `-`, `@`, or tab, so an imported layout with an item named `=HYPERLINK(...)` can't execute as a spreadsheet formula on export. Carriage return was also added to the quote-trigger regex.

## Verification
- `npm run typecheck` — clean
- `npm run lint` — clean (via `npx eslint --no-eslintrc -c .eslintrc.json` fallback; the default `npm run lint` hits the known nested-worktree `@next/next` double-load)
- `npm run build` — succeeds

## Notes
Re-homing an outdoor item onto the ground floor when an upper floor is active would require a `layout-reducer.ts` change (owned by a sibling branch), so the placement is a no-op in that case rather than being relocated.

Fixes #62
Fixes #73
Fixes #72