### PR TITLE
Fix 2D view scaling, stale selection outlines, and wall cutouts

### DIFF
--- a/components/room-organizer/canvas-2d/render.ts
+++ b/components/room-organizer/canvas-2d/render.ts
@@ -15,6 +15,25 @@ export interface Render2DOptions {
 }
 
 const PADDING = 60;
+
+// Decoded floor-plan image cache, keyed on the data-URL. Decoding a multi-MB
+// data-URL is async: the first render kicks off the load and re-renders once
+// the pixels are ready (so the image never paints over grid/furniture drawn
+// after it). Subsequent renders reuse the cached, already-decoded Image and
+// draw it synchronously in the correct layer order.
+let floorPlanImageCache: { url: string; image: HTMLImageElement } | null = null;
+
+/**
+ * Callback the render effect installs so the async floor-plan decode can
+ * trigger a full repaint (redrawing the whole scene in the right layer order)
+ * once the image is ready. Set via {@link setFloorPlanRepaintHandler}.
+ */
+let requestRepaint: (() => void) | null = null;
+
+/** Register the repaint handler used when an async floor-plan image finishes loading. */
+export function setFloorPlanRepaintHandler(handler: (() => void) | null): void {
+  requestRepaint = handler;
+}
 const WIFI_RING_FILLS = ['rgba(0, 255, 0, 0.15)', 'rgba(255, 255, 0, 0.10)', 'rgba(255, 102, 0, 0.08)'];
 const WIFI_RING_STROKES = ['rgba(0, 255, 0, 0.4)', 'rgba(255, 255, 0, 0.3)', 'rgba(255, 102, 0, 0.2)'];
 const CCTV_RING_FILLS = ['rgba(0, 136, 255, 0.12)', 'rgba(0, 221, 255, 0.08)', 'rgba(136, 0, 255, 0.06)'];
