### PR TITLE
test: set up Vitest and cover core pure logic

### DIFF
--- a/.github/workflows/deploy-room-organizer.yml
+++ b/.github/workflows/deploy-room-organizer.yml
@@ -29,6 +29,7 @@
       - run: npm install
       - run: npx tsc --noEmit
       - run: npm run lint -- --max-warnings=0
+      - run: npm run test
       - run: npm run build                                                                                                                                                         
         env:
           GITHUB_PAGES: 'true'                                                                                                                                                     

--- a/components/room-organizer/hooks/layout-reducer.test.ts
+++ b/components/room-organizer/hooks/layout-reducer.test.ts
@@ -1,0 +1,488 @@
+import { describe, expect, it } from 'vitest';
+import { makeCatalogItem, makeFloor, makeItem, makeLayout } from '../lib/__testfixtures__/fixtures';
+import { MAX_FLOORS, MAX_ROOM_DIMENSION } from '../lib/constants';
+import { INITIAL_GROUND_FLOOR, layoutReducer, type LayoutState } from './layout-reducer';
+import type { FurnitureItem } from '../lib/types';
+
+function stateWith(items: FurnitureItem[], floorCount = 1, activeFloorIndex = 0): LayoutState {
+  const floors = Array.from({ length: floorCount }, (_, i) =>
+    makeFloor({ id: `floor-${i}`, name: `Floor ${i}`, items: i === activeFloorIndex ? items : [] })
+  );
+  return { layout: makeLayout({ floors }), activeFloorIndex };
+}
+
+function activeItems(state: LayoutState): FurnitureItem[] {
+  return state.layout.floors[state.activeFloorIndex]!.items;
+}
+
+describe('layoutReducer — building properties', () => {
+  it('setName / setWidth / setHeight update the layout', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setName', name: 'Villa' });
+    state = layoutReducer(state, { type: 'setWidth', width: 12 });
+    state = layoutReducer(state, { type: 'setHeight', height: 14 });
+    expect(state.layout.name).toBe('Villa');
+    expect(state.layout.width).toBe(12);
+    expect(state.layout.height).toBe(14);
+  });
+});
+
+describe('layoutReducer — item CRUD', () => {
+  it('addCatalogItem adds an item to the active floor, locked, at given position', () => {
+    const state = layoutReducer(stateWith([]), {
+      type: 'addCatalogItem',
+      catalogItem: makeCatalogItem(),
+      id: 'new-1',
+      position: { x: 2, z: 3 },
+    });
+    const items = activeItems(state);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({ id: 'new-1', locked: true, rotation: 0, position: { x: 2, z: 3 } });
+  });
+
+  it('addCatalogItem defaults position to origin and adds sofaShape for sofas', () => {
+    const state = layoutReducer(stateWith([]), {
+      type: 'addCatalogItem',
+      catalogItem: makeCatalogItem({ type: 'sofa' }),
+      id: 'sofa-1',
+    });
+    expect(activeItems(state)[0]).toMatchObject({ position: { x: 0, z: 0 }, sofaShape: 'standard' });
+  });
+
+  it('removeItem removes only the matching item', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a' }), makeItem({ id: 'b' })]), {
+      type: 'removeItem',
+      id: 'a',
+    });
+    expect(activeItems(state).map((i) => i.id)).toEqual(['b']);
+  });
+
+  it('updateItem merges the patch into the matching item', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a', color: '#000' })]), {
+      type: 'updateItem',
+      id: 'a',
+      patch: { color: '#fff', name: 'Renamed' },
+    });
+    expect(activeItems(state)[0]).toMatchObject({ color: '#fff', name: 'Renamed' });
+  });
+
+  it('duplicateItem clones with new id offset by +0.5,+0.5', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a', position: { x: 1, z: 2 } })]), {
+      type: 'duplicateItem',
+      sourceId: 'a',
+      newId: 'a-copy',
+    });
+    const items = activeItems(state);
+    expect(items).toHaveLength(2);
+    expect(items[1]).toMatchObject({ id: 'a-copy', position: { x: 1.5, z: 2.5 } });
+  });
+
+  it('duplicateItem is a no-op when the source is missing', () => {
+    const before = stateWith([makeItem({ id: 'a' })]);
+    const after = layoutReducer(before, { type: 'duplicateItem', sourceId: 'zzz', newId: 'x' });
+    expect(after).toBe(before);
+  });
+
+  it('rotateItem advances rotation by 90° and wraps at 2π', () => {
+    let state = stateWith([makeItem({ id: 'a', rotation: (3 * Math.PI) / 2 })]);
+    state = layoutReducer(state, { type: 'rotateItem', id: 'a' });
+    // (3π/2 + π/2) % 2π === 0
+    expect(activeItems(state)[0]!.rotation).toBeCloseTo(0, 10);
+  });
+
+  it('moveItem sets an absolute position', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a' })]), {
+      type: 'moveItem',
+      id: 'a',
+      x: 5,
+      z: -3,
+    });
+    expect(activeItems(state)[0]!.position).toEqual({ x: 5, z: -3 });
+  });
+
+  it('resizeItem clamps to a 0.1 minimum', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a', width: 2 })]), {
+      type: 'resizeItem',
+      id: 'a',
+      dimension: 'width',
+      value: -5,
+    });
+    expect(activeItems(state)[0]!.width).toBe(0.1);
+  });
+
+  it('toggleMirror flips the mirrored flag', () => {
+    let state = stateWith([makeItem({ id: 'a' })]);
+    state = layoutReducer(state, { type: 'toggleMirror', id: 'a' });
+    expect(activeItems(state)[0]!.mirrored).toBe(true);
+    state = layoutReducer(state, { type: 'toggleMirror', id: 'a' });
+    expect(activeItems(state)[0]!.mirrored).toBe(false);
+  });
+
+  it('setRotation / setColor / setLocked / setSofaShape / setSignalRange patch fields', () => {
+    let state = stateWith([makeItem({ id: 'a', type: 'sofa' })]);
+    state = layoutReducer(state, { type: 'setRotation', id: 'a', rotation: 1.23 });
+    state = layoutReducer(state, { type: 'setColor', id: 'a', color: '#abc' });
+    state = layoutReducer(state, { type: 'setLocked', id: 'a', locked: true });
+    state = layoutReducer(state, { type: 'setSofaShape', id: 'a', shape: 'L-shape' });
+    state = layoutReducer(state, { type: 'setSignalRange', id: 'a', range: 4 });
+    expect(activeItems(state)[0]).toMatchObject({
+      rotation: 1.23,
+      color: '#abc',
+      locked: true,
+      sofaShape: 'L-shape',
+      signalRange: 4,
+    });
+  });
+});
+
+describe('layoutReducer — bulk item operations', () => {
+  it('replaceItems swaps the active floor items wholesale', () => {
+    const replacement = [makeItem({ id: 'x' })];
+    const state = layoutReducer(stateWith([makeItem({ id: 'a' })]), {
+      type: 'replaceItems',
+      items: replacement,
+    });
+    expect(activeItems(state).map((i) => i.id)).toEqual(['x']);
+  });
+
+  it('addItems appends to existing items', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a' })]), {
+      type: 'addItems',
+      items: [makeItem({ id: 'b' }), makeItem({ id: 'c' })],
+    });
+    expect(activeItems(state).map((i) => i.id)).toEqual(['a', 'b', 'c']);
+  });
+
+  it('clearItems empties the active floor', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a' })]), { type: 'clearItems' });
+    expect(activeItems(state)).toEqual([]);
+  });
+
+  it('setLockAll locks/unlocks every item', () => {
+    let state = stateWith([makeItem({ id: 'a' }), makeItem({ id: 'b' })]);
+    state = layoutReducer(state, { type: 'setLockAll', locked: true });
+    expect(activeItems(state).every((i) => i.locked === true)).toBe(true);
+    state = layoutReducer(state, { type: 'setLockAll', locked: false });
+    expect(activeItems(state).every((i) => i.locked === false)).toBe(true);
+  });
+
+  it('bulkSetPositions moves only listed items and leaves others untouched', () => {
+    const state = layoutReducer(
+      stateWith([makeItem({ id: 'a', position: { x: 0, z: 0 } }), makeItem({ id: 'b', position: { x: 1, z: 1 } })]),
+      { type: 'bulkSetPositions', positions: new Map([['a', { x: 9, z: 9 }]]) }
+    );
+    const items = activeItems(state);
+    expect(items.find((i) => i.id === 'a')!.position).toEqual({ x: 9, z: 9 });
+    expect(items.find((i) => i.id === 'b')!.position).toEqual({ x: 1, z: 1 });
+  });
+});
+
+describe('layoutReducer — rotateSelection (rigid rotation about centroid)', () => {
+  it('preserves the centroid and each item distance to it', () => {
+    const items = [
+      makeItem({ id: 'a', position: { x: 0, z: 0 }, rotation: 0 }),
+      makeItem({ id: 'b', position: { x: 2, z: 0 }, rotation: 0 }),
+      makeItem({ id: 'c', position: { x: 2, z: 2 }, rotation: 0 }),
+      makeItem({ id: 'd', position: { x: 0, z: 2 }, rotation: 0 }),
+    ];
+    const state = layoutReducer(stateWith(items), {
+      type: 'rotateSelection',
+      ids: new Set(['a', 'b', 'c', 'd']),
+      radians: Math.PI / 3,
+    });
+    const rotated = activeItems(state);
+    const cx = rotated.reduce((s, i) => s + i.position!.x, 0) / 4;
+    const cz = rotated.reduce((s, i) => s + i.position!.z, 0) / 4;
+    // Centroid fixed at (1, 1).
+    expect(cx).toBeCloseTo(1, 10);
+    expect(cz).toBeCloseTo(1, 10);
+    // Each distance to centroid preserved (rigid rotation).
+    for (const original of items) {
+      const now = rotated.find((r) => r.id === original.id)!;
+      const dOld = Math.hypot(original.position!.x - 1, original.position!.z - 1);
+      const dNew = Math.hypot(now.position!.x - 1, now.position!.z - 1);
+      expect(dNew).toBeCloseTo(dOld, 10);
+      // Each item's own rotation advanced by the same angle.
+      expect(now.rotation).toBeCloseTo(Math.PI / 3, 10);
+    }
+  });
+
+  it('preserves pairwise distances between items (arrangement rigid)', () => {
+    const items = [
+      makeItem({ id: 'a', position: { x: -1, z: 0 } }),
+      makeItem({ id: 'b', position: { x: 3, z: 1 } }),
+    ];
+    const state = layoutReducer(stateWith(items), {
+      type: 'rotateSelection',
+      ids: new Set(['a', 'b']),
+      radians: 1.1,
+    });
+    const [a, b] = activeItems(state);
+    const dOld = Math.hypot(-1 - 3, 0 - 1);
+    const dNew = Math.hypot(a!.position!.x - b!.position!.x, a!.position!.z - b!.position!.z);
+    expect(dNew).toBeCloseTo(dOld, 10);
+  });
+
+  it('is a no-op when the only selected item has no position (centroid undefined)', () => {
+    // The centroid is computed from positioned items only; a selection of
+    // positionless items produces an empty `selected` set and returns the floor
+    // unchanged.
+    const before = stateWith([makeItem({ id: 'p', position: undefined, rotation: 0 })]);
+    const after = layoutReducer(before, {
+      type: 'rotateSelection',
+      ids: new Set(['p']),
+      radians: Math.PI / 2,
+    });
+    expect(after).toBe(before);
+  });
+
+  it('rotates a positionless item in place when a positioned item is also selected', () => {
+    const items = [
+      makeItem({ id: 'anchor', position: { x: 0, z: 0 }, rotation: 0 }),
+      makeItem({ id: 'p', position: undefined, rotation: 0 }),
+    ];
+    const state = layoutReducer(stateWith(items), {
+      type: 'rotateSelection',
+      ids: new Set(['anchor', 'p']),
+      radians: Math.PI / 2,
+    });
+    const positionless = activeItems(state).find((i) => i.id === 'p')!;
+    expect(positionless.position).toBeUndefined();
+    expect(positionless.rotation).toBeCloseTo(Math.PI / 2, 10);
+  });
+
+  it('leaves unselected items untouched and is a no-op with no positioned selection', () => {
+    const before = stateWith([makeItem({ id: 'a', position: { x: 5, z: 5 } })]);
+    const after = layoutReducer(before, {
+      type: 'rotateSelection',
+      ids: new Set(['zzz']),
+      radians: 1,
+    });
+    expect(after).toBe(before);
+  });
+});
+
+describe('layoutReducer — floor-scoped finishes', () => {
+  it('setFloorColor / setFloorPattern / setWallPattern update the active floor', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setFloorColor', color: '#123456' });
+    state = layoutReducer(state, { type: 'setFloorPattern', pattern: 'tile' });
+    state = layoutReducer(state, { type: 'setWallPattern', pattern: 'brick' });
+    const floor = state.layout.floors[0]!;
+    expect(floor).toMatchObject({ floorColor: '#123456', floorPattern: 'tile', wallPattern: 'brick' });
+  });
+
+  it('setWallColor sets and clears (null) a wall color', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setWallColor', wall: 'north', color: '#aaa' });
+    expect(state.layout.floors[0]!.wallColors).toEqual({ north: '#aaa' });
+    state = layoutReducer(state, { type: 'setWallColor', wall: 'north', color: null });
+    expect(state.layout.floors[0]!.wallColors).toEqual({});
+  });
+
+  it('toggleExteriorWall hides then unhides a wall', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'toggleExteriorWall', wallId: 'east' });
+    expect(state.layout.floors[0]!.hiddenWalls).toEqual(['east']);
+    state = layoutReducer(state, { type: 'toggleExteriorWall', wallId: 'east' });
+    expect(state.layout.floors[0]!.hiddenWalls).toEqual([]);
+  });
+
+  it('addInteriorWall / removeInteriorWall / clearInteriorWalls', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, {
+      type: 'addInteriorWall',
+      wall: { id: 'w1', x1: 0, z1: 0, x2: 1, z2: 0 },
+    });
+    expect(state.layout.floors[0]!.interiorWalls).toHaveLength(1);
+    state = layoutReducer(state, {
+      type: 'addInteriorWall',
+      wall: { id: 'w2', x1: 0, z1: 0, x2: 0, z2: 1 },
+    });
+    state = layoutReducer(state, { type: 'removeInteriorWall', id: 'w1' });
+    expect(state.layout.floors[0]!.interiorWalls!.map((w) => w.id)).toEqual(['w2']);
+    state = layoutReducer(state, { type: 'clearInteriorWalls' });
+    expect(state.layout.floors[0]!.interiorWalls).toEqual([]);
+  });
+});
+
+describe('layoutReducer — roof + floor plan', () => {
+  it('setRoofStyle / setRoofColor update the roof', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setRoofStyle', style: 'hipped' });
+    state = layoutReducer(state, { type: 'setRoofColor', color: '#111' });
+    expect(state.layout.roof).toMatchObject({ style: 'hipped', color: '#111' });
+  });
+
+  it('setFloorPlan sets and clears the image', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setFloorPlan', image: 'data:img' });
+    expect(state.layout.floorPlanImage).toBe('data:img');
+    state = layoutReducer(state, { type: 'setFloorPlan', image: null });
+    expect(state.layout.floorPlanImage).toBeUndefined();
+  });
+
+  it('setFloorPlanOpacity / setFloorPlanFitMode update the layout', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setFloorPlanOpacity', opacity: 0.25 });
+    state = layoutReducer(state, { type: 'setFloorPlanFitMode', mode: 'cover' });
+    expect(state.layout.floorPlanOpacity).toBe(0.25);
+    expect(state.layout.floorPlanFitMode).toBe('cover');
+  });
+});
+
+describe('layoutReducer — floor / building operations', () => {
+  it('setActiveFloorIndex clamps into range', () => {
+    const state = stateWith([], 3);
+    expect(layoutReducer(state, { type: 'setActiveFloorIndex', index: 2 }).activeFloorIndex).toBe(2);
+    expect(layoutReducer(state, { type: 'setActiveFloorIndex', index: 99 }).activeFloorIndex).toBe(2);
+    expect(layoutReducer(state, { type: 'setActiveFloorIndex', index: -5 }).activeFloorIndex).toBe(0);
+  });
+
+  it('addFloor appends and makes the new floor active', () => {
+    const state = layoutReducer(stateWith([], 1), {
+      type: 'addFloor',
+      floor: { id: 'f2', floorColor: '#fff', items: [] },
+    });
+    expect(state.layout.floors).toHaveLength(2);
+    expect(state.activeFloorIndex).toBe(1);
+    expect(state.layout.floors[1]!.name).toBe('First Floor');
+  });
+
+  it('addFloor is a no-op at MAX_FLOORS', () => {
+    const before = stateWith([], MAX_FLOORS);
+    const after = layoutReducer(before, {
+      type: 'addFloor',
+      floor: { id: 'over', floorColor: '#fff', items: [] },
+    });
+    expect(after).toBe(before);
+  });
+
+  it('duplicateFloor clones items with fresh ids and activates the copy', () => {
+    const base = stateWith([makeItem({ id: 'orig', type: 'chair' })], 1);
+    const state = layoutReducer(base, { type: 'duplicateFloor', sourceIndex: 0, newId: 'copy' });
+    expect(state.layout.floors).toHaveLength(2);
+    expect(state.activeFloorIndex).toBe(1);
+    const copy = state.layout.floors[1]!;
+    expect(copy.name).toBe('Floor 0 copy');
+    expect(copy.items).toHaveLength(1);
+    expect(copy.items[0]!.id).not.toBe('orig');
+  });
+
+  it('renameFloor renames the target floor without changing the active one', () => {
+    const state = stateWith([], 2, 1);
+    const next = layoutReducer(state, { type: 'renameFloor', index: 0, name: 'Basement' });
+    expect(next.layout.floors[0]!.name).toBe('Basement');
+    expect(next.activeFloorIndex).toBe(1);
+  });
+
+  describe('removeFloor — activeFloorIndex correctness (fixed bug)', () => {
+    it('removing a floor below the active one shifts active down', () => {
+      // floors [0,1,2], active = 2; remove index 0 → active should follow to 1.
+      const state = stateWith([], 3, 2);
+      const next = layoutReducer(state, { type: 'removeFloor', index: 0 });
+      expect(next.layout.floors).toHaveLength(2);
+      expect(next.activeFloorIndex).toBe(1);
+    });
+
+    it('removing a floor above the active one keeps active unchanged', () => {
+      const state = stateWith([], 3, 0);
+      const next = layoutReducer(state, { type: 'removeFloor', index: 2 });
+      expect(next.activeFloorIndex).toBe(0);
+    });
+
+    it('removing the active floor keeps index in range (clamped)', () => {
+      const state = stateWith([], 3, 2);
+      const next = layoutReducer(state, { type: 'removeFloor', index: 2 });
+      // active was 2, index 2 is not < 2 so it stays 2, then clamped to len-1 = 1.
+      expect(next.activeFloorIndex).toBe(1);
+    });
+
+    it('is a no-op when only one floor remains', () => {
+      const before = stateWith([], 1, 0);
+      const after = layoutReducer(before, { type: 'removeFloor', index: 0 });
+      expect(after).toBe(before);
+    });
+  });
+
+  describe('reorderFloor — activeFloorIndex tracking', () => {
+    it('moving the active floor makes active follow to its new slot', () => {
+      const state = stateWith([], 3, 0);
+      const next = layoutReducer(state, { type: 'reorderFloor', from: 0, to: 2 });
+      expect(next.activeFloorIndex).toBe(2);
+    });
+
+    it('moving a floor from below the active up past it shifts active down', () => {
+      // active = 2; move floor 0 → 2. Item at 0 removed (active→1), inserted at 2 (2<=1? no) → 1.
+      const state = stateWith([], 3, 2);
+      const next = layoutReducer(state, { type: 'reorderFloor', from: 0, to: 2 });
+      expect(next.activeFloorIndex).toBe(1);
+    });
+
+    it('moving a floor from above the active down past it shifts active up', () => {
+      // active = 0; move floor 2 → 0. from(2) not < active(0); to(0) <= active(0) → active += 1 = 1.
+      const state = stateWith([], 3, 0);
+      const next = layoutReducer(state, { type: 'reorderFloor', from: 2, to: 0 });
+      expect(next.activeFloorIndex).toBe(1);
+    });
+
+    it('is a no-op for from === to or out-of-range indices', () => {
+      const before = stateWith([], 3, 1);
+      expect(layoutReducer(before, { type: 'reorderFloor', from: 1, to: 1 })).toBe(before);
+      expect(layoutReducer(before, { type: 'reorderFloor', from: 0, to: 9 })).toBe(before);
+      expect(layoutReducer(before, { type: 'reorderFloor', from: -1, to: 0 })).toBe(before);
+    });
+
+    it('actually reorders the floors array', () => {
+      const state = stateWith([], 3, 0);
+      const next = layoutReducer(state, { type: 'reorderFloor', from: 0, to: 2 });
+      expect(next.layout.floors.map((f) => f.id)).toEqual(['floor-1', 'floor-2', 'floor-0']);
+    });
+  });
+});
+
+describe('layoutReducer — applyLayout', () => {
+  it('clamps non-positive width/height to 1 and huge dims to MAX_ROOM_DIMENSION', () => {
+    const state: LayoutState = { layout: makeLayout(), activeFloorIndex: 0 };
+    const applied = layoutReducer(state, {
+      type: 'applyLayout',
+      layout: makeLayout({ width: -3, height: 9999 }),
+    });
+    expect(applied.layout.width).toBe(1);
+    expect(applied.layout.height).toBe(MAX_ROOM_DIMENSION);
+  });
+
+  it('clamps a non-finite width to 1', () => {
+    const state: LayoutState = { layout: makeLayout(), activeFloorIndex: 0 };
+    const applied = layoutReducer(state, {
+      type: 'applyLayout',
+      layout: makeLayout({ width: Number.NaN }),
+    });
+    expect(applied.layout.width).toBe(1);
+  });
+
+  it('truncates floors beyond MAX_FLOORS and backfills empty floorColor', () => {
+    const floors = Array.from({ length: MAX_FLOORS + 2 }, (_, i) =>
+      makeFloor({ id: `f${i}`, name: `F${i}`, floorColor: i === 0 ? '' : '#abc' })
+    );
+    const state: LayoutState = { layout: makeLayout(), activeFloorIndex: 0 };
+    const applied = layoutReducer(state, { type: 'applyLayout', layout: makeLayout({ floors }) });
+    expect(applied.layout.floors).toHaveLength(MAX_FLOORS);
+    expect(applied.layout.floors[0]!.floorColor).toBe('#c9a57d');
+  });
+
+  it('replaces an empty floors array with a default ground floor', () => {
+    const state: LayoutState = { layout: makeLayout(), activeFloorIndex: 0 };
+    const applied = layoutReducer(state, { type: 'applyLayout', layout: makeLayout({ floors: [] }) });
+    expect(applied.layout.floors).toEqual([INITIAL_GROUND_FLOOR]);
+  });
+
+  it('clamps activeFloorIndex to the incoming floor count', () => {
+    const state: LayoutState = { layout: makeLayout(), activeFloorIndex: 3 };
+    const applied = layoutReducer(state, {
+      type: 'applyLayout',
+      layout: makeLayout({ floors: [makeFloor({ id: 'only' })] }),
+    });
+    expect(applied.activeFloorIndex).toBe(0);
+  });
+});

