### PR TITLE
Fix multi-select group ops, harden schema, repair keyboard shortcuts

### DIFF
--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -1,4 +1,4 @@
-import { MAX_FLOORS } from '../lib/constants';
+import { MAX_FLOORS, MAX_ROOM_DIMENSION } from '../lib/constants';
 import type {
   CatalogItem,
   FloorLayout,
@@ -238,14 +238,49 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
       }));
 
     case 'rotateSelection':
-      return withActiveFloor(state, (floor) => ({
-        ...floor,
-        items: floor.items.map((item) =>
-          action.ids.has(item.id)
-            ? { ...item, rotation: ((item.rotation ?? 0) + action.radians) % (Math.PI * 2) }
-            : item
-        ),
-      }));
+      return withActiveFloor(state, (floor) => {
+        // Rotate the whole group about its centroid: each selected item both
+        // spins in place (its own rotation) AND orbits the centroid, so the
+        // arrangement is preserved instead of every piece twisting individually.
+        const selected = floor.items.filter(
+          (item) => action.ids.has(item.id) && item.position
+        );
+        if (selected.length === 0) return floor;
+        let cx = 0;
+        let cz = 0;
+        for (const item of selected) {
+          cx += item.position!.x;
+          cz += item.position!.z;
+        }
+        cx /= selected.length;
+        cz /= selected.length;
+        // `group.rotation.y = rotation` (Three RY) maps a local offset (dx, dz)
+        // to world (dx·cosθ + dz·sinθ, −dx·sinθ + dz·cosθ). Use that same matrix
+        // for the orbit so the position sweep matches the rendered spin.
+        const theta = action.radians;
+        const cos = Math.cos(theta);
+        const sin = Math.sin(theta);
+        return {
+          ...floor,
+          items: floor.items.map((item) => {
+            if (!action.ids.has(item.id)) return item;
+            const nextRotation = ((item.rotation ?? 0) + theta) % (Math.PI * 2);
+            if (!item.position) {
+              return { ...item, rotation: nextRotation };
+            }
+            const dx = item.position.x - cx;
+            const dz = item.position.z - cz;
+            return {
+              ...item,
+              rotation: nextRotation,
+              position: {
+                x: cx + dx * cos + dz * sin,
+                z: cz - dx * sin + dz * cos,
+              },
+            };
+          }),
+        };
+      });
 
     case 'setLockAll':
       return withActiveFloor(state, (floor) => ({
@@ -411,17 +446,24 @@ function patchItem(
   }));
 }
 