@@ -25,21 +44,31 @@ export function render2DTopDown(options: Render2DOptions): void {
   const ctx = canvas.getContext('2d');
   if (!ctx) return;
 
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  // The backing store is sized clientWidth/clientHeight × devicePixelRatio (by
+  // the ResizeObserver in use-scene-effects), but all drawing below works in
+  // CSS-pixel (logical) coordinates. Reset the transform to a DPR scale so 1
+  // logical unit maps to `dpr` device pixels — that keeps strokes and text
+  // crisp on retina while the layout maths stays resolution-independent.
+  const dpr = canvas.width / Math.max(1, canvas.clientWidth || canvas.width);
+  const viewWidth = canvas.width / dpr;
+  const viewHeight = canvas.height / dpr;
+
+  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  ctx.clearRect(0, 0, viewWidth, viewHeight);
 
   const scale = Math.min(
-    (canvas.width - PADDING * 2) / layout.width,
-    (canvas.height - PADDING * 2) / layout.height
+    (viewWidth - PADDING * 2) / layout.width,
+    (viewHeight - PADDING * 2) / layout.height
   );
-  const offsetX = (canvas.width - layout.width * scale) / 2;
-  const offsetY = (canvas.height - layout.height * scale) / 2;
+  const offsetX = (viewWidth - layout.width * scale) / 2;
+  const offsetY = (viewHeight - layout.height * scale) / 2;
 
   drawFloor(ctx, layout, floor, offsetX, offsetY, scale);
   drawGrid(ctx, layout, offsetX, offsetY, scale);
   drawRoomOutline(ctx, layout, offsetX, offsetY, scale);
 
   if (options.showHeatmap) {
-    drawHeatmap(ctx, layout, floor.items, offsetX, offsetY, scale);
+    drawHeatmap(ctx, layout, floor.items, offsetX, offsetY, scale, viewWidth, viewHeight);
   }
 
   if (options.showWiFiSignals) {
@@ -62,16 +91,33 @@ function drawFloor(
   offsetY: number,
   scale: number
 ): void {
-  if (layout.floorPlanImage) {
-    const img = new Image();
-    img.src = layout.floorPlanImage;
-    const draw = () => {
+  const url = layout.floorPlanImage;
+  if (url) {
+    // Fill the floor colour first so there's a base while (or if) the image is
+    // still decoding — avoids a flash of the raw canvas background.
+    ctx.fillStyle = floor.floorColor;
+    ctx.fillRect(offsetX, offsetY, layout.width * scale, layout.height * scale);
+
+    if (floorPlanImageCache?.url === url && floorPlanImageCache.image.complete) {
+      const img = floorPlanImageCache.image;
       ctx.globalAlpha = layout.floorPlanOpacity ?? 1;
       ctx.drawImage(img, offsetX, offsetY, layout.width * scale, layout.height * scale);
       ctx.globalAlpha = 1;
-    };
-    if (img.complete) draw();
-    else img.onload = draw;
+      return;
+    }
+
+    // Not cached (or a different plan): decode once, then trigger a full
+    // repaint so grid/furniture end up on top of the image instead of the
+    // async onload painting over them.
+    if (floorPlanImageCache?.url !== url) {
+      const img = new Image();
+      floorPlanImageCache = { url, image: img };
+      img.onload = () => {
+        // Ignore stale loads if the plan changed again before this resolved.
+        if (floorPlanImageCache?.image === img) requestRepaint?.();
+      };
+      img.src = url;
+    }
   } else {
     ctx.fillStyle = floor.floorColor;
     ctx.fillRect(offsetX, offsetY, layout.width * scale, layout.height * scale);
@@ -232,7 +278,9 @@ function drawHeatmap(
   items: readonly FurnitureItem[],
   offsetX: number,
   offsetY: number,
-  scale: number
+  scale: number,
+  viewWidth: number,
+  viewHeight: number
 ): void {
   const COLS = 20;
   const ROWS = 20;
@@ -291,15 +339,23 @@ function drawHeatmap(
   }
   ctx.restore();
 
-  drawHeatmapLegend(ctx, max / cellArea);
+  drawHeatmapLegend(ctx, max / cellArea, viewWidth, viewHeight);
 }
 
-function drawHeatmapLegend(ctx: CanvasRenderingContext2D, maxPricePerSqM: number): void {
+function drawHeatmapLegend(
+  ctx: CanvasRenderingContext2D,
+  maxPricePerSqM: number,
+  viewWidth: number,
+  viewHeight: number
+): void {
   const padding = 12;
   const barWidth = 140;
   const barHeight = 12;
-  const x = ctx.canvas.width - barWidth - padding;
-  const y = ctx.canvas.height - barHeight - padding - 18;
+  // Position in logical (CSS-pixel) space — ctx is DPR-scaled, so using the raw
+  // backing-store size (ctx.canvas.width) would push the legend off-screen on
+  // retina.
+  const x = viewWidth - barWidth - padding;
+  const y = viewHeight - barHeight - padding - 18;
 
   ctx.save();
   ctx.fillStyle = 'rgba(255,255,255,0.9)';

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, type RefObject, type MutableRefObject } from 'react';
-import { render2DTopDown } from '../canvas-2d/render';
+import { render2DTopDown, setFloorPlanRepaintHandler } from '../canvas-2d/render';
 import { hasCollisions } from '../lib/geometry';
 import { FLOOR_HEIGHT_METERS } from '../lib/types';
 import { disposeObject, removeAndDispose } from '../three/builder-utils';
@@ -164,48 +164,6 @@ export function useSceneEffects({
     renderInteriorWallPreview(THREE, scene, wallDraft, wallSnapResult.point, activeFloorY);
   }, [isReady, invalidate, threeModuleRef, sceneRef, view.drawWallMode, wallDraft, wallSnapResult, activeFloorY]);
 
-  // Cyan outline on selected wall
-  useEffect(() => {
-    invalidate();
-    if (!isReady) return undefined;
-    const THREE = threeModuleRef.current;
-    const scene = sceneRef.current;
-    if (!THREE || !scene) return undefined;
-
-    for (const child of [...scene.children]) {
-      if (child.userData.type === 'wall-selection') removeAndDispose(scene, child);
-    }
-    if (!selectedWall) return undefined;
-
-    const tag = selectedWall.kind === 'interior' ? 'interior-wall' : 'wall';
-    const wallMesh = scene.children.find(
-      (obj) => obj.userData.type === tag && obj.userData.wallId === selectedWall.id
-    ) as ThreeNS.Mesh | undefined;
-    if (!wallMesh) return undefined;
-
-    const edges = new THREE.EdgesGeometry(wallMesh.geometry);
-    const material = new THREE.LineBasicMaterial({
-      color: 0x7ff3ff,
-      transparent: true,
-      opacity: 0.95,
-      depthTest: false,
-    });
-    const outline = new THREE.LineSegments(edges, material);
-    outline.position.copy(wallMesh.position);
-    outline.rotation.copy(wallMesh.rotation);
-    outline.scale.copy(wallMesh.scale);
-    outline.renderOrder = 999;
-    outline.userData.type = 'wall-selection';
-    scene.add(outline);
-    invalidate();
-
-    return () => {
-      scene.remove(outline);
-      edges.dispose();
-      material.dispose();
-    };
-  }, [isReady, invalidate, threeModuleRef, sceneRef, rendererRef, cameraRef, selectedWall, layout.floors, activeFloorIndex]);
-
   // Build floor + walls
   useEffect(() => {
     invalidate();
@@ -222,7 +180,13 @@ export function useSceneEffects({
 
     for (const { floor, index } of floorsToRender) {
       const isActive = index === activeFloorIndex;
-      const wallOpenings = computeWallOpenings(floor.items, layout.width, layout.height);
+      const wallOpenings = computeWallOpenings(
+        floor.items,
+        layout.width,
+        layout.height,
+        3,
+        floor.interiorWalls ?? []
+      );
       // Stairs on the floor below create openings in this floor's plane.
       const floorBelow = index > 0 ? layout.floors[index - 1] : undefined;
       const floorOpenings = computeFloorOpenings(floorBelow);
@@ -382,10 +346,14 @@ export function useSceneEffects({
       outline.userData.type = 'selection-outline';
       group.add(outline);
     }
+    // view.showAllFloors is included because the furniture effect rebuilds all
+    // groups when it toggles (destroying the outline LineSegments children); the
+    // outline effect must re-run afterward to reattach outlines, otherwise a
+    // selected item is left with no outline after a Show-All-Floors toggle.
   }, [
     isReady, invalidate, threeModuleRef, sceneRef,
     activeFloor, activeFloorIndex, layout.width, layout.height,
-    selectedItemId, extraSelectedIds, highlightedIds,
+    selectedItemId, extraSelectedIds, highlightedIds, view.showAllFloors,
   ]);
 
   // Wi-Fi rings + camera vision cones. Independently tagged overlays, so
@@ -474,14 +442,68 @@ export function useSceneEffects({
         THREE, scene, walls,
         index * FLOOR_HEIGHT_METERS,
         view.showAllFloors && !isActive ? 0.25 : undefined,
-        { openingCandidates: floor.items }
+        { openingCandidates: floor.items, roomWidth: layout.width, roomDepth: layout.height }
       );
     }
     // layout.floors/activeFloor are read for the wall segments and the
     // door/window opening candidates only; the two keys cover exactly that,
     // so a furniture edit doesn't re-extrude every interior wall.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isReady, invalidate, threeModuleRef, sceneRef, interiorWallsKey, wallOpeningsKey, activeFloorIndex, view.showAllFloors]);
+  }, [isReady, invalidate, threeModuleRef, sceneRef, interiorWallsKey, wallOpeningsKey, activeFloorIndex, view.showAllFloors, layout.width, layout.height]);
+
+  // Cyan outline on selected wall. Declared AFTER the shell + interior-wall
+  // rebuild effects and keyed on the same rebuild keys, so it always snapshots
+  // the CURRENT wall mesh. If it ran before the rebuilds (or without those
+  // keys) a hidden/moved/re-extruded wall would leave a stale floating outline.
+  useEffect(() => {
+    invalidate();
+    if (!isReady) return undefined;
+    const THREE = threeModuleRef.current;
+    const scene = sceneRef.current;
+    if (!THREE || !scene) return undefined;
+
+    for (const child of [...scene.children]) {
+      if (child.userData.type === 'wall-selection') removeAndDispose(scene, child);
+    }
+    if (!selectedWall) return undefined;
+
+    const tag = selectedWall.kind === 'interior' ? 'interior-wall' : 'wall';
+    const wallMesh = scene.children.find(
+      (obj) => obj.userData.type === tag && obj.userData.wallId === selectedWall.id
+    ) as ThreeNS.Mesh | undefined;
+    if (!wallMesh) return undefined;
+
+    const edges = new THREE.EdgesGeometry(wallMesh.geometry);
+    const material = new THREE.LineBasicMaterial({
+      color: 0x7ff3ff,
+      transparent: true,
+      opacity: 0.95,
+      depthTest: false,
+    });
+    const outline = new THREE.LineSegments(edges, material);
+    outline.position.copy(wallMesh.position);
+    outline.rotation.copy(wallMesh.rotation);
+    outline.scale.copy(wallMesh.scale);
+    outline.renderOrder = 999;
+    outline.userData.type = 'wall-selection';
+    scene.add(outline);
+    invalidate();
+
+    return () => {
+      scene.remove(outline);
+      edges.dispose();
+      material.dispose();
+    };
+    // Keyed on the shell + interior-wall rebuild keys (not layout.floors
+    // identity) so the outline re-snapshots the fresh mesh after any wall
+    // rebuild, hide, or move — without rebuilding on unrelated furniture edits.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    isReady, invalidate, threeModuleRef, sceneRef, rendererRef, cameraRef,
+    selectedWall, activeFloorIndex,
+    shellFinishesKey, wallOpeningsKey, interiorWallsKey,
+    layout.width, layout.height, view.showAllFloors, view.wallDisplay,
+  ]);
 
   // Measurement markers
   useEffect(() => {
@@ -539,22 +561,52 @@ export function useSceneEffects({
     });
   }, [isReady, invalidate, threeModuleRef, sceneRef, layout.roof, layout.width, layout.height, layout.floors.length, activeFloorIndex, view.showAllFloors]);
 
-  // 2D top-down view
+  // 2D top-down view. The backing store is sized to the container's
+  // clientWidth/clientHeight × devicePixelRatio (via a ResizeObserver) so the
+  // aspect ratio matches the on-screen element (circles stay circular) and the
+  // render is crisp on retina; a resize re-paints. The floor-plan repaint
+  // handler lets an async image decode trigger a full repaint in the correct
+  // layer order.
   useEffect(() => {
     invalidate();
-    if (!view.view2D) return;
+    if (!view.view2D) return undefined;
     const canvas = canvas2DRef.current;
-    if (!canvas) return;
-    render2DTopDown({
-      canvas,
-      layout,
-      floor: activeFloor,
-      selectedItemId,
-      showMeasurements: view.showMeasurements,
-      showWiFiSignals: view.showWiFiSignals,
-      showHeatmap: view.showHeatmap,
-      hasCollision: (item) => hasCollisions(item, activeFloor.items, layout.width, layout.height),
-    });
+    if (!canvas) return undefined;
+
+    const paint = () => {
+      const width = canvas.clientWidth;
+      const height = canvas.clientHeight;
+      if (width === 0 || height === 0) return;
+      const dpr = window.devicePixelRatio || 1;
+      const backingWidth = Math.round(width * dpr);
+      const backingHeight = Math.round(height * dpr);
+      // Only resize the backing store when it actually changes — assigning
+      // canvas.width/height clears the canvas even when the value is unchanged.
+      if (canvas.width !== backingWidth) canvas.width = backingWidth;
+      if (canvas.height !== backingHeight) canvas.height = backingHeight;
+
+      render2DTopDown({
+        canvas,
+        layout,
+        floor: activeFloor,
+        selectedItemId,
+        showMeasurements: view.showMeasurements,
+        showWiFiSignals: view.showWiFiSignals,
+        showHeatmap: view.showHeatmap,
+        hasCollision: (item) => hasCollisions(item, activeFloor.items, layout.width, layout.height),
+      });
+    };
+
+    setFloorPlanRepaintHandler(paint);
+    paint();
+
+    const observer = new ResizeObserver(paint);
+    observer.observe(canvas);
+
+    return () => {
+      observer.disconnect();
+      setFloorPlanRepaintHandler(null);
+    };
   }, [invalidate, canvas2DRef, view.view2D, view.showMeasurements, view.showWiFiSignals, view.showHeatmap, layout, activeFloor, selectedItemId]);
 }
 

--- a/components/room-organizer/panels/viewport.tsx
+++ b/components/room-organizer/panels/viewport.tsx
@@ -68,10 +68,15 @@ export function Viewport(props: ViewportProps): JSX.Element {
          * can attach its renderer before isReady becomes true. The
          * inactive canvas is hidden, not unmounted.
          */}
+        {/*
+         * No fixed width/height attributes: the 2D backing store is sized to
+         * clientWidth/clientHeight × devicePixelRatio by a ResizeObserver in
+         * use-scene-effects, so the canvas stays crisp on retina and its aspect
+         * ratio matches the container (circles stay circular). CSS stretches the
+         * element to fill the viewport.
+         */}
         <canvas
           ref={props.canvas2DRef}
-          width={800}
-          height={600}
           className={props.view2D ? '' : 'hidden'}
           style={{
             width: '100%',

--- a/components/room-organizer/three/interior-walls.ts
+++ b/components/room-organizer/three/interior-walls.ts
@@ -1,4 +1,5 @@
 import { removeAndDispose } from './builder-utils';
+import { classifyOpeningOwners, mergeHoleRects, type OpeningOwner } from './wall-openings';
 import type { FurnitureItem, InteriorWall } from '../lib/types';
 import type * as ThreeNS from 'three';
 
@@ -7,7 +8,6 @@ type ThreeModule = typeof import('three');
 const INTERIOR_WALL_TAG = 'interior-wall';
 const WALL_THICKNESS = 0.16;
 const WALL_HEIGHT = 2.6;
-const OPENING_DISTANCE_THRESHOLD = 0.4;
 
 interface SegmentOpening {
   /** Centre position along the wall, measured from the segment midpoint (m). */
@@ -26,6 +26,13 @@ export function clearInteriorWalls(scene: ThreeNS.Scene): void {
 export interface RenderInteriorWallsOptions {
   /** Door / window items considered for opening cutouts; pass [] to disable. */
   openingCandidates?: readonly FurnitureItem[];
+  /**
+   * Room footprint, so an opening can be classified across ALL walls (exterior
+   * + interior) and cut by exactly one. Omit to fall back to interior-only
+   * proximity (legacy behaviour).
+   */
+  roomWidth?: number;
+  roomDepth?: number;
 }
 
 export function renderInteriorWalls(
@@ -36,12 +43,20 @@ export function renderInteriorWalls(
   ghostOpacity?: number,
   options: RenderInteriorWallsOptions = {}
 ): void {
+  // Classify every opening to exactly one wall across the whole floor (exterior
+  // + interior). An opening this interior wall doesn't own is cut elsewhere, so
+  // it never gets double-cut at a junction.
+  const owners =
+    options.openingCandidates && options.roomWidth !== undefined && options.roomDepth !== undefined
+      ? classifyOpeningOwners(options.openingCandidates, options.roomWidth, options.roomDepth, walls)
+      : null;
+
   for (const wall of walls) {
     const length = Math.hypot(wall.x2 - wall.x1, wall.z2 - wall.z1);
     if (length < 0.01) continue;
 
     const openings = options.openingCandidates
-      ? computeSegmentOpenings(wall, options.openingCandidates)
+      ? computeSegmentOpenings(wall, options.openingCandidates, owners)
       : [];
 
     const material = new THREE.MeshStandardMaterial({
@@ -111,13 +126,19 @@ function buildExtrudedWallGeometry(
   shape.lineTo(-halfLen, height);
   shape.closePath();
 
-  for (const opening of openings) {
-    const x0 = opening.centerAlongWall - opening.width / 2;
-    const x1 = opening.centerAlongWall + opening.width / 2;
-    const y0 = opening.bottomFromFloor;
-    const y1 = y0 + opening.height;
+  // Merge overlapping openings before punching holes — earcut rejects
+  // overlapping holes and yields phantom fill / self-intersecting triangles.
+  const rects = openings.map(
+    (o) =>
+      [
+        o.centerAlongWall - o.width / 2,
+        o.bottomFromFloor,
+        o.centerAlongWall + o.width / 2,
+        o.bottomFromFloor + o.height,
+      ] as [number, number, number, number]
+  );
+  for (const [x0, y0, x1, y1] of mergeHoleRects(rects)) {
     if (x1 - x0 <= 0 || y1 - y0 <= 0) continue;
-
     const hole = new THREE.Path();
     hole.moveTo(x0, y0);
     hole.lineTo(x1, y0);
@@ -133,10 +154,19 @@ function buildExtrudedWallGeometry(
   return geometry;
 }
 
-/** Project doors/windows onto the segment and return any cutouts near it. */
+/** Perpendicular distance for the legacy interior-only proximity fallback. */
+const OPENING_DISTANCE_THRESHOLD = 0.4;
+
+/**
+ * Project doors/windows onto the segment and return any cutouts this wall owns.
+ * When an `owners` map is given (the floor-wide single-wall classification),
+ * only openings assigned to THIS wall are cut, so an opening at a junction is
+ * never double-cut. Without it, fall back to a local proximity test.
+ */
 function computeSegmentOpenings(
   wall: InteriorWall,
-  items: readonly FurnitureItem[]
+  items: readonly FurnitureItem[],
+  owners: ReadonlyMap<string, OpeningOwner> | null
 ): SegmentOpening[] {
   const length = Math.hypot(wall.x2 - wall.x1, wall.z2 - wall.z1);
   if (length < 0.05) return [];
@@ -151,19 +181,30 @@ function computeSegmentOpenings(
   for (const item of items) {
     if (item.type !== 'door' && item.type !== 'window') continue;
     if (!item.position) continue;
-    const localX = (item.position.x - cx) * dx + (item.position.z - cz) * dz;
-    const localPerp = -(item.position.x - cx) * dz + (item.position.z - cz) * dx;
-    if (Math.abs(localPerp) > OPENING_DISTANCE_THRESHOLD) continue;
 
-    const halfItem = item.width / 2;
-    if (localX + halfItem < -halfLen || localX - halfItem > halfLen) continue;
+    if (owners) {
+      // Authoritative: only cut openings the classifier assigned to this wall.
+      const owner = owners.get(item.id);
+      if (!owner || owner.kind !== 'interior' || owner.wallId !== wall.id) continue;
+    } else {
+      // Legacy proximity fallback (no room dims supplied).
+      const localPerp = -(item.position.x - cx) * dz + (item.position.z - cz) * dx;
+      if (Math.abs(localPerp) > OPENING_DISTANCE_THRESHOLD) continue;
+    }
+
+    const localX = (item.position.x - cx) * dx + (item.position.z - cz) * dz;
+    if (localX + item.width / 2 < -halfLen || localX - item.width / 2 > halfLen) continue;
 
     const bottom = item.type === 'door' ? 0 : 1.0;
+    // Clamp the width to the segment first, then clamp the centre using the
+    // clamped half-width so an oversized opening can't extend past the wall.
+    const width = Math.min(item.width, Math.max(0, length - 0.05));
+    const halfItem = width / 2;
     const clampedCenter = Math.max(-halfLen + halfItem, Math.min(halfLen - halfItem, localX));
     openings.push({
       centerAlongWall: clampedCenter,
       bottomFromFloor: bottom,
-      width: Math.min(item.width, length - 0.05),
+      width,
       height: Math.min(item.height, WALL_HEIGHT - bottom - 0.05),
     });
   }

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -1,6 +1,6 @@
 import { removeAndDispose } from './builder-utils';
 import { buildFloorMaterial } from './floor-patterns';
-import { openingsForWall, type FloorOpening, type WallOpening } from './wall-openings';
+import { mergeHoleRects, openingsForWall, type FloorOpening, type WallOpening } from './wall-openings';
 import { buildWallMaterial } from './wall-patterns';
 import type { FloorPattern, FloorPlanFitMode, WallId, WallPattern } from '../lib/types';
 import type * as ThreeNS from 'three';
@@ -447,12 +447,19 @@ function buildWallGeometryWithCutouts(
   shape.lineTo(-halfW, halfH);
   shape.closePath();
 
-  for (const cutout of cutouts) {
-    const x0 = cutout.centerAlongWall - cutout.width / 2;
-    const x1 = cutout.centerAlongWall + cutout.width / 2;
-    const y0 = -halfH + cutout.bottomFromFloor;
-    const y1 = y0 + cutout.height;
-
+  // Merge overlapping cutouts before building holes — overlapping holes are
+  // illegal for earcut and produce phantom fill / self-intersecting triangles.
+  const rects = cutouts.map(
+    (c) =>
+      [
+        c.centerAlongWall - c.width / 2,
+        -halfH + c.bottomFromFloor,
+        c.centerAlongWall + c.width / 2,
+        -halfH + c.bottomFromFloor + c.height,
+      ] as [number, number, number, number]
+  );
+  for (const [x0, y0, x1, y1] of mergeHoleRects(rects)) {
+    if (x1 - x0 <= 0 || y1 - y0 <= 0) continue;
     const hole = new THREE.Path();
     hole.moveTo(x0, y0);
     hole.lineTo(x1, y0);
@@ -490,13 +497,20 @@ function buildFloorGeometryWithOpenings(
   shape.lineTo(-halfW, halfD);
   shape.closePath();
 
-  for (const opening of openings) {
-    const x0 = opening.centerX - opening.width / 2;
-    const x1 = opening.centerX + opening.width / 2;
-    // The -90° X rotation maps shape-Y to world -Z, so negate Z.
-    const y0 = -(opening.centerZ + opening.depth / 2);
-    const y1 = -(opening.centerZ - opening.depth / 2);
-
+  // Merge overlapping stairwell openings so two adjacent stairs never produce
+  // overlapping holes (illegal for earcut). The -90° X rotation maps shape-Y to
+  // world -Z, so negate Z when forming each rectangle.
+  const rects = openings.map(
+    (o) =>
+      [
+        o.centerX - o.width / 2,
+        -(o.centerZ + o.depth / 2),
+        o.centerX + o.width / 2,
+        -(o.centerZ - o.depth / 2),
+      ] as [number, number, number, number]
+  );
+  for (const [x0, y0, x1, y1] of mergeHoleRects(rects)) {
+    if (x1 - x0 <= 0 || y1 - y0 <= 0) continue;
     const hole = new THREE.Path();
     hole.moveTo(x0, y0);
     hole.lineTo(x1, y0);

--- a/components/room-organizer/three/wall-openings.ts
+++ b/components/room-organizer/three/wall-openings.ts
@@ -1,4 +1,4 @@
-import type { FloorLayout, FurnitureItem, WallId } from '../lib/types';
+import type { FloorLayout, FurnitureItem, InteriorWall, WallId } from '../lib/types';
 
 /** A rectangular hole in a floor plane (e.g. where stairs connect floors). */
 export interface FloorOpening {
@@ -62,11 +62,142 @@ export interface OpeningClassification {
 }
 
 const NEARNESS_THRESHOLD = 0.6;
+/** Interior walls are thinner; a door only counts as "on" one if it's very near. */
+const INTERIOR_NEARNESS_THRESHOLD = 0.4;
+
+/**
+ * Which wall an opening (door/window) belongs to. An opening is assigned to
+ * EXACTLY ONE wall — the nearest by true distance across all exterior and
+ * interior candidates — so a door near a junction is cut only once.
+ */
+export type OpeningOwner =
+  | { kind: 'exterior'; wall: WallId }
+  | { kind: 'interior'; wallId: string };
+
+interface WallCandidate {
+  owner: OpeningOwner;
+  /** Segment endpoints in room-local coords. */
+  x1: number;
+  z1: number;
+  x2: number;
+  z2: number;
+  /** Max perpendicular distance for this opening to count as "on" the wall. */
+  threshold: number;
+}
+
+function exteriorCandidates(roomWidth: number, roomDepth: number): WallCandidate[] {
+  const hw = roomWidth / 2;
+  const hd = roomDepth / 2;
+  return [
+    { owner: { kind: 'exterior', wall: 'north' }, x1: -hw, z1: -hd, x2: hw, z2: -hd, threshold: NEARNESS_THRESHOLD },
+    { owner: { kind: 'exterior', wall: 'south' }, x1: -hw, z1: hd, x2: hw, z2: hd, threshold: NEARNESS_THRESHOLD },
+    { owner: { kind: 'exterior', wall: 'west' }, x1: -hw, z1: -hd, x2: -hw, z2: hd, threshold: NEARNESS_THRESHOLD },
+    { owner: { kind: 'exterior', wall: 'east' }, x1: hw, z1: -hd, x2: hw, z2: hd, threshold: NEARNESS_THRESHOLD },
+  ];
+}
+
+/** Perpendicular distance from a point to a finite segment. */
+function distanceToSegment(px: number, pz: number, c: WallCandidate): number {
+  const vx = c.x2 - c.x1;
+  const vz = c.z2 - c.z1;
+  const lenSq = vx * vx + vz * vz;
+  if (lenSq < 1e-9) return Math.hypot(px - c.x1, pz - c.z1);
+  let t = ((px - c.x1) * vx + (pz - c.z1) * vz) / lenSq;
+  t = Math.max(0, Math.min(1, t));
+  const projX = c.x1 + t * vx;
+  const projZ = c.z1 + t * vz;
+  return Math.hypot(px - projX, pz - projZ);
+}
+
+/**
+ * Classify every door/window to exactly one wall (the nearest candidate within
+ * that candidate's threshold). Returns a map from item id to its owning wall;
+ * items with no wall in range are omitted.
+ */
+export function classifyOpeningOwners(
+  items: readonly FurnitureItem[],
+  roomWidth: number,
+  roomDepth: number,
+  interiorWalls: readonly InteriorWall[] = []
+): Map<string, OpeningOwner> {
+  const candidates: WallCandidate[] = [
+    ...exteriorCandidates(roomWidth, roomDepth),
+    ...interiorWalls.map<WallCandidate>((w) => ({
+      owner: { kind: 'interior', wallId: w.id },
+      x1: w.x1,
+      z1: w.z1,
+      x2: w.x2,
+      z2: w.z2,
+      threshold: INTERIOR_NEARNESS_THRESHOLD,
+    })),
+  ];
+
+  const owners = new Map<string, OpeningOwner>();
+  for (const item of items) {
+    if (item.type !== 'door' && item.type !== 'window') continue;
+    if (!item.position) continue;
+
+    let best: { owner: OpeningOwner; distance: number } | null = null;
+    for (const c of candidates) {
+      const distance = distanceToSegment(item.position.x, item.position.z, c);
+      if (distance > c.threshold) continue;
+      if (!best || distance < best.distance) best = { owner: c.owner, distance };
+    }
+    if (best) owners.set(item.id, best.owner);
+  }
+  return owners;
+}
+
+/**
+ * Merge overlapping/touching axis-aligned hole rectangles so no two holes on a
+ * wall overlap — overlapping holes are illegal for earcut and produce phantom
+ * fill or self-intersecting triangles. Rectangles are `[x0, y0, x1, y1]`.
+ * Returns a disjoint set covering the same area (rectangle union via a sweep
+ * that unions any pair whose AABBs intersect, iterated to a fixed point).
+ */
+export function mergeHoleRects(
+  rects: ReadonlyArray<readonly [number, number, number, number]>
+): Array<[number, number, number, number]> {
+  const merged: Array<[number, number, number, number]> = rects.map(
+    (r) => [r[0], r[1], r[2], r[3]] as [number, number, number, number]
+  );
+
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (let i = 0; i < merged.length; i++) {
+      for (let j = i + 1; j < merged.length; j++) {
+        const a = merged[i]!;
+        const b = merged[j]!;
+        // AABB overlap test (touching edges count as overlapping so adjacent
+        // holes fuse into one clean rectangle instead of leaving a zero-width
+        // sliver of wall that earcut can choke on).
+        const overlap = a[0] <= b[2] && b[0] <= a[2] && a[1] <= b[3] && b[1] <= a[3];
+        if (!overlap) continue;
+        // Union into the bounding rectangle. For like-height openings on a wall
+        // (equal y0/y1) this is an exact interval union; otherwise the bounding
+        // box slightly over-cuts, which is safe (no phantom fill) and rare.
+        a[0] = Math.min(a[0], b[0]);
+        a[1] = Math.min(a[1], b[1]);
+        a[2] = Math.max(a[2], b[2]);
+        a[3] = Math.max(a[3], b[3]);
+        merged.splice(j, 1);
+        changed = true;
+        j--;
+      }
+    }
+  }
+  return merged;
+}
 
 /**
  * For each wall (N/S/E/W), collect the cutouts contributed by `door` and
  * `window` items that sit close enough to that wall's plane. The cutout
  * coordinates are in wall-local space (origin at the wall's centre).
+ *
+ * Each opening is assigned to exactly one wall (see {@link classifyOpeningOwners});
+ * an interior wall may claim an opening, in which case no exterior wall cuts it.
+ * Pass the floor's `interiorWalls` so the classifier can consider them.
  *
  * Returns a `Map<WallId, WallOpening[]>` where missing keys mean "no
  * cutouts on this wall". Callers should use {@link openingsForWall} to
@@ -76,20 +207,22 @@ export function computeWallOpenings(
   items: readonly FurnitureItem[],
   roomWidth: number,
   roomDepth: number,
-  wallHeight = 3
+  wallHeight = 3,
+  interiorWalls: readonly InteriorWall[] = []
 ): Map<WallId, WallOpening[]> {
   const result = new Map<WallId, WallOpening[]>();
+  const owners = classifyOpeningOwners(items, roomWidth, roomDepth, interiorWalls);
 
   for (const item of items) {
     const classification = classifyOpening(item);
     if (!classification) continue;
     if (!item.position) continue;
 
-    const wall = closestWall(item.position, roomWidth, roomDepth);
-    if (wall === null) continue;
-
-    const distance = distanceToWall(item.position, wall, roomWidth, roomDepth);
-    if (distance > NEARNESS_THRESHOLD) continue;
+    const owner = owners.get(item.id);
+    // Only cut this opening if the classifier assigned it to an EXTERIOR wall;
+    // interior-owned openings are cut by interior-walls.ts instead.
+    if (!owner || owner.kind !== 'exterior') continue;
+    const wall = owner.wall;
 
     const opening = buildOpening(item, classification, wall, roomWidth, roomDepth, wallHeight);
     if (!opening) continue;
@@ -112,37 +245,6 @@ function classifyOpening(item: FurnitureItem): OpeningClassification | null {
   return null;
 }
 
-function closestWall(position: { x: number; z: number }, roomWidth: number, roomDepth: number): WallId | null {
-  const distances: Array<{ wall: WallId; distance: number }> = [
-    { wall: 'north', distance: Math.abs(position.z - -roomDepth / 2) },
-    { wall: 'south', distance: Math.abs(position.z - roomDepth / 2) },
-    { wall: 'west', distance: Math.abs(position.x - -roomWidth / 2) },
-    { wall: 'east', distance: Math.abs(position.x - roomWidth / 2) },
-  ];
-  distances.sort((a, b) => a.distance - b.distance);
-  const closest = distances[0];
-  if (!closest || closest.distance > NEARNESS_THRESHOLD) return null;
-  return closest.wall;
-}
-
-function distanceToWall(
-  position: { x: number; z: number },
-  wall: WallId,
-  roomWidth: number,
-  roomDepth: number
-): number {
-  switch (wall) {
-    case 'north':
-      return Math.abs(position.z - -roomDepth / 2);
-    case 'south':
-      return Math.abs(position.z - roomDepth / 2);
-    case 'west':
-      return Math.abs(position.x - -roomWidth / 2);
-    case 'east':
-      return Math.abs(position.x - roomWidth / 2);
-  }
-}
-
 function buildOpening(
   item: FurnitureItem,
   classification: OpeningClassification,
@@ -152,11 +254,14 @@ function buildOpening(
   wallHeight: number
 ): WallOpening | null {
   const centerAlongWall = projectAlongWall(item.position!, wall);
-  const halfWallLength = (wall === 'north' || wall === 'south' ? roomWidth : roomDepth) / 2;
+  const wallLength = wall === 'north' || wall === 'south' ? roomWidth : roomDepth;
+  const halfWallLength = wallLength / 2;
 
-  // Clamp to keep the opening fully inside the wall so we never punch through
-  // a corner.
-  const half = item.width / 2;
+  // Clamp the width to the wall segment first (an oversized/resized opening must
+  // not extend past the wall outline), then clamp the centre using the CLAMPED
+  // half-width so the hole always stays fully inside the wall.
+  const width = Math.min(item.width, Math.max(0, wallLength - 0.05));
+  const half = width / 2;
   const clampedCenter = Math.max(-halfWallLength + half, Math.min(halfWallLength - half, centerAlongWall));
 
   const bottomFromFloor = classification.groundLevel
@@ -167,7 +272,7 @@ function buildOpening(
     id: item.id,
     centerAlongWall: clampedCenter,
     bottomFromFloor,
-    width: Math.min(item.width, halfWallLength * 2 - 0.05),
+    width,
     height: Math.min(item.height, wallHeight - bottomFromFloor - 0.05),
   };
 }


### PR DESCRIPTION
## Summary

Three fixes on one branch, scoped to the room-organizer rendering pipeline.

### 2D top-down view (Fixes #66)
- The 2D canvas backing store is now sized to `clientWidth`/`clientHeight × devicePixelRatio` via a `ResizeObserver` on the canvas, instead of a hardcoded 800×600 stretched by CSS. The aspect ratio matches the container (circles stay circular) and the render is crisp on retina; a window/container resize re-paints.
- `render.ts` is DPR-aware: it resets the transform to a DPR scale and draws in logical (CSS-pixel) coordinates. The heatmap legend is positioned in logical space so it can't fall off-screen on retina.
- Fixed the floor-plan image async race: the decoded `Image` is cached keyed on its URL, and its load triggers a full repaint so grid/furniture render on top of the image instead of the async `onload` painting over them.

### Selection outlines (Fixes #75)
- Added `view.showAllFloors` to the furniture selection-outline effect deps, so it re-runs after the furniture effect rebuilds groups on a Show-All-Floors toggle instead of leaving a selected item with no outline.
- Moved the wall-selection outline effect to run **after** the shell + interior-wall rebuild effects and keyed it on the same rebuild keys, so it always snapshots the current wall mesh — a hidden/moved/re-extruded wall no longer leaves a floating outline.

### Wall cutout robustness (Fixes #61)
- Each door/window is classified to exactly one wall — the nearest by true (clamped-to-segment) distance across all exterior + interior candidates — so an opening near a junction is cut only once instead of being double-cut by both an exterior and an interior wall.
- Overlapping hole rectangles are merged (rectangle union to a fixed point; exact interval union for equal-height openings) before building `shape.holes` in the exterior-wall, interior-wall, and floor-opening geometry. Overlapping holes are illegal for earcut and produce phantom fill / self-intersecting triangles.
- Hole width is clamped to the wall segment (and the centre re-clamped with the clamped half-width) so an oversized/resized opening can't extend past the wall outline.

## Verification
- `npm run typecheck` — clean
- `npx eslint --no-eslintrc -c .eslintrc.json --ext .ts,.tsx app components --max-warnings=0` — clean (plain `npm run lint` hits the nested-worktree `@next/next` double-load)
- `npm run build` — compiles, type-checks, and exports successfully

Scope: `panels/viewport.tsx`, `canvas-2d/render.ts`, `hooks/use-scene-effects.ts`, `three/wall-openings.ts`, `three/interior-walls.ts`, `three/room-builder.ts`.