--- a/components/room-organizer/lib/__testfixtures__/fixtures.ts
+++ b/components/room-organizer/lib/__testfixtures__/fixtures.ts
@@ -1,0 +1,55 @@
+import type { CatalogItem, FloorLayout, FurnitureItem, RoomLayout } from '../types';
+
+/** Build a valid FurnitureItem with sane defaults; override any field. */
+export function makeItem(overrides: Partial<FurnitureItem> = {}): FurnitureItem {
+  return {
+    id: 'item-1',
+    type: 'chair',
+    name: 'Chair',
+    width: 1,
+    depth: 1,
+    height: 1,
+    color: '#ffffff',
+    icon: '🪑',
+    position: { x: 0, z: 0 },
+    rotation: 0,
+    ...overrides,
+  };
+}
+
+/** Build a valid CatalogItem (no id/position/rotation). */
+export function makeCatalogItem(overrides: Partial<CatalogItem> = {}): CatalogItem {
+  return {
+    type: 'chair',
+    name: 'Chair',
+    width: 1,
+    depth: 1,
+    height: 1,
+    color: '#ffffff',
+    icon: '🪑',
+    price: 100,
+    category: 'seating',
+    ...overrides,
+  };
+}
+
+export function makeFloor(overrides: Partial<FloorLayout> = {}): FloorLayout {
+  return {
+    id: 'ground',
+    name: 'Ground Floor',
+    floorColor: '#c9a57d',
+    items: [],
+    ...overrides,
+  };
+}
+
+export function makeLayout(overrides: Partial<RoomLayout> = {}): RoomLayout {
+  return {
+    name: 'My Home',
+    width: 8,
+    height: 8,
+    floors: [makeFloor()],
+    roof: { style: 'gable', color: '#5d3a23' },
+    ...overrides,
+  };
+}