+function clampRoomDimension(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) return 1;
+  return Math.min(value, MAX_ROOM_DIMENSION);
+}
+
 function normaliseLayout(layout: RoomLayout): RoomLayout {
-  if (layout.floors.length === 0) {
-    return { ...layout, floors: [INITIAL_GROUND_FLOOR] };
-  }
-  return {
-    ...layout,
-    floors: layout.floors.map((floor) => ({
-      ...floor,
-      floorColor: floor.floorColor || '#c9a57d',
-    })),
-  };
+  // Defense in depth: even after schema validation, clamp dimensions and floor
+  // count here so any layout reaching the reducer stays within safe bounds.
+  const width = clampRoomDimension(layout.width);
+  const height = clampRoomDimension(layout.height);
+  const floors =
+    layout.floors.length === 0
+      ? [INITIAL_GROUND_FLOOR]
+      : layout.floors.slice(0, MAX_FLOORS).map((floor) => ({
+          ...floor,
+          floorColor: floor.floorColor || '#c9a57d',
+        }));
+  return { ...layout, width, height, floors };
 }
 
 function clampActiveIndex(index: number, floorCount: number): number {

--- a/components/room-organizer/hooks/use-keyboard-shortcuts.ts
+++ b/components/room-organizer/hooks/use-keyboard-shortcuts.ts
@@ -73,7 +73,12 @@ export function useKeyboardShortcuts({
 
       // Everything below is a bare single-key shortcut. Never swallow browser
       // shortcuts like Cmd/Ctrl+F (find), Ctrl+R (reload), or Cmd+M.
-      if (ctrlOrCmd || event.altKey) return;
+      // AltGr is reported as ctrlKey+altKey on Windows, so a plain guard on
+      // those modifiers makes AltGr-produced keys (e.g. `[`/`]` on German /
+      // French / Nordic layouts) unreachable. Skip the guard when AltGraph is
+      // actually engaged — real Ctrl/Cmd chords never set the AltGraph state.
+      const altGraph = event.getModifierState('AltGraph');
+      if (!altGraph && (ctrlOrCmd || event.altKey)) return;
 
       if (event.key === 'f' && selectedItem) {
         event.preventDefault();
@@ -98,7 +103,7 @@ export function useKeyboardShortcuts({
         return;
       }
 
-      if (event.key === 'r' && selectedItem) {
+      if (event.key.toLowerCase() === 'r' && selectedItem) {
         event.preventDefault();
         if (event.shiftKey) {
           // Fine-grained 15° rotations when Shift is held.

--- a/components/room-organizer/lib/constants.ts
+++ b/components/room-organizer/lib/constants.ts
@@ -9,6 +9,14 @@ export const CURRENCY_SYMBOL = '$';
 
 export const MAX_FLOORS = 4;
 
+/**
+ * Upper bound (metres) for a room's width/height. The editor UI tops out at
+ * 20m; this generous defensive cap keeps ingested/corrupt layouts from feeding
+ * absurd or non-positive dimensions into PlaneGeometry, texture fitting, and
+ * collision math while still accepting any realistic custom layout.
+ */
+export const MAX_ROOM_DIMENSION = 100;
+
 /** How far a bracketed security camera stands off the wall, in metres. */
 export const CAMERA_BRACKET_ARM = 0.22;
 

--- a/components/room-organizer/lib/schema.ts
+++ b/components/room-organizer/lib/schema.ts
@@ -1,6 +1,8 @@
-import type { FloorLayout, FloorPlanFitMode, FurnitureItem, RoomLayout } from './types';
+import { MAX_FLOORS, MAX_ROOM_DIMENSION } from './constants';
+import type { FloorLayout, FloorPlanFitMode, FurnitureItem, RoofStyle, RoomLayout } from './types';
 
 const FIT_MODES: readonly FloorPlanFitMode[] = ['stretch', 'cover', 'contain'];
+const ROOF_STYLES: readonly RoofStyle[] = ['none', 'flat', 'gable', 'hipped'];
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
@@ -8,6 +10,19 @@ function isFiniteNumber(value: unknown): value is number {
 
 function isPositiveNumber(value: unknown): value is number {
   return isFiniteNumber(value) && value > 0;
+}
+
+/**
+ * A room dimension must be finite AND strictly positive (0/negative break
+ * PlaneGeometry, fitTextureToRoom, and collision math) and sanely bounded so a
+ * corrupt value can't blow up the geometry.
+ */
+function isRoomDimension(value: unknown): value is number {
+  return isPositiveNumber(value) && value <= MAX_ROOM_DIMENSION;
+}
+
+function isOptionalBoolean(value: unknown): boolean {
+  return value === undefined || typeof value === 'boolean';
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {
@@ -41,6 +56,13 @@ export function isFurnitureItem(value: unknown): value is FurnitureItem {
   if (v.visionRange !== undefined && !isFiniteNumber(v.visionRange)) return false;
   if (v.visionFov !== undefined && !isFiniteNumber(v.visionFov)) return false;
   if (v.wallRotation !== undefined && !isFiniteNumber(v.wallRotation)) return false;
+  // Booleans must be real booleans: a corrupt `locked:"no"` reads truthy for
+  // keyboard-delete guards yet fails `=== true` drag checks, desyncing the two.
+  if (!isOptionalBoolean(v.locked)) return false;
+  if (!isOptionalBoolean(v.mirrored)) return false;
+  if (!isOptionalBoolean(v.cameraBracket)) return false;
+  if (!isOptionalBoolean(v.isCCTV)) return false;
+  if (!isOptionalBoolean(v.isWiFiAccessPoint)) return false;
   return true;
 }
 
@@ -84,9 +106,14 @@ export function isRoomLayout(value: unknown): value is RoomLayout {
   const v = value;
 
   if (typeof v.name !== 'string') return false;
-  if (!isFiniteNumber(v.width)) return false;
-  if (!isFiniteNumber(v.height)) return false;
-  if (!Array.isArray(v.floors) || v.floors.length === 0 || !v.floors.every(isFloorLayout)) {
+  if (!isRoomDimension(v.width)) return false;
+  if (!isRoomDimension(v.height)) return false;
+  if (
+    !Array.isArray(v.floors) ||
+    v.floors.length === 0 ||
+    v.floors.length > MAX_FLOORS ||
+    !v.floors.every(isFloorLayout)
+  ) {
     return false;
   }
 
@@ -102,7 +129,7 @@ export function isRoomLayout(value: unknown): value is RoomLayout {
   if (v.roof !== undefined) {
     if (!isPlainObject(v.roof)) return false;
     const roof = v.roof;
-    if (typeof roof.style !== 'string') return false;
+    if (!ROOF_STYLES.includes(roof.style as RoofStyle)) return false;
     if (roof.color !== undefined && typeof roof.color !== 'string') return false;
   }
 
@@ -141,8 +168,8 @@ function isLegacySingleFloorLayout(value: unknown): value is LegacySingleFloorLa
   const v = value;
   return (
     typeof v.name === 'string' &&
-    isFiniteNumber(v.width) &&
-    isFiniteNumber(v.height) &&
+    isRoomDimension(v.width) &&
+    isRoomDimension(v.height) &&
     typeof v.floorColor === 'string' &&
     Array.isArray(v.items) &&
     v.items.every(isFurnitureItem) &&

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -267,7 +267,20 @@ export function RoomOrganizer(): JSX.Element {
       if (current === null) {
         return id;
       }
-      if (current === id) return current;
+      if (current === id) {
+        // Toggling the primary off: promote an extra to primary (keeping the
+        // rest of the multi-select intact) or clear the selection entirely.
+        let promoted: string | null = null;
+        setExtraSelectedIds((extras) => {
+          if (extras.size === 0) return extras;
+          const next = new Set(extras);
+          const [first] = next;
+          promoted = first ?? null;
+          if (promoted !== null) next.delete(promoted);
+          return next;
+        });
+        return promoted;
+      }
       setExtraSelectedIds((extras) => {
         const next = new Set(extras);
         if (next.has(id)) next.delete(id);
@@ -381,6 +394,30 @@ export function RoomOrganizer(): JSX.Element {
     setSelectedItemId(null);
     setExtraSelectedIds(new Set());
   }, [actions, activeFloor.items, allSelectedIds]);
+
+  // Duplicate the current selection. For a multi-select every selected item is
+  // copied (each offset by the reducer) and the copies become the new
+  // selection, so the result is a clean set of duplicates rather than one new
+  // copy mixed in with the stale originals' ids.
+  const duplicateSelected = useCallback(
+    (primaryId: string) => {
+      if (allSelectedIds.size > 1 && allSelectedIds.has(primaryId)) {
+        // Duplicate the primary first so it becomes the new primary, then the
+        // remaining selected items in a stable order.
+        const others = Array.from(allSelectedIds).filter((id) => id !== primaryId);
+        const newPrimary = actions.duplicateItem(primaryId);
+        const newExtras = others.map((id) => actions.duplicateItem(id));
+        setSelectedItemId(newPrimary);
+        setExtraSelectedIds(new Set(newExtras));
+        return;
+      }
+      const newId = actions.duplicateItem(primaryId);
+      setSelectedItemId(newId);
+      // Clear stale extras so the selection is only the fresh copy.
+      setExtraSelectedIds(new Set());
+    },
+    [actions, allSelectedIds]
+  );
 
   const history = useHistory(layout, useCallback(
     (snapshot: RoomLayout) => {
@@ -545,10 +582,7 @@ export function RoomOrganizer(): JSX.Element {
           removeItem(id);
         }
       },
-      duplicateItem: (id: string) => {
-        const newId = actions.duplicateItem(id);
-        setSelectedItemId(newId);
-      },
+      duplicateItem: duplicateSelected,
       rotateItem: rotateItemHandler,
       rotateItemBy: (id: string, radians: number) => {
         if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
@@ -601,6 +635,7 @@ export function RoomOrganizer(): JSX.Element {
     [
       removeItem,
       removeSelected,
+      duplicateSelected,
       allSelectedIds,
       actions,
       activeFloor.items,
@@ -790,10 +825,7 @@ export function RoomOrganizer(): JSX.Element {
             playCue('rotate');
           }}
           onToggleCameraBracket={toggleCameraBracket}
-          onDuplicate={(id: string) => {
-            const newId = actions.duplicateItem(id);
-            setSelectedItemId(newId);
-          }}
+          onDuplicate={duplicateSelected}
           onRemove={removeItem}
           onClose={() => {
             setSelectedItemId(null);


### PR DESCRIPTION
Fixes three issues on one branch.

## #69 — multi-select gaps
- **Group rotate** (`rotateSelection`): now rotates each selected item's **position** about the selection centroid in addition to adding the angle to its own rotation, so a group of items rotates rigidly instead of every piece twisting in place and destroying the arrangement. The orbit uses the same matrix Three applies for `group.rotation.y` (`x' = cx + dx·cosθ + dz·sinθ`, `z' = cz − dx·sinθ + dz·cosθ`), so the position sweep matches the rendered spin direction.
- **Duplicate with a multi-select**: now copies every selected item (each offset by the reducer) and selects the copies. A single-select duplicate clears stale `extraSelectedIds`, so the selection is never a mix of the new copy and old ids.
- **Ctrl-click deselect of the primary**: toggling the primary item off now promotes an extra to primary (or clears the selection) instead of being a no-op.

## #77 — schema hardening round 2
- Room `width`/`height` must be finite, strictly positive, and `≤ MAX_ROOM_DIMENSION` (0/negative broke PlaneGeometry, texture fitting, and collision math).
- `roof.style` validated against the `RoofStyle` union (`none`/`flat`/`gable`/`hipped`).
- Floor count above `MAX_FLOORS` is rejected on parse.
- `locked`/`mirrored`/`cameraBracket`/`isCCTV`/`isWiFiAccessPoint` are validated as real booleans, so a corrupt `locked:"no"` can no longer read truthy for keyboard-delete yet fail `=== true` drag checks.
- `normaliseLayout` clamps dimensions and floor count as defense in depth.
- Legacy single-floor migration remains non-destructive (and now also validates dimensions).

## #76 — keyboard: Shift+R dead code + AltGr layouts
- `event.key.toLowerCase() === 'r'` so the Shift+R 15° fine-rotate branch is reachable (with Shift the key is `R`).
- AltGr (reported as `ctrlKey+altKey` on Windows) no longer blocks the `[`/`]` shortcuts on German/French/Nordic layouts: the modifier guard is skipped when `event.getModifierState('AltGraph')` is true. Real Ctrl+R (reload) and Cmd+F (find) still pass through to the browser.

## Verification
- `npm run typecheck` — clean
- ESLint (fallback `npx eslint --no-eslintrc -c .eslintrc.json ...` due to the nested-worktree @next/next double-load) — clean, `--max-warnings=0`
- `npm run build` — compiled and exported successfully

Fixes #69
Fixes #77
Fixes #76