### PR TITLE
Fix walkthrough-mode conflicts

### DIFF
--- a/components/room-organizer/hooks/use-keyboard-shortcuts.ts
+++ b/components/room-organizer/hooks/use-keyboard-shortcuts.ts
@@ -24,8 +24,15 @@ export interface KeyboardShortcutHandlers {
 
 export interface UseKeyboardShortcutsOptions {
   selectedItem: FurnitureItem | null;
-  selectedWall: { id: string; kind: 'exterior' | 'interior' } | null; 
+  selectedWall: { id: string; kind: 'exterior' | 'interior' } | null;
   hasSignalItems: boolean;
+  /**
+   * When first-person walkthrough owns the keyboard (WASD/arrows drive the
+   * camera), every bare single-key shortcut is gated off so holding e.g. W to
+   * walk forward doesn't also toggle the WiFi overlay (see #67). Ctrl/Cmd chords
+   * (undo/redo/duplicate) and Escape still fire.
+   */
+  walkthroughActive?: boolean;
   handlers: KeyboardShortcutHandlers;
 }
 
@@ -40,6 +47,7 @@ export function useKeyboardShortcuts({
   selectedItem,
   selectedWall,
   hasSignalItems,
+  walkthroughActive = false,
   handlers,
 }: UseKeyboardShortcutsOptions): void {
   useEffect(() => {
@@ -70,6 +78,13 @@ export function useKeyboardShortcuts({
         handlers.deselect();
         return;
       }
+
+      // While walkthrough owns the keyboard, WASD/arrows/Shift drive the camera.
+      // Gate every bare single-key shortcut below off so walking forward (W)
+      // doesn't also toggle the WiFi overlay, `2`/`m`/`g`/`p`/`[`/`]`/PageUp/Down
+      // don't fire mid-walk, etc. (see #67). Ctrl/Cmd chords and Escape above
+      // still work; the walkthrough hook owns its own Esc-to-exit handling.
+      if (walkthroughActive) return;
 
       // Everything below is a bare single-key shortcut. Never swallow browser
       // shortcuts like Cmd/Ctrl+F (find), Ctrl+R (reload), or Cmd+M.
@@ -181,7 +196,7 @@ export function useKeyboardShortcuts({
 
     window.addEventListener('keydown', onKeyDown);
     return () => window.removeEventListener('keydown', onKeyDown);
-  }, [selectedItem, selectedWall, hasSignalItems, handlers]);
+  }, [selectedItem, selectedWall, hasSignalItems, walkthroughActive, handlers]);
 }
 
 function isTypingTarget(target: EventTarget | null): boolean {

--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -31,6 +31,7 @@ export interface UseThreeSceneResult {
 export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResult {
   const {
     canvasRef,
+    walkthroughActive,
     onItemSelect,
     onItemDragStart,
     onItemDrag,
@@ -64,7 +65,8 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
 
   // Latest-callback refs: capture handlers without making them part of the
   // init-effect dependency list (which would tear down the scene unnecessarily).
-  const handlersRef = useRef({
+  const handlersRef = useRef<SceneEventHandlers>({
+    walkthroughActive,
     onItemSelect,
     onItemDragStart,
     onItemDrag,
@@ -78,6 +80,7 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
     getDragPlaneY,
   });
   handlersRef.current = {
+    walkthroughActive,
     onItemSelect,
     onItemDragStart,
     onItemDrag,

--- a/components/room-organizer/hooks/use-walkthrough.ts
+++ b/components/room-organizer/hooks/use-walkthrough.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import type * as ThreeNS from 'three';
 import type { OrbitControls as OrbitControlsType } from 'three/examples/jsm/controls/OrbitControls.js';
 import type { PointerLockControls as PointerLockControlsType } from 'three/examples/jsm/controls/PointerLockControls.js';
@@ -13,8 +13,17 @@ export interface UseWalkthroughOptions {
   orbitRef: React.MutableRefObject<OrbitControlsType | null>;
   eyeHeight?: number;
   walkSpeed?: number;
+  /** Room footprint (metres) used to clamp the walker inside the walls. */
+  roomWidth?: number;
+  roomDepth?: number;
   /** Request a render on the next animation frame (render-on-demand). */
   invalidate?: () => void;
+  /**
+   * Called when the user presses Escape a second time (while pointer lock is
+   * already released) to leave walkthrough entirely (see #67). The first Esc is
+   * browser-reserved and only exits pointer lock.
+   */
+  onExit?: () => void;
 }
 
 const MOVEMENT_KEYS = new Set([
@@ -30,6 +39,11 @@ const MOVEMENT_KEYS = new Set([
   'ShiftRight',
 ]);
 
+// Keep the walker a little inside the exterior walls so the camera never clips
+// through them or steps off the floor plate. A full wall-segment collision test
+// is out of scope — this footprint clamp is the minimal guard (see #67).
+const WALL_MARGIN = 0.35;
+
 /**
  * First-person walkthrough mode using PointerLockControls.
  *
@@ -38,7 +52,12 @@ const MOVEMENT_KEYS = new Set([
  *  - Lazy-loads PointerLockControls and attaches them to the canvas.
  *  - Moves the camera to eye level and listens for WASD / arrow movement,
  *    with Shift for sprint.
+ *  - Clamps the walker to the room footprint so it can't leave the plate.
  *  - On disable / unmount, restores orbit controls and the camera pose.
+ *
+ * `eyeHeight` (which tracks the active floor) is read live from a ref so a floor
+ * switch mid-walk only re-seats the camera's height — it never tears the mode
+ * down and drops pointer lock (see #67).
  */
 export function useWalkthrough(options: UseWalkthroughOptions): void {
   const {
@@ -49,8 +68,37 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
     orbitRef,
     eyeHeight = 1.6,
     walkSpeed = 3.0,
+    roomWidth = Infinity,
+    roomDepth = Infinity,
     invalidate,
+    onExit,
   } = options;
+
+  // Live values the RAF loop / Esc handler read without re-running the init
+  // effect (which would drop pointer lock). Updated every render.
+  const eyeHeightRef = useRef(eyeHeight);
+  const walkSpeedRef = useRef(walkSpeed);
+  const roomWidthRef = useRef(roomWidth);
+  const roomDepthRef = useRef(roomDepth);
+  const invalidateRef = useRef(invalidate);
+  const onExitRef = useRef(onExit);
+  eyeHeightRef.current = eyeHeight;
+  walkSpeedRef.current = walkSpeed;
+  roomWidthRef.current = roomWidth;
+  roomDepthRef.current = roomDepth;
+  invalidateRef.current = invalidate;
+  onExitRef.current = onExit;
+
+  // Re-seat the camera's height when the active floor (eyeHeight) changes while
+  // walking, preserving x/z. Deliberately separate from the init effect so a
+  // floor switch never re-inits and drops pointer lock (see #67).
+  useEffect(() => {
+    if (!enabled) return;
+    const camera = cameraRef.current;
+    if (!camera) return;
+    camera.position.y = eyeHeight;
+    invalidateRef.current?.();
+  }, [enabled, eyeHeight, cameraRef]);
 
   useEffect(() => {
     if (!enabled) return undefined;
@@ -74,10 +122,31 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
       if (MOVEMENT_KEYS.has(event.code)) pressed.add(event.code);
     };
     const onKeyUp = (event: KeyboardEvent) => pressed.delete(event.code);
+    // Escape exit: the browser reserves the first Escape to release pointer
+    // lock, so we only act on an Escape received while already unlocked — that
+    // second press leaves walkthrough mode entirely (see #67).
+    const onEscape = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (controls?.isLocked) return;
+      onExitRef.current?.();
+    };
     window.addEventListener('keydown', onKeyDown);
     window.addEventListener('keyup', onKeyUp);
+    window.addEventListener('keydown', onEscape);
     cleanup.push(() => window.removeEventListener('keydown', onKeyDown));
     cleanup.push(() => window.removeEventListener('keyup', onKeyUp));
+    cleanup.push(() => window.removeEventListener('keydown', onEscape));
+
+    const clampToFootprint = (): void => {
+      const halfW = roomWidthRef.current / 2 - WALL_MARGIN;
+      const halfD = roomDepthRef.current / 2 - WALL_MARGIN;
+      if (Number.isFinite(halfW) && halfW > 0) {
+        camera.position.x = Math.max(-halfW, Math.min(halfW, camera.position.x));
+      }
+      if (Number.isFinite(halfD) && halfD > 0) {
+        camera.position.z = Math.max(-halfD, Math.min(halfD, camera.position.z));
+      }
+    };
 
     void (async () => {
       const controlsModule = await import('three/examples/jsm/controls/PointerLockControls.js');
@@ -85,8 +154,9 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
 
       controls = new controlsModule.PointerLockControls(camera, canvas);
       savedCameraPosition = camera.position.clone();
-      camera.position.set(0, eyeHeight, 3);
-      camera.lookAt(0, eyeHeight, 0);
+      camera.position.set(0, eyeHeightRef.current, 3);
+      camera.lookAt(0, eyeHeightRef.current, 0);
+      clampToFootprint();
 
       const requestLock = () => controls?.lock();
       canvas.addEventListener('click', requestLock);
@@ -108,10 +178,10 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
         if (!controls?.isLocked) return;
         // Walkthrough is an active mode: mouse-look mutates the camera outside
         // this loop, so render every frame while pointer lock is engaged.
-        invalidate?.();
+        invalidateRef.current?.();
 
         const sprint = pressed.has('ShiftLeft') || pressed.has('ShiftRight');
-        const speed = walkSpeed * (sprint ? 2 : 1);
+        const speed = walkSpeedRef.current * (sprint ? 2 : 1);
 
         let dz = 0;
         let dx = 0;
@@ -133,7 +203,8 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
         const distance = speed * delta;
         camera.position.addScaledVector(forward, -dz * distance);
         camera.position.addScaledVector(right, dx * distance);
-        camera.position.y = eyeHeight;
+        camera.position.y = eyeHeightRef.current;
+        clampToFootprint();
       };
       rafId = requestAnimationFrame(step);
       cleanup.push(() => cancelAnimationFrame(rafId));
@@ -150,5 +221,5 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
       }
       if (orbit) orbit.enabled = true;
     };
-  }, [enabled, invalidate, canvasRef, threeModuleRef, cameraRef, orbitRef, eyeHeight, walkSpeed]);
+  }, [enabled, canvasRef, threeModuleRef, cameraRef, orbitRef]);
 }

--- a/components/room-organizer/panels/bottom-hud.tsx
+++ b/components/room-organizer/panels/bottom-hud.tsx
@@ -23,7 +23,7 @@ export interface BottomHudProps {
 }
 
 export function BottomHud({ selectedWall, onSelectedWallChange, onOrbit, onZoom, onFit, placeCatalogItem }: BottomHudProps): JSX.Element {
-  const { layout, actions, view, toggle, isReady, error, gameMode, setGameMode, playCue } = useRoomEditor();
+  const { layout, actions, view, toggle, setView, isReady, error, gameMode, setGameMode, playCue } = useRoomEditor();
   const { setSelectedItemId, setExtraSelectedIds } = useSelection();
   const [buildToolCategory, setBuildToolCategory] = useState<BuildToolCategory>('seating');
 
@@ -128,7 +128,10 @@ export function BottomHud({ selectedWall, onSelectedWallChange, onOrbit, onZoom,
         onSetMode={(mode) => {
           setGameMode(mode);
           if (mode === 'live') {
-            if (!view.walkthroughMode) toggle('walkthroughMode');
+            // Walkthrough needs the 3D view — the hook requires `!view2D`, so
+            // entering Live from the 2D top-down view is otherwise a silent
+            // no-op (see #67). Drop view2D as we switch walkthrough on.
+            setView((v) => ({ ...v, view2D: false, walkthroughMode: true }));
           } else if (view.walkthroughMode) {
             toggle('walkthroughMode');
           }

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -116,6 +116,11 @@ export function RoomOrganizer(): JSX.Element {
   const { recent: recentColors, pushColor } = useRecentColors();
   const [view, setView] = useState<ViewSettings>(INITIAL_VIEW_SETTINGS);
 
+  // First-person walkthrough only runs in the 3D view; the 2D top-down renderer
+  // has no PointerLockControls. This single signal gates walkthrough-aware
+  // behaviour: canvas select/drag/hover, single-key shortcuts and the hook.
+  const walkthroughActive = view.walkthroughMode && !view.view2D;
+
   const playCue = useCallback(
     (cue: SoundCue) => {
       if (view.soundsEnabled) playSound(cue);
@@ -460,6 +465,7 @@ export function RoomOrganizer(): JSX.Element {
   const { isReady, error, invalidate, threeModuleRef, sceneRef, rendererRef, cameraRef, controlsRef, worldPositionFromClient } =
     useThreeScene({
       canvasRef,
+      walkthroughActive,
       onItemSelect: handleSelect,
       onItemDragStart: handleDragStart,
       onItemDrag: handleDrag,
@@ -482,13 +488,19 @@ export function RoomOrganizer(): JSX.Element {
   invalidateBoxRef.current = invalidate;
 
   useWalkthrough({
-    enabled: isReady && view.walkthroughMode && !view.view2D,
+    enabled: isReady && walkthroughActive,
     invalidate,
     canvasRef,
     threeModuleRef,
     cameraRef,
     orbitRef: controlsRef,
     eyeHeight: activeFloorY + 1.6,
+    roomWidth: layout.width,
+    roomDepth: layout.height,
+    onExit: useCallback(() => {
+      setView((v) => (v.walkthroughMode ? { ...v, walkthroughMode: false } : v));
+      setGameMode((mode) => (mode === 'live' ? 'build' : mode));
+    }, []),
   });
 
   useSceneEffects({
@@ -656,6 +668,7 @@ export function RoomOrganizer(): JSX.Element {
     selectedItem,
     selectedWall,
     hasSignalItems,
+    walkthroughActive,
     handlers: shortcutHandlers,
   });
 
@@ -728,7 +741,7 @@ export function RoomOrganizer(): JSX.Element {
         selectionCount={allSelectedIds.size}
         showMeasurements={view.showMeasurements}
         showMinimap={view.showMinimap}
-        walkthroughActive={view.walkthroughMode && !view.view2D}
+        walkthroughActive={walkthroughActive}
         measurementDistance={measurementDistance(measurementPoints)}
         measurementPointsPlaced={view.measurementMode ? measurementPoints.length : 0}
         wallDrawStatus={

--- a/components/room-organizer/three/drag-handlers.ts
+++ b/components/room-organizer/three/drag-handlers.ts
@@ -17,6 +17,12 @@ export type SelectionMode = 'replace' | 'toggle';
  * re-attaching DOM listeners.
  */
 export interface SceneEventHandlers {
+  /**
+   * When true, first-person walkthrough owns the canvas (PointerLockControls).
+   * Select / drag / hover must no-op so the lock-engaging click doesn't select
+   * furniture, open a popover or start a zero-distance drag (see #67).
+   */
+  walkthroughActive?: boolean;
   onItemSelect: (id: string, mode: SelectionMode) => void;
   onItemDragStart?: (id: string) => void;
   onItemDrag: (id: string, x: number, z: number) => void;
@@ -103,6 +109,9 @@ export function attachDragHandlers({
   };
 
   const onPointerDown = (event: PointerEvent): void => {
+    // In walkthrough mode the canvas click only engages pointer lock — it must
+    // not select furniture, open a popover or start a drag (see #67).
+    if (handlersRef.current.walkthroughActive) return;
     // Only track a single primary pointer at a time. A second finger arriving
     // mid-gesture is ignored here so it can drive OrbitControls' pinch.
     if (activePointerId !== null) return;
@@ -164,6 +173,8 @@ export function attachDragHandlers({
 
   let lastHoverId: string | null = null;
   const updateHover = (event: PointerEvent): void => {
+    // No hover affordance while walkthrough owns the camera (see #67).
+    if (handlersRef.current.walkthroughActive) return;
     const hoverCallback = handlersRef.current.onItemHover;
     if (!hoverCallback) return;
     setPointerFromEvent(event);


### PR DESCRIPTION
## Summary

First-person walkthrough mode (WASD + `PointerLockControls`) shared window keyboard listeners and the canvas pointer handlers with build mode, so entering and moving through it fought the editor. This resolves every conflict from the audit.

## Changes

- **Single-key shortcuts fire while walking.** Threaded a `walkthroughActive` signal into `use-keyboard-shortcuts`; every bare single-key shortcut early-returns while walkthrough is active, so holding `W` to walk no longer toggles the WiFi overlay (`2`, `m`, `g`, `p`, `[`, `]`, PageUp/Down likewise gated). Ctrl/Cmd chords (undo/redo/duplicate) and Escape still fire.
- **Lock-engaging click selects/locks furniture.** Added `walkthroughActive` to `SceneEventHandlers` (threaded through `handlersRef`); `onPointerDown` and hover no-op while walkthrough owns the canvas, so the click that engages pointer lock no longer selects furniture, opens the popover, starts a zero-distance drag, or pollutes undo.
- **Floor switch mid-walk teleports and drops pointer lock.** `eyeHeight`/footprint/callbacks are read from refs; the init effect no longer depends on `eyeHeight`. A separate effect re-seats only the camera's `y` on a floor change, preserving `x`/`z` and keeping pointer lock engaged.
- **No keyboard exit.** A second Escape (received while pointer lock is already released) leaves walkthrough entirely via a new `onExit` callback.
- **"Live" in 2D view was a silent no-op.** Entering Live now drops `view2D` in the same `setView` that turns walkthrough on, so the mode actually engages.
- **No collision.** The walkthrough camera's `x`/`z` is clamped to the room footprint (± small margin) each frame so the walker can't leave the plate or clip through exterior walls. (A full wall-segment test is out of scope.)

## Verification

- `npm run typecheck` — clean
- `npx eslint --no-eslintrc -c .eslintrc.json --ext .ts,.tsx app components --max-warnings=0` — clean (the plain `npm run lint` hits the known nested-worktree `@next/next` double-load)
- `npm run build` — compiles, type-checks, generates and exports all pages

Fixes #67