--- a/components/room-organizer/lib/achievements.test.ts
+++ b/components/room-organizer/lib/achievements.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest';
+import { makeFloor, makeItem, makeLayout } from './__testfixtures__/fixtures';
+import { ACHIEVEMENTS } from './achievements';
+import type { FurnitureItem } from './types';
+
+function achievement(id: string) {
+  const found = ACHIEVEMENTS.find((a) => a.id === id);
+  if (!found) throw new Error(`No achievement ${id}`);
+  return found;
+}
+
+function layoutWithItems(items: FurnitureItem[]) {
+  return makeLayout({ floors: [makeFloor({ items })] });
+}
+
+function repeatItems(n: number, overrides: Partial<FurnitureItem> = {}): FurnitureItem[] {
+  return Array.from({ length: n }, (_, i) => makeItem({ id: `i${i}`, ...overrides }));
+}
+
+describe('achievements — count thresholds fire at the boundary', () => {
+  it('first-steps fires at 1 item, not at 0', () => {
+    expect(achievement('first-steps').isMet(layoutWithItems([]))).toBe(false);
+    expect(achievement('first-steps').isMet(layoutWithItems(repeatItems(1)))).toBe(true);
+  });
+
+  it('furnished fires at 10, not at 9', () => {
+    expect(achievement('furnished').isMet(layoutWithItems(repeatItems(9)))).toBe(false);
+    expect(achievement('furnished').isMet(layoutWithItems(repeatItems(10)))).toBe(true);
+  });
+
+  it('overstuffed fires at 25, not at 24', () => {
+    expect(achievement('overstuffed').isMet(layoutWithItems(repeatItems(24)))).toBe(false);
+    expect(achievement('overstuffed').isMet(layoutWithItems(repeatItems(25)))).toBe(true);
+  });
+
+  it('counts items across all floors', () => {
+    const layout = makeLayout({
+      floors: [makeFloor({ id: 'g', items: repeatItems(6) }), makeFloor({ id: 'u', items: repeatItems(6) })],
+    });
+    expect(achievement('furnished').isMet(layout)).toBe(true);
+  });
+});
+
+describe('achievements — spend thresholds', () => {
+  it('big-spender fires at exactly §10,000', () => {
+    const under = repeatItems(1, { price: 9_999 });
+    const at = repeatItems(1, { price: 10_000 });
+    expect(achievement('big-spender').isMet(layoutWithItems(under))).toBe(false);
+    expect(achievement('big-spender').isMet(layoutWithItems(at))).toBe(true);
+  });
+
+  it('open-plan requires >=5 items AND total under §3,000', () => {
+    const cheapFive = repeatItems(5, { price: 100 }); // total 500
+    const pricyFive = repeatItems(5, { price: 1_000 }); // total 5000
+    const cheapFour = repeatItems(4, { price: 100 });
+    expect(achievement('open-plan').isMet(layoutWithItems(cheapFive))).toBe(true);
+    expect(achievement('open-plan').isMet(layoutWithItems(pricyFive))).toBe(false);
+    expect(achievement('open-plan').isMet(layoutWithItems(cheapFour))).toBe(false);
+  });
+});
+
+describe('achievements — type/structure predicates', () => {
+  it('wifi-everywhere requires a real wifi access point flag', () => {
+    expect(achievement('wifi-everywhere').isMet(layoutWithItems(repeatItems(1)))).toBe(false);
+    expect(
+      achievement('wifi-everywhere').isMet(layoutWithItems([makeItem({ isWiFiAccessPoint: true })]))
+    ).toBe(true);
+  });
+
+  it('sky-high and penthouse fire at 2 and 4 floors', () => {
+    const floors = (n: number) => makeLayout({ floors: Array.from({ length: n }, (_, i) => makeFloor({ id: `f${i}` })) });
+    expect(achievement('sky-high').isMet(floors(1))).toBe(false);
+    expect(achievement('sky-high').isMet(floors(2))).toBe(true);
+    expect(achievement('penthouse').isMet(floors(3))).toBe(false);
+    expect(achievement('penthouse').isMet(floors(4))).toBe(true);
+  });
+
+  it('going-up needs a staircase; door-installer needs a door', () => {
+    expect(achievement('going-up').isMet(layoutWithItems([makeItem({ type: 'stairs' })]))).toBe(true);
+    expect(achievement('going-up').isMet(layoutWithItems([makeItem({ type: 'chair' })]))).toBe(false);
+    expect(achievement('door-installer').isMet(layoutWithItems([makeItem({ type: 'door' })]))).toBe(true);
+  });
+
+  it('roof-it requires a non-none roof style', () => {
+    expect(achievement('roof-it').isMet(makeLayout({ roof: { style: 'none' } }))).toBe(false);
+    expect(achievement('roof-it').isMet(makeLayout({ roof: { style: 'gable' } }))).toBe(true);
+  });
+
+  it('green-thumb fires at 3 plants/trees/flowerpots', () => {
+    const two = [makeItem({ id: '1', type: 'plant' }), makeItem({ id: '2', type: 'tree' })];
+    const three = [...two, makeItem({ id: '3', type: 'flowerpot' })];
+    expect(achievement('green-thumb').isMet(layoutWithItems(two))).toBe(false);
+    expect(achievement('green-thumb').isMet(layoutWithItems(three))).toBe(true);
+  });
+
+  it('window-watcher fires at 3 windows', () => {
+    expect(achievement('window-watcher').isMet(layoutWithItems(repeatItems(2, { type: 'window' })))).toBe(false);
+    expect(achievement('window-watcher').isMet(layoutWithItems(repeatItems(3, { type: 'window' })))).toBe(true);
+  });
+
+  it('wall-whisperer fires when any floor has an interior wall', () => {
+    const withWall = makeLayout({
+      floors: [makeFloor({ interiorWalls: [{ id: 'w', x1: 0, z1: 0, x2: 1, z2: 0 }] })],
+    });
+    expect(achievement('wall-whisperer').isMet(makeLayout())).toBe(false);
+    expect(achievement('wall-whisperer').isMet(withWall)).toBe(true);
+  });
+
+  it('decorator fires at 6 unique furniture types', () => {
+    const types = ['chair', 'table', 'bed', 'desk', 'lamp', 'sofa'];
+    const items = types.map((t, i) => makeItem({ id: `i${i}`, type: t }));
+    expect(achievement('decorator').isMet(layoutWithItems(items.slice(0, 5)))).toBe(false);
+    expect(achievement('decorator').isMet(layoutWithItems(items))).toBe(true);
+  });
+});

--- a/components/room-organizer/lib/alignment.test.ts
+++ b/components/room-organizer/lib/alignment.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { makeItem } from './__testfixtures__/fixtures';
+import { alignSelection, distributeSelection } from './alignment';
+
+describe('alignSelection — edge alignment', () => {
+  const items = [
+    makeItem({ id: 'a', width: 2, depth: 2, position: { x: 0, z: 0 } }),
+    makeItem({ id: 'b', width: 4, depth: 4, position: { x: 6, z: 3 } }),
+  ];
+  const ids = new Set(['a', 'b']);
+
+  it('min-x aligns left edges', () => {
+    const result = alignSelection(items, ids, 'min-x');
+    // Leftmost edge is a's: 0 - 1 = -1. Each item centre = -1 + halfWidth.
+    expect(result.get('a')!.x).toBeCloseTo(-1 + 1, 10); // 0
+    expect(result.get('b')!.x).toBeCloseTo(-1 + 2, 10); // 1
+  });
+
+  it('max-x aligns right edges', () => {
+    const result = alignSelection(items, ids, 'max-x');
+    // Rightmost edge is b's: 6 + 2 = 8. Each centre = 8 - halfWidth.
+    expect(result.get('a')!.x).toBeCloseTo(8 - 1, 10); // 7
+    expect(result.get('b')!.x).toBeCloseTo(8 - 2, 10); // 6
+  });
+
+  it('center-x aligns centres to the average', () => {
+    const result = alignSelection(items, ids, 'center-x');
+    const avg = (0 + 6) / 2; // 3
+    expect(result.get('a')!.x).toBeCloseTo(avg, 10);
+    expect(result.get('b')!.x).toBeCloseTo(avg, 10);
+  });
+
+  it('min-z aligns top edges and leaves x untouched', () => {
+    const result = alignSelection(items, ids, 'min-z');
+    const minZ = Math.min(0 - 1, 3 - 2); // min(-1, 1) = -1
+    expect(result.get('a')!.z).toBeCloseTo(minZ + 1, 10); // 0
+    expect(result.get('b')!.z).toBeCloseTo(minZ + 2, 10); // 1
+    expect(result.get('a')!.x).toBeCloseTo(0, 10);
+  });
+
+  it('returns an empty map for fewer than two positioned items', () => {
+    expect(alignSelection(items, new Set(['a']), 'min-x').size).toBe(0);
+  });
+});
+
+describe('distributeSelection', () => {
+  it('evenly spaces the middle items along X, keeping the ends fixed', () => {
+    const items = [
+      makeItem({ id: 'a', position: { x: 0, z: 0 } }),
+      makeItem({ id: 'b', position: { x: 1, z: 0 } }),
+      makeItem({ id: 'c', position: { x: 9, z: 0 } }),
+    ];
+    const result = distributeSelection(items, new Set(['a', 'b', 'c']), 'x');
+    // Ends fixed, middle placed at start + step*1 = 0 + 4.5.
+    expect(result.has('a')).toBe(false);
+    expect(result.has('c')).toBe(false);
+    expect(result.get('b')!.x).toBeCloseTo(4.5, 10);
+  });
+
+  it('distributes along Z and leaves x untouched', () => {
+    const items = [
+      makeItem({ id: 'a', position: { x: 2, z: 0 } }),
+      makeItem({ id: 'b', position: { x: 3, z: 5 } }),
+      makeItem({ id: 'c', position: { x: 4, z: 10 } }),
+    ];
+    const result = distributeSelection(items, new Set(['a', 'b', 'c']), 'z');
+    expect(result.get('b')!.z).toBeCloseTo(5, 10);
+    expect(result.get('b')!.x).toBeCloseTo(3, 10);
+  });
+
+  it('returns an empty map for fewer than three positioned items', () => {
+    const items = [makeItem({ id: 'a', position: { x: 0, z: 0 } }), makeItem({ id: 'b', position: { x: 1, z: 0 } })];
+    expect(distributeSelection(items, new Set(['a', 'b']), 'x').size).toBe(0);
+  });
+});

--- a/components/room-organizer/lib/geometry.test.ts
+++ b/components/room-organizer/lib/geometry.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'vitest';
+import { makeItem } from './__testfixtures__/fixtures';
+import {
+  boundingRadius,
+  hasCollisions,
+  itemInBounds,
+  itemsOverlap,
+  rotatedHalfExtents,
+  snapToGrid,
+} from './geometry';
+
+describe('boundingRadius', () => {
+  it('is the half-diagonal of the footprint', () => {
+    expect(boundingRadius({ width: 4, depth: 3 })).toBeCloseTo(2.5, 10); // hypot(2,1.5)
+  });
+});
+
+describe('rotatedHalfExtents', () => {
+  it('equals half the raw dims at 0 rotation', () => {
+    expect(rotatedHalfExtents({ width: 2, depth: 4, rotation: 0 })).toEqual({ halfW: 1, halfD: 2 });
+  });
+
+  it('swaps width/depth extents at 90°', () => {
+    const e = rotatedHalfExtents({ width: 2, depth: 4, rotation: Math.PI / 2 });
+    expect(e.halfW).toBeCloseTo(2, 10);
+    expect(e.halfD).toBeCloseTo(1, 10);
+  });
+
+  it('at 45° a unit square spans its diagonal', () => {
+    const e = rotatedHalfExtents({ width: 1, depth: 1, rotation: Math.PI / 4 });
+    expect(e.halfW).toBeCloseTo(Math.SQRT2 / 2, 10);
+    expect(e.halfD).toBeCloseTo(Math.SQRT2 / 2, 10);
+  });
+});
+
+describe('itemsOverlap — OBB via SAT', () => {
+  it('detects two axis-aligned boxes overlapping', () => {
+    const a = makeItem({ id: 'a', width: 2, depth: 2, position: { x: 0, z: 0 } });
+    const b = makeItem({ id: 'b', width: 2, depth: 2, position: { x: 1, z: 0 } });
+    expect(itemsOverlap(a, b)).toBe(true);
+  });
+
+  it('reports no overlap for clearly separated boxes', () => {
+    const a = makeItem({ id: 'a', width: 1, depth: 1, position: { x: 0, z: 0 } });
+    const b = makeItem({ id: 'b', width: 1, depth: 1, position: { x: 5, z: 0 } });
+    expect(itemsOverlap(a, b)).toBe(false);
+  });
+
+  it('returns false when either item lacks a position', () => {
+    const a = makeItem({ id: 'a', position: undefined });
+    const b = makeItem({ id: 'b', position: { x: 0, z: 0 } });
+    expect(itemsOverlap(a, b)).toBe(false);
+  });
+
+  it('thin bars: SAT separates a diagonal gap the bounding-circle broad phase misses', () => {
+    // Two long thin bars both aligned along +X (spanning x∈[-2,2], z∈[-0.1,0.1]),
+    // stacked with a vertical gap of ~1.2m. Their bounding circles (radius ~2)
+    // overlap because the bars are long, but the oriented boxes are clearly apart.
+    const a = makeItem({ id: 'a', width: 4, depth: 0.2, rotation: 0, position: { x: 0, z: 0 } });
+    const b = makeItem({ id: 'b', width: 4, depth: 0.2, rotation: 0, position: { x: 0, z: 1.4 } });
+    const dist = Math.hypot(0, 1.4);
+    // Broad phase (circles) passes: distance 1.4 < r_a + r_b ≈ 4.0.
+    expect(dist).toBeLessThan(boundingRadius(a) + boundingRadius(b));
+    // SAT rejects: the bars' z-ranges [-0.1,0.1] and [1.3,1.5] don't touch.
+    expect(itemsOverlap(a, b)).toBe(false);
+  });
+
+  it('a 45°-rotated square overlaps a box its corner pokes into', () => {
+    const a = makeItem({ id: 'a', width: 2, depth: 2, rotation: Math.PI / 4, position: { x: 0, z: 0 } });
+    // Corner of the rotated square reaches ~sqrt(2) ≈ 1.414 along +X.
+    const b = makeItem({ id: 'b', width: 1, depth: 1, rotation: 0, position: { x: 1.6, z: 0 } });
+    expect(itemsOverlap(a, b)).toBe(true);
+  });
+});
+
+describe('itemInBounds', () => {
+  const W = 10;
+  const D = 10;
+
+  it('is true for an item well inside the room', () => {
+    expect(itemInBounds(makeItem({ width: 2, depth: 2, position: { x: 0, z: 0 } }), W, D)).toBe(true);
+  });
+
+  it('is false when the footprint crosses a wall', () => {
+    expect(itemInBounds(makeItem({ width: 2, depth: 2, position: { x: 4.5, z: 0 } }), W, D)).toBe(false);
+  });
+
+  it('accounts for rotation when checking bounds', () => {
+    // A 4×0.2 bar at 45° near the corner spans its diagonal and pokes out.
+    const bar = makeItem({ width: 4, depth: 0.2, rotation: Math.PI / 4, position: { x: 4, z: 4 } });
+    expect(itemInBounds(bar, W, D)).toBe(false);
+  });
+
+  it('returns false for a positionless item', () => {
+    expect(itemInBounds(makeItem({ position: undefined }), W, D)).toBe(false);
+  });
+});
+
+describe('snapToGrid', () => {
+  it('rounds to the nearest multiple', () => {
+    expect(snapToGrid(0.24, 0.5)).toBe(0);
+    expect(snapToGrid(0.26, 0.5)).toBe(0.5);
+    expect(snapToGrid(-0.26, 0.5)).toBe(-0.5);
+    expect(snapToGrid(1.0, 0.25)).toBe(1.0);
+  });
+});
+
+describe('hasCollisions', () => {
+  const W = 10;
+  const D = 10;
+
+  it('flags an in-room item overlapping another', () => {
+    const a = makeItem({ id: 'a', width: 2, depth: 2, position: { x: 0, z: 0 } });
+    const b = makeItem({ id: 'b', width: 2, depth: 2, position: { x: 1, z: 0 } });
+    expect(hasCollisions(a, [a, b], W, D)).toBe(true);
+  });
+
+  it('flags an in-room item that crosses the wall even with no neighbours', () => {
+    const a = makeItem({ id: 'a', width: 2, depth: 2, position: { x: 4.5, z: 0 } });
+    expect(hasCollisions(a, [a], W, D)).toBe(true);
+  });
+
+  it('does not flag a lone, in-bounds item', () => {
+    const a = makeItem({ id: 'a', width: 2, depth: 2, position: { x: 0, z: 0 } });
+    expect(hasCollisions(a, [a], W, D)).toBe(false);
+  });
+
+  it('never flags security cameras against room bounds', () => {
+    const cam = makeItem({ id: 'c', type: 'security-camera', position: { x: 4.9, z: 4.9 } });
+    expect(hasCollisions(cam, [cam], W, D)).toBe(false);
+  });
+
+  it('openings ignore room bounds but still collide with neighbours', () => {
+    const door = makeItem({ id: 'd', type: 'door', width: 1, depth: 0.2, position: { x: 5, z: 0 } });
+    expect(hasCollisions(door, [door], W, D)).toBe(false);
+    const other = makeItem({ id: 'o', type: 'window', width: 1, depth: 0.2, position: { x: 5, z: 0 } });
+    expect(hasCollisions(door, [door, other], W, D)).toBe(true);
+  });
+
+  it('outdoor items are flagged when they poke into the room', () => {
+    const tree = makeItem({ id: 't', type: 'tree', category: 'outdoor', width: 1, depth: 1, position: { x: 0, z: 0 } });
+    expect(hasCollisions(tree, [tree], W, D)).toBe(true);
+  });
+
+  it('outdoor items placed fully outside are allowed', () => {
+    const tree = makeItem({ id: 't', type: 'tree', category: 'outdoor', width: 1, depth: 1, position: { x: 8, z: 0 } });
+    expect(hasCollisions(tree, [tree], W, D)).toBe(false);
+  });
+
+  it('returns false for a positionless item', () => {
+    expect(hasCollisions(makeItem({ position: undefined }), [], W, D)).toBe(false);
+  });
+});

--- a/components/room-organizer/lib/schema.test.ts
+++ b/components/room-organizer/lib/schema.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+import { makeFloor, makeItem, makeLayout } from './__testfixtures__/fixtures';
+import { MAX_FLOORS, MAX_ROOM_DIMENSION } from './constants';
+import { isFloorLayout, isFurnitureItem, isRoomLayout, parseStoredLayout } from './schema';
+
+describe('isFurnitureItem', () => {
+  it('accepts a well-formed item', () => {
+    expect(isFurnitureItem(makeItem())).toBe(true);
+  });
+
+  it('accepts an item without optional fields', () => {
+    const minimal = {
+      id: 'a',
+      type: 'chair',
+      name: 'Chair',
+      width: 1,
+      depth: 1,
+      height: 1,
+      color: '#fff',
+      icon: 'x',
+    };
+    expect(isFurnitureItem(minimal)).toBe(true);
+  });
+
+  it.each([
+    ['non-object', null],
+    ['missing id', { ...makeItem(), id: 5 }],
+    ['zero width', { ...makeItem(), width: 0 }],
+    ['negative depth', { ...makeItem(), depth: -1 }],
+    ['non-finite height', { ...makeItem(), height: Number.POSITIVE_INFINITY }],
+    ['non-string color', { ...makeItem(), color: 123 }],
+    ['malformed position', { ...makeItem(), position: { x: 1 } }],
+    ['non-finite rotation', { ...makeItem(), rotation: Number.NaN }],
+    ['non-boolean locked', { ...makeItem(), locked: 'no' }],
+    ['non-boolean mirrored', { ...makeItem(), mirrored: 1 }],
+    ['non-boolean isWiFiAccessPoint', { ...makeItem(), isWiFiAccessPoint: 'yes' }],
+  ])('rejects %s', (_label, value) => {
+    expect(isFurnitureItem(value)).toBe(false);
+  });
+});
+
+describe('isFloorLayout', () => {
+  it('accepts a valid floor', () => {
+    expect(isFloorLayout(makeFloor({ items: [makeItem()] }))).toBe(true);
+  });
+
+  it('rejects a floor whose items are malformed', () => {
+    expect(isFloorLayout(makeFloor({ items: [{ id: 'bad' } as never] }))).toBe(false);
+  });
+
+  it('rejects a floor with a non-string wall color', () => {
+    expect(isFloorLayout({ ...makeFloor(), wallColors: { north: 5 } })).toBe(false);
+  });
+
+  it('rejects a floor whose interior wall has a non-finite coordinate', () => {
+    const floor = { ...makeFloor(), interiorWalls: [{ id: 'w', x1: 0, z1: 0, x2: Number.NaN, z2: 1 }] };
+    expect(isFloorLayout(floor)).toBe(false);
+  });
+});
+
+describe('isRoomLayout', () => {
+  it('accepts the current multi-floor shape', () => {
+    expect(isRoomLayout(makeLayout())).toBe(true);
+  });
+
+  it.each([
+    ['zero width', makeLayout({ width: 0 })],
+    ['negative height', makeLayout({ height: -4 })],
+    ['over-max dimension', makeLayout({ width: MAX_ROOM_DIMENSION + 1 })],
+    ['empty floors', makeLayout({ floors: [] })],
+    ['too many floors', makeLayout({ floors: Array.from({ length: MAX_FLOORS + 1 }, (_, i) => makeFloor({ id: `f${i}` })) })],
+  ])('rejects %s', (_label, value) => {
+    expect(isRoomLayout(value)).toBe(false);
+  });
+
+  it('rejects a bad roof style', () => {
+    expect(isRoomLayout({ ...makeLayout(), roof: { style: 'dome' } })).toBe(false);
+  });
+
+  it('rejects a bad floorPlanFitMode', () => {
+    expect(isRoomLayout({ ...makeLayout(), floorPlanFitMode: 'squish' })).toBe(false);
+  });
+
+  it('accepts exactly MAX_ROOM_DIMENSION and exactly MAX_FLOORS', () => {
+    const layout = makeLayout({
+      width: MAX_ROOM_DIMENSION,
+      floors: Array.from({ length: MAX_FLOORS }, (_, i) => makeFloor({ id: `f${i}` })),
+    });
+    expect(isRoomLayout(layout)).toBe(true);
+  });
+});
+
+describe('parseStoredLayout', () => {
+  it('accepts and returns the current multi-floor shape as-is', () => {
+    const layout = makeLayout();
+    expect(parseStoredLayout(layout)).toBe(layout);
+  });
+
+  it('migrates a legacy single-floor layout into the multi-floor shape', () => {
+    const legacy = {
+      name: 'Legacy Home',
+      width: 6,
+      height: 7,
+      items: [makeItem({ id: 'sofa' })],
+      floorColor: '#deadbe',
+      floorPattern: 'wood',
+      wallPattern: 'brick',
+      wallColors: { north: '#111' },
+      floorPlanOpacity: 0.4,
+    };
+    const parsed = parseStoredLayout(legacy);
+    expect(parsed).not.toBeNull();
+    expect(parsed!.floors).toHaveLength(1);
+    const ground = parsed!.floors[0]!;
+    expect(ground).toMatchObject({
+      id: 'ground',
+      name: 'Ground Floor',
+      floorColor: '#deadbe',
+      floorPattern: 'wood',
+      wallPattern: 'brick',
+      wallColors: { north: '#111' },
+    });
+    expect(ground.items.map((i) => i.id)).toEqual(['sofa']);
+    expect(parsed!.floorPlanOpacity).toBe(0.4);
+    // Legacy has no floors key.
+    expect('floors' in legacy).toBe(false);
+  });
+
+  it('does not treat an object that already has floors as legacy', () => {
+    // A malformed multi-floor object (bad floor) should be rejected, not migrated.
+    const almost = { ...makeLayout(), floors: [{ id: 'x' }] };
+    expect(parseStoredLayout(almost)).toBeNull();
+  });
+
+  it.each([
+    ['null', null],
+    ['a string', 'not a layout'],
+    ['non-positive dims', makeLayout({ width: 0 })],
+    ['bad roof style', { ...makeLayout(), roof: { style: 'dome' } }],
+    ['over MAX_FLOORS', makeLayout({ floors: Array.from({ length: MAX_FLOORS + 1 }, (_, i) => makeFloor({ id: `f${i}` })) })],
+    ['non-boolean flag on item', makeLayout({ floors: [makeFloor({ items: [{ ...makeItem(), locked: 'no' } as never] })] })],
+    ['malformed position on item', makeLayout({ floors: [makeFloor({ items: [{ ...makeItem(), position: { x: 1 } } as never] })] })],
+  ])('rejects %s (returns null)', (_label, value) => {
+    expect(parseStoredLayout(value)).toBeNull();
+  });
+});

--- a/components/room-organizer/lib/share.test.ts
+++ b/components/room-organizer/lib/share.test.ts
@@ -1,0 +1,103 @@
+import { beforeAll, describe, expect, it } from 'vitest';
+import { makeFloor, makeItem, makeLayout } from './__testfixtures__/fixtures';
+import { decodeShareUrl, encodeShareUrl, isShareUrlReasonablySized } from './share';
+
+// share.ts encodes via window.btoa / window.atob. In the Node test environment
+// there is no window, so provide a minimal shim backed by Node's global
+// btoa/atob before importing exercises the codec.
+beforeAll(() => {
+  if (typeof (globalThis as { window?: unknown }).window === 'undefined') {
+    (globalThis as { window?: unknown }).window = {
+      btoa: (s: string) => Buffer.from(s, 'binary').toString('base64'),
+      atob: (s: string) => Buffer.from(s, 'base64').toString('binary'),
+    };
+  }
+});
+
+const ORIGIN = 'https://example.com/app';
+const PREFIX = '#layout=';
+
+function hashOf(url: string): string {
+  return url.slice(url.indexOf(PREFIX));
+}
+
+describe('encodeShareUrl / decodeShareUrl roundtrip', () => {
+  it('roundtrips a basic layout', () => {
+    const layout = makeLayout({ name: 'Roundtrip House' });
+    const { url } = encodeShareUrl(layout, ORIGIN);
+    expect(url.startsWith(`${ORIGIN}${PREFIX}`)).toBe(true);
+    const decoded = decodeShareUrl(hashOf(url));
+    expect(decoded).toEqual(layout);
+  });
+
+  it('roundtrips unicode and emoji names', () => {
+    const layout = makeLayout({ name: 'Château 🏰 des Rêves — 日本語' });
+    const { url } = encodeShareUrl(layout, ORIGIN);
+    const decoded = decodeShareUrl(hashOf(url));
+    expect(decoded!.name).toBe('Château 🏰 des Rêves — 日本語');
+  });
+
+  it('roundtrips a layout with items across multiple floors', () => {
+    const layout = makeLayout({
+      floors: [
+        makeFloor({ id: 'g', items: [makeItem({ id: 'a', type: 'sofa' })] }),
+        makeFloor({ id: 'u', name: 'First Floor', items: [makeItem({ id: 'b', type: 'bed' })] }),
+      ],
+    });
+    const decoded = decodeShareUrl(hashOf(encodeShareUrl(layout, ORIGIN).url));
+    expect(decoded).toEqual(layout);
+  });
+
+  it('produces URL-safe base64 (no + / = characters in the payload)', () => {
+    const layout = makeLayout({ name: '???>>><<<~~~ padding padding padding' });
+    const { url } = encodeShareUrl(layout, ORIGIN);
+    const payload = url.slice(url.indexOf(PREFIX) + PREFIX.length);
+    expect(payload).not.toMatch(/[+/=]/);
+  });
+});
+
+describe('encodeShareUrl — floor-plan stripping', () => {
+  it('strips a floor-plan image and reports strippedFloorPlan=true', () => {
+    const layout = makeLayout({ floorPlanImage: 'data:image/png;base64,AAAA' });
+    const { url, strippedFloorPlan } = encodeShareUrl(layout, ORIGIN);
+    expect(strippedFloorPlan).toBe(true);
+    const decoded = decodeShareUrl(hashOf(url));
+    expect(decoded!.floorPlanImage).toBeUndefined();
+  });
+
+  it('does not mutate the source layout when stripping', () => {
+    const layout = makeLayout({ floorPlanImage: 'data:image/png;base64,AAAA' });
+    encodeShareUrl(layout, ORIGIN);
+    expect(layout.floorPlanImage).toBe('data:image/png;base64,AAAA');
+  });
+
+  it('reports strippedFloorPlan=false when there is no image', () => {
+    expect(encodeShareUrl(makeLayout(), ORIGIN).strippedFloorPlan).toBe(false);
+  });
+});
+
+describe('decodeShareUrl — corrupt input returns null without throwing', () => {
+  it('returns null when the hash prefix is missing', () => {
+    expect(decodeShareUrl('#other=abc')).toBeNull();
+  });
+
+  it('returns null for an empty payload', () => {
+    expect(decodeShareUrl(PREFIX)).toBeNull();
+  });
+
+  it('returns null for garbage base64 that is not valid JSON', () => {
+    expect(decodeShareUrl(`${PREFIX}!!!not-base64!!!`)).toBeNull();
+  });
+
+  it('returns null when the payload decodes to a non-layout object', () => {
+    const encoded = Buffer.from(JSON.stringify({ foo: 'bar' }), 'binary').toString('base64');
+    expect(decodeShareUrl(`${PREFIX}${encoded}`)).toBeNull();
+  });
+});
+
+describe('isShareUrlReasonablySized', () => {
+  it('accepts a short URL and rejects an oversized one', () => {
+    expect(isShareUrlReasonablySized('https://x.com/#layout=abc')).toBe(true);
+    expect(isShareUrlReasonablySized('x'.repeat(12_001))).toBe(false);
+  });
+});

--- a/components/room-organizer/lib/wall-snap.test.ts
+++ b/components/room-organizer/lib/wall-snap.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+import { snapWallEndpoint } from './wall-snap';
+import type { InteriorWall } from './types';
+
+const ROOM = { roomWidth: 10, roomDepth: 10 };
+
+describe('snapWallEndpoint — vertex snap', () => {
+  it('snaps to an existing wall endpoint within range', () => {
+    const walls: InteriorWall[] = [{ id: 'w', x1: 2, z1: 2, x2: 3, z2: 3 }];
+    const result = snapWallEndpoint({ point: { x: 2.1, z: 1.9 }, existingWalls: walls, ...ROOM });
+    expect(result.kind).toBe('vertex');
+    expect(result.point).toEqual({ x: 2, z: 2 });
+  });
+
+  it('snaps to a building corner', () => {
+    const result = snapWallEndpoint({ point: { x: 4.8, z: 4.7 }, existingWalls: [], ...ROOM });
+    expect(result.kind).toBe('vertex');
+    expect(result.point).toEqual({ x: 5, z: 5 });
+  });
+
+  it('does not vertex-snap when the nearest vertex is beyond snapDistance', () => {
+    const result = snapWallEndpoint({
+      point: { x: 0, z: 0 },
+      existingWalls: [{ id: 'w', x1: 3, z1: 3, x2: 3.5, z2: 3.5 }],
+      ...ROOM,
+    });
+    expect(result.kind).toBe('none');
+    expect(result.point).toEqual({ x: 0, z: 0 });
+  });
+
+  it('respects a custom snapDistance', () => {
+    const walls: InteriorWall[] = [{ id: 'w', x1: 2, z1: 2, x2: 3, z2: 3 }];
+    // Cursor is exactly 0.4m from the (2,2) endpoint.
+    const near = { point: { x: 2.4, z: 2 }, existingWalls: walls, ...ROOM };
+    expect(snapWallEndpoint({ ...near, snapDistance: 0.3 }).kind).toBe('none');
+    expect(snapWallEndpoint({ ...near, snapDistance: 0.5 }).kind).toBe('vertex');
+  });
+
+  it('ignores stale endpoints that sit outside the lot', () => {
+    // Wall endpoint far outside the room should not be a snap target.
+    const walls: InteriorWall[] = [{ id: 'w', x1: 99, z1: 99, x2: 1, z2: 1 }];
+    const result = snapWallEndpoint({ point: { x: 4.9, z: 4.9 }, existingWalls: walls, ...ROOM });
+    // Should snap to the building corner (5,5), not the stale (99,99) vertex.
+    expect(result.point).toEqual({ x: 5, z: 5 });
+  });
+});
+
+describe('snapWallEndpoint — right-angle snap', () => {
+  it('snaps to a horizontal line from the chain anchor', () => {
+    const result = snapWallEndpoint({
+      point: { x: 3, z: 1.1 },
+      existingWalls: [],
+      fromPoint: { x: 0, z: 1 },
+      ...ROOM,
+    });
+    expect(result.kind).toBe('right-angle');
+    expect(result.point).toEqual({ x: 3, z: 1 });
+  });
+
+  it('snaps to a vertical line from the chain anchor', () => {
+    const result = snapWallEndpoint({
+      point: { x: 1.1, z: 3 },
+      existingWalls: [],
+      fromPoint: { x: 1, z: 0 },
+      ...ROOM,
+    });
+    expect(result.kind).toBe('right-angle');
+    expect(result.point).toEqual({ x: 1, z: 3 });
+  });
+
+  it('does not right-angle snap without a fromPoint', () => {
+    const result = snapWallEndpoint({ point: { x: 3, z: 0.05 }, existingWalls: [], ...ROOM });
+    expect(result.kind).toBe('none');
+  });
+});
+
+describe('snapWallEndpoint — clamping', () => {
+  it('clamps a point dragged onto the grass back to the footprint', () => {
+    const result = snapWallEndpoint({ point: { x: 100, z: -100 }, existingWalls: [], ...ROOM });
+    // The exact corner is a vertex within range post-clamp.
+    expect(result.point.x).toBeLessThanOrEqual(5);
+    expect(result.point.z).toBeGreaterThanOrEqual(-5);
+    expect(result.point).toEqual({ x: 5, z: -5 });
+  });
+
+  it('clamps but reports "none" when far from any vertex after clamping', () => {
+    const result = snapWallEndpoint({ point: { x: 0, z: 20 }, existingWalls: [], ...ROOM });
+    // z clamps to 5, x stays 0 → distance to nearest corner (±5,5) is 5 > snapDistance → none.
+    expect(result.kind).toBe('none');
+    expect(result.point).toEqual({ x: 0, z: 5 });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "threejs-sims-house-builder",
-  "version": "1.3.1",
+  "version": "1.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "threejs-sims-house-builder",
-      "version": "1.3.1",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-label": "^2.1.0",
@@ -32,7 +32,8 @@
         "postcss": "^8.5.10",
         "tailwindcss": "^3.4.13",
         "tailwindcss-animate": "^1.0.7",
-        "typescript": "^5.6.3"
+        "typescript": "^5.6.3",
+        "vitest": "^4.1.10"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -966,6 +967,16 @@
         "node": ">=12.4.0"
       }
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.143.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.143.0.tgz",
+      "integrity": "sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -1813,6 +1824,269 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.2.3.tgz",
+      "integrity": "sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.2.3.tgz",
+      "integrity": "sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.2.3.tgz",
+      "integrity": "sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.2.3.tgz",
+      "integrity": "sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.2.3.tgz",
+      "integrity": "sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.2.3.tgz",
+      "integrity": "sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.2.3.tgz",
+      "integrity": "sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.2.3.tgz",
+      "integrity": "sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.2.3.tgz",
+      "integrity": "sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.2.3.tgz",
+      "integrity": "sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.2.3.tgz",
+      "integrity": "sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.2.3.tgz",
+      "integrity": "sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.2.3.tgz",
+      "integrity": "sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1824,6 +2098,13 @@
       "version": "1.16.1",
       "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.16.1.tgz",
       "integrity": "sha512-TvZbIpeKqGQQ7X0zSCvPH9riMSFQFSggnfBjFZ1mEoILW+UuXCKwOoPcgjMwiUtRqFZ8jWhPJc4um14vC6I4ag==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
       "license": "MIT"
     },
@@ -1853,6 +2134,31 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -2560,6 +2866,119 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.10.tgz",
+      "integrity": "sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.10.tgz",
+      "integrity": "sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.10",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.10.tgz",
+      "integrity": "sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.10.tgz",
+      "integrity": "sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.10",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.10.tgz",
+      "integrity": "sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.10.tgz",
+      "integrity": "sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.10.tgz",
+      "integrity": "sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.10",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@webgpu/types": {
       "version": "0.1.70",
       "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
@@ -2850,6 +3269,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types-flow": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
@@ -3121,6 +3550,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -3237,6 +3676,13 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
       "license": "MIT"
     },
@@ -3401,8 +3847,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "devOptional": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -3585,6 +4031,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
+      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.2",
@@ -4137,6 +4590,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -4145,6 +4608,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -5305,6 +5778,279 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lightningcss": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.33.0.tgz",
+      "integrity": "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.33.0",
+        "lightningcss-darwin-arm64": "1.33.0",
+        "lightningcss-darwin-x64": "1.33.0",
+        "lightningcss-freebsd-x64": "1.33.0",
+        "lightningcss-linux-arm-gnueabihf": "1.33.0",
+        "lightningcss-linux-arm64-gnu": "1.33.0",
+        "lightningcss-linux-arm64-musl": "1.33.0",
+        "lightningcss-linux-x64-gnu": "1.33.0",
+        "lightningcss-linux-x64-musl": "1.33.0",
+        "lightningcss-win32-arm64-msvc": "1.33.0",
+        "lightningcss-win32-x64-msvc": "1.33.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.33.0.tgz",
+      "integrity": "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.33.0.tgz",
+      "integrity": "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.33.0.tgz",
+      "integrity": "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.33.0.tgz",
+      "integrity": "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.33.0.tgz",
+      "integrity": "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.33.0.tgz",
+      "integrity": "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.33.0.tgz",
+      "integrity": "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.33.0.tgz",
+      "integrity": "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.33.0.tgz",
+      "integrity": "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.33.0.tgz",
+      "integrity": "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.33.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.33.0.tgz",
+      "integrity": "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
     "node_modules/lilconfig": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
@@ -5367,6 +6113,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -5727,6 +6483,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.4.tgz",
+      "integrity": "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5852,6 +6622,13 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
     },
@@ -6357,6 +7134,39 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/rolldown": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.2.3.tgz",
+      "integrity": "sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.143.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.2.3",
+        "@rolldown/binding-darwin-arm64": "1.2.3",
+        "@rolldown/binding-darwin-x64": "1.2.3",
+        "@rolldown/binding-freebsd-x64": "1.2.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.2.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.2.3",
+        "@rolldown/binding-linux-arm64-musl": "1.2.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.2.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-gnu": "1.2.3",
+        "@rolldown/binding-linux-x64-musl": "1.2.3",
+        "@rolldown/binding-openharmony-arm64": "1.2.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.2.3",
+        "@rolldown/binding-win32-x64-msvc": "1.2.3"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -6651,6 +7461,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6664,6 +7481,20 @@
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stable-hash/-/stable-hash-0.0.5.tgz",
       "integrity": "sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.2.0.tgz",
+      "integrity": "sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==",
       "dev": true,
       "license": "MIT"
     },
@@ -6997,6 +7828,23 @@
       "integrity": "sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.3.0.tgz",
+      "integrity": "sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -7043,6 +7891,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.1.tgz",
+      "integrity": "sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/to-regex-range": {
@@ -7370,6 +8228,200 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/vite": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.2.1.tgz",
+      "integrity": "sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lightningcss": "^1.33.0",
+        "picomatch": "^4.0.5",
+        "postcss": "^8.5.25",
+        "rolldown": "~1.2.1",
+        "tinyglobby": "^0.2.17"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.4.0",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.10",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.10.tgz",
+      "integrity": "sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.10",
+        "@vitest/mocker": "4.1.10",
+        "@vitest/pretty-format": "4.1.10",
+        "@vitest/runner": "4.1.10",
+        "@vitest/snapshot": "4.1.10",
+        "@vitest/spy": "4.1.10",
+        "@vitest/utils": "4.1.10",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.10",
+        "@vitest/browser-preview": "4.1.10",
+        "@vitest/browser-webdriverio": "4.1.10",
+        "@vitest/coverage-istanbul": "4.1.10",
+        "@vitest/coverage-v8": "4.1.10",
+        "@vitest/ui": "4.1.10",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+      "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -7473,6 +8525,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint --ext .ts,.tsx app components",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@radix-ui/react-label": "^2.1.0",
@@ -39,6 +41,7 @@
     "postcss": "^8.5.10",
     "tailwindcss": "^3.4.13",
     "tailwindcss-animate": "^1.0.7",
-    "typescript": "^5.6.3"
+    "typescript": "^5.6.3",
+    "vitest": "^4.1.10"
   }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    // Modules under test are React-free and Three.js-free pure logic, so the
+    // fast Node environment is sufficient — no jsdom needed.
+    environment: 'node',
+    globals: false,
+    include: ['components/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary

Sets up **Vitest** (node environment, TS-native, ESM-friendly) as the project's first testing framework and adds a focused unit-test suite for the pure, React-free business logic. **150 tests, all green.**

- `vitest` added as a devDependency; `vitest.config.ts` uses the `node` environment (modules under test have no React/Three.js dependency, so no jsdom).
- New scripts: `npm run test` (`vitest run`) and `npm run test:watch` (`vitest`). Existing scripts untouched.
- Tests are co-located as `*.test.ts` next to source, with shared fixtures under `lib/__testfixtures__/`.
- The deploy workflow now runs `npm run test` after typecheck and lint.

## Coverage

| Module | Focus |
| --- | --- |
| `hooks/layout-reducer.ts` | item CRUD, bulk ops, `rotateSelection` (rigid rotation about centroid — distances + centroid preserved), floor add/remove/reorder with `activeFloorIndex` tracking, `applyLayout` clamping/normalisation |
| `lib/schema.ts` | `parseStoredLayout` accepts multi-floor, migrates legacy single-floor, rejects malformed input (bad dims, roof style, over-MAX_FLOORS, non-boolean flags, malformed position) |
| `lib/share.ts` | encode/decode roundtrip incl. unicode/emoji, floor-plan stripping, corrupt-hash null handling |
| `lib/geometry.ts` | OBB/SAT overlap incl. rotated cases, `hasCollisions`, `snapToGrid`, `itemInBounds`, rotated-AABB extents |
| `lib/wall-snap.ts` | vertex / right-angle snapping, snap radius, lot clamping |
| `lib/alignment.ts` | edge alignment, axis distribution |
| `lib/achievements.ts` | threshold predicates fire/don't-fire at the boundary |

## Notes

- No source under `components/` was modified — test files and config only.
- No genuine bugs found; every test asserts current behavior. No `test.todo`/`test.skip` parked.

## Verification

- `npm run test` — 150 passed (7 files)
- `npm run typecheck` — clean
- `npm run lint -- --max-warnings=0` — clean
- `npm run build` — succeeds

Fixes #6