### PR TITLE
Fix geometry polish bundle: camera seating, roof winding, grid, stairs holes

### DIFF
--- a/components/room-organizer/canvas-2d/render.ts
+++ b/components/room-organizer/canvas-2d/render.ts
@@ -1,3 +1,4 @@
+import { GRID_SIZE_METERS } from '../lib/constants';
 import { rotatedHalfExtents } from '../lib/geometry';
 import type { FloorLayout, FurnitureItem, RoomLayout } from '../lib/types';
 
@@ -133,16 +134,24 @@ function drawGrid(
 ): void {
   ctx.strokeStyle = '#ddd';
   ctx.lineWidth = 1;
-  for (let x = 0; x <= layout.width; x += 0.5) {
+  // Anchor the grid to the world centre (0,0) so the drawn cells line up with
+  // `snapToGrid`, which rounds world coordinates to multiples of
+  // GRID_SIZE_METERS about the origin. Corner-anchoring (0, 0.5, 1.0 …) drifts
+  // by `(width/2 mod GRID_SIZE_METERS)` and makes items look off-grid.
+  const halfW = layout.width / 2;
+  const halfD = layout.height / 2;
+  for (let wx = Math.ceil(-halfW / GRID_SIZE_METERS) * GRID_SIZE_METERS; wx <= halfW; wx += GRID_SIZE_METERS) {
+    const sx = offsetX + (wx + halfW) * scale;
     ctx.beginPath();
-    ctx.moveTo(offsetX + x * scale, offsetY);
-    ctx.lineTo(offsetX + x * scale, offsetY + layout.height * scale);
+    ctx.moveTo(sx, offsetY);
+    ctx.lineTo(sx, offsetY + layout.height * scale);
     ctx.stroke();
   }
-  for (let y = 0; y <= layout.height; y += 0.5) {
+  for (let wz = Math.ceil(-halfD / GRID_SIZE_METERS) * GRID_SIZE_METERS; wz <= halfD; wz += GRID_SIZE_METERS) {
+    const sy = offsetY + (wz + halfD) * scale;
     ctx.beginPath();
-    ctx.moveTo(offsetX, offsetY + y * scale);
-    ctx.lineTo(offsetX + layout.width * scale, offsetY + y * scale);
+    ctx.moveTo(offsetX, sy);
+    ctx.lineTo(offsetX + layout.width * scale, sy);
     ctx.stroke();
   }
 }

--- a/components/room-organizer/lib/opening-snap.ts
+++ b/components/room-organizer/lib/opening-snap.ts
@@ -20,7 +20,23 @@ export interface OpeningSnap {
   wallKind: WallKind;
   /** Distance from the original cursor position to the wall, in metres. */
   distance: number;
+  /**
+   * The interior wall segment this snap landed on, when `wallKind` is
+   * `interior`. Wall-mounted items use it to seat on whichever side the cursor
+   * is on (an interior wall has no fixed inside/outside) and to inset by the
+   * wall's half-thickness so the item's back face rests on the surface rather
+   * than sinking into the centreline.
+   */
+  interiorWall?: { x1: number; z1: number; x2: number; z2: number };
 }
+
+/**
+ * Interior walls are modelled 0.16 m thick (see three/interior-walls.ts, which
+ * owns the authoritative constant). A flush inset measured from the wall
+ * centreline would bury a wall-mounted item's back face half that depth inside
+ * the wall, so seating against an interior wall adds this half-thickness.
+ */
+const INTERIOR_WALL_HALF_THICKNESS = 0.08;
 
 export interface SnapOpeningOptions {
   position: { x: number; z: number };
@@ -77,6 +93,7 @@ export function snapOpeningToWall(options: SnapOpeningOptions): OpeningSnap {
       rotation: -Math.atan2(wall.z2 - wall.z1, wall.x2 - wall.x1),
       wallKind: 'interior',
       distance: projected.distance,
+      interiorWall: { x1: wall.x1, z1: wall.z1, x2: wall.x2, z2: wall.z2 },
     });
   }
 
@@ -113,6 +130,26 @@ function projectOntoSegment(
   return { point: projected, distance };
 }
 
+/**
+ * Which side of an interior wall the cursor is on, expressed as a sign along
+ * the wall's `(sin rot, cos rot)` normal. `snapOpeningToWall` derives that
+ * normal from `rot = -atan2(dz, dx)`, i.e. N = (-dz, dx)/len — the left-hand
+ * perpendicular of the wall direction. A camera dropped on the −N side should
+ * seat there instead of teleporting to the +N side.
+ *
+ * Returns +1 when the cursor lies on the +N side (or exactly on the line).
+ */
+function interiorWallSide(
+  cursor: { x: number; z: number },
+  wall: { x1: number; z1: number; x2: number; z2: number }
+): 1 | -1 {
+  const dx = wall.x2 - wall.x1;
+  const dz = wall.z2 - wall.z1;
+  // Perpendicular component of (cursor - wallStart) along N = (-dz, dx).
+  const localPerp = (cursor.x - wall.x1) * -dz + (cursor.z - wall.z1) * dx;
+  return localPerp >= 0 ? 1 : -1;
+}
+
 export function isOpening(type: string): boolean {
   return type === 'door' || type === 'window';
 }
@@ -137,11 +174,19 @@ export function isWallMounted(type: string): boolean {
  */
 export function snapWallMountedItem(options: SnapOpeningOptions & { itemDepth: number }): OpeningSnap {
   const snap = snapOpeningToWall(options);
-  const inset = options.itemDepth / 2 + 0.02;
-  // Three.js rotation.y maps the local +Z axis to (sin θ, cos θ) in world XZ;
-  // that direction points into the room for every wall snapOpeningToWall picks.
-  const forwardX = Math.sin(snap.rotation);
-  const forwardZ = Math.cos(snap.rotation);
+  // Three.js rotation.y maps the local +Z axis to (sin θ, cos θ) in world XZ.
+  // For an exterior wall that direction always points into the room, so the
+  // sign is +1. For an interior wall it's an arbitrary normal, so seat the item
+  // on whichever side the cursor dropped and inset past the wall half-thickness
+  // so the back face rests on the surface instead of the centreline.
+  let inset = options.itemDepth / 2 + 0.02;
+  let side: 1 | -1 = 1;
+  if (snap.wallKind === 'interior' && snap.interiorWall) {
+    side = interiorWallSide(options.position, snap.interiorWall);
+    inset += INTERIOR_WALL_HALF_THICKNESS;
+  }
+  const forwardX = Math.sin(snap.rotation) * side;
+  const forwardZ = Math.cos(snap.rotation) * side;
   return {
     ...snap,
     position: {
@@ -165,20 +210,30 @@ export function snapWallMountedItem(options: SnapOpeningOptions & { itemDepth: n
 export function reseatWallMountedItem(
   options: SnapOpeningOptions & { itemDepth: number; rotation: number; bracketArm?: number }
 ): { x: number; z: number } {
-  const snap = snapOpeningToWall(options); // wall-plane point + inward-facing rotation
+  const snap = snapOpeningToWall(options); // wall-plane point + wall-normal rotation
   const inwardX = Math.sin(snap.rotation);
   const inwardZ = Math.cos(snap.rotation);
+  const isInterior = snap.wallKind === 'interior' && snap.interiorWall != null;
+
   if (options.bracketArm != null) {
+    // Stand-off mount: an exterior wall's normal already points into the room,
+    // but an interior wall's is arbitrary, so put the arm on the cursor's side
+    // instead of unconditionally along +normal (which flings it through the
+    // wall when the camera sits on the −normal side).
+    const bracketSide = isInterior ? interiorWallSide(options.position, snap.interiorWall!) : 1;
     return {
-      x: snap.position.x + inwardX * options.bracketArm,
-      z: snap.position.z + inwardZ * options.bracketArm,
+      x: snap.position.x + inwardX * bracketSide * options.bracketArm,
+      z: snap.position.z + inwardZ * bracketSide * options.bracketArm,
     };
   }
+
   const facingX = Math.sin(options.rotation);
   const facingZ = Math.cos(options.rotation);
-  // +1 if the item faces the room interior, −1 if it faces the exterior.
+  // +1 if the item faces along the wall normal, −1 if it faces the other side.
   const side = facingX * inwardX + facingZ * inwardZ >= 0 ? 1 : -1;
-  const inset = options.itemDepth / 2 + 0.02;
+  // Interior walls are thick; inset past the half-thickness so the back face
+  // rests on the surface rather than embedding into the centreline.
+  const inset = options.itemDepth / 2 + 0.02 + (isInterior ? INTERIOR_WALL_HALF_THICKNESS : 0);
   return {
     x: snap.position.x + inwardX * side * inset,
     z: snap.position.z + inwardZ * side * inset,

--- a/components/room-organizer/three/roof.ts
+++ b/components/room-organizer/three/roof.ts
@@ -143,12 +143,15 @@ function buildHippedRoof(
      0,     peakHeight, 0, // 4 apex
   ]);
 
-  // Four triangle faces (one per side).
+  // Four triangle faces (one per side). Wound counter-clockwise when viewed
+  // from outside so each slope's normal points up-and-outward; the naive
+  // (0,1,4)… order winds them inward/down (normals verified by cross-product),
+  // which reads inside-out under shadows/AO and vanishes without DoubleSide.
   const indices = new Uint16Array([
-    0, 1, 4,
-    1, 2, 4,
-    2, 3, 4,
-    3, 0, 4,
+    1, 0, 4,
+    2, 1, 4,
+    3, 2, 4,
+    0, 3, 4,
   ]);
 
   const geometry = new THREE.BufferGeometry();

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -1,3 +1,4 @@
+import { GRID_SIZE_METERS } from '../lib/constants';
 import { removeAndDispose } from './builder-utils';
 import { buildFloorMaterial } from './floor-patterns';
 import { mergeHoleRects, openingsForWall, type FloorOpening, type WallOpening } from './wall-openings';
@@ -384,7 +385,15 @@ function buildWalls(
   }
 
   if (yOffset === 0 && ghostOpacity === undefined) {
-    const grid = new THREE.GridHelper(Math.max(width, depth) * 1.5, 20);
+    // Match the snap grid: `snapToGrid` rounds world coordinates to multiples of
+    // GRID_SIZE_METERS about the origin. A GridHelper centres its divisions on
+    // the origin, so as long as each cell is exactly GRID_SIZE_METERS the drawn
+    // lines coincide with the snap positions. Size up to a whole number of cells
+    // that covers the room (with a little margin), then derive the divisions.
+    const span = Math.max(width, depth) * 1.5;
+    const divisions = Math.max(2, Math.ceil(span / GRID_SIZE_METERS));
+    const size = divisions * GRID_SIZE_METERS;
+    const grid = new THREE.GridHelper(size, divisions);
     grid.userData.type = ROOM_OBJECT_TAGS.Wall;
     scene.add(grid);
   }
@@ -497,18 +506,31 @@ function buildFloorGeometryWithOpenings(
   shape.lineTo(-halfW, halfD);
   shape.closePath();
 
-  // Merge overlapping stairwell openings so two adjacent stairs never produce
-  // overlapping holes (illegal for earcut). The -90° X rotation maps shape-Y to
-  // world -Z, so negate Z when forming each rectangle.
-  const rects = openings.map(
-    (o) =>
-      [
-        o.centerX - o.width / 2,
-        -(o.centerZ + o.depth / 2),
-        o.centerX + o.width / 2,
-        -(o.centerZ - o.depth / 2),
-      ] as [number, number, number, number]
-  );
+  // The -90° X rotation maps shape-Y to world -Z, so negate Z below.
+  //
+  // Split openings by whether they're axis-aligned (rotation a multiple of 90°)
+  // or genuinely rotated. Axis-aligned holes go through mergeHoleRects so two
+  // stacked stairwells fuse into one clean rectangle (overlapping holes are
+  // illegal for earcut). Rotated holes are cut as individual rotated rectangles
+  // matching the stairs' footprint — no over-inflated AABB, so no corner gaps.
+  const axisAligned: FloorOpening[] = [];
+  const rotated: FloorOpening[] = [];
+  for (const o of openings) {
+    (isAxisAlignedRotation(o.rotation) ? axisAligned : rotated).push(o);
+  }
+
+  const rects = axisAligned.map((o) => {
+    // At 90°/270° the footprint's width and depth swap in world space.
+    const swap = Math.abs(Math.sin(o.rotation)) > 0.5;
+    const worldW = swap ? o.depth : o.width;
+    const worldD = swap ? o.width : o.depth;
+    return [
+      o.centerX - worldW / 2,
+      -(o.centerZ + worldD / 2),
+      o.centerX + worldW / 2,
+      -(o.centerZ - worldD / 2),
+    ] as [number, number, number, number];
+  });
   for (const [x0, y0, x1, y1] of mergeHoleRects(rects)) {
     if (x1 - x0 <= 0 || y1 - y0 <= 0) continue;
     const hole = new THREE.Path();
@@ -520,7 +542,46 @@ function buildFloorGeometryWithOpenings(
     shape.holes.push(hole);
   }
 
+  for (const o of rotated) {
+    if (o.width <= 0 || o.depth <= 0) continue;
+    // Rotate the footprint corners about the opening centre. rotation.y turns
+    // local +X toward world -Z, so a world-space point is
+    // (cx + lx·cos + lz·sin, cz - lx·sin + lz·cos); shape-Y is world -Z.
+    const cos = Math.cos(o.rotation);
+    const sin = Math.sin(o.rotation);
+    const hw = o.width / 2;
+    const hd = o.depth / 2;
+    const localCorners: Array<[number, number]> = [
+      [-hw, -hd],
+      [hw, -hd],
+      [hw, hd],
+      [-hw, hd],
+    ];
+    const corners: Array<[number, number]> = localCorners.map(([lx, lz]) => {
+      const worldX = o.centerX + lx * cos + lz * sin;
+      const worldZ = o.centerZ - lx * sin + lz * cos;
+      return [worldX, -worldZ];
+    });
+    const hole = new THREE.Path();
+    hole.moveTo(corners[0]![0], corners[0]![1]);
+    hole.lineTo(corners[1]![0], corners[1]![1]);
+    hole.lineTo(corners[2]![0], corners[2]![1]);
+    hole.lineTo(corners[3]![0], corners[3]![1]);
+    hole.closePath();
+    shape.holes.push(hole);
+  }
+
   return new THREE.ShapeGeometry(shape);
+}
+
+/**
+ * True when a rotation is (within a small tolerance) a multiple of 90°, so the
+ * footprint stays axis-aligned in world space and can be cut — and merged with
+ * neighbours — as an ordinary AABB rectangle.
+ */
+function isAxisAlignedRotation(rotation: number): boolean {
+  const twist = Math.abs(Math.sin(2 * rotation));
+  return twist < 1e-3;
 }
 
 function hexFromInt(value: number): string {

--- a/components/room-organizer/three/wall-openings.ts
+++ b/components/room-organizer/three/wall-openings.ts
@@ -7,10 +7,21 @@ export interface FloorOpening {
   centerX: number;
   /** Centre Z in room-local coords. */
   centerZ: number;
-  /** Width of the opening (along X). */
+  /**
+   * Width of the opening along the opening's own local X axis (before
+   * `rotation`). This is the stairs' true footprint width, not an
+   * axis-aligned bounding box.
+   */
   width: number;
-  /** Depth of the opening (along Z). */
+  /** Depth of the opening along the opening's own local Z axis (before `rotation`). */
   depth: number;
+  /**
+   * Rotation of the opening about its centre (radians, Y axis), matching the
+   * stairs' rotation. The floor builder cuts a rotated rectangle so a 45°
+   * staircase doesn't leave triangular floor gaps at the corners of an
+   * inflated axis-aligned hole.
+   */
+  rotation: number;
 }
 
 /**
@@ -25,18 +36,19 @@ export function computeFloorOpenings(
   const openings: FloorOpening[] = [];
   for (const item of floorBelow.items) {
     if (item.type !== 'stairs' || !item.position) continue;
-    // When rotated 90° or 270° the width and depth swap in world space.
-    const rotation = item.rotation ?? 0;
-    const sin = Math.abs(Math.sin(rotation));
-    const cos = Math.abs(Math.cos(rotation));
-    const worldWidth = item.width * cos + item.depth * sin;
-    const worldDepth = item.width * sin + item.depth * cos;
+    // Cut a hole matching the stairs' true (rotated) footprint plus a small
+    // clearance margin, and carry the rotation so the floor builder can cut a
+    // rotated rectangle. Previously the hole was the axis-aligned bounding box
+    // of the rotated footprint, which over-cuts at non-90° angles (e.g. a 45°
+    // 1.2×2.4 staircase produced a 2.65×2.65 hole) yet still left floor gaps at
+    // the footprint corners.
     openings.push({
       id: item.id,
       centerX: item.position.x,
       centerZ: item.position.z,
-      width: worldWidth + 0.1,
-      depth: worldDepth + 0.1,
+      width: item.width + 0.1,
+      depth: item.depth + 0.1,
+      rotation: item.rotation ?? 0,
     });
   }
   return openings;


### PR DESCRIPTION
Fixes a bundle of verified low-severity geometry issues.

## Interior-wall camera seating (`lib/opening-snap.ts`)
A camera dropped on the −normal side of an interior wall previously teleported through to the +normal side, because the seat offset always followed the wall's fixed inward normal. The normal sign is now chosen from the cursor side (`sign(localPerp)` of the drop position against the wall line) in both `snapWallMountedItem` and the bracket path of `reseatWallMountedItem`. The flush inset also adds the interior-wall half-thickness (0.08 m, half of the 0.16 m modelled thickness) so the camera's back face rests on the wall surface instead of embedding into the centreline. Exterior-wall behaviour is unchanged.

## Hipped-roof winding (`three/roof.ts`)
All four slope triangles were wound so their normals pointed inward/down (verified by cross-product). Their winding is reversed so normals face up-and-outward; eaves/gable geometry is untouched.

## Grid alignment (`canvas-2d/render.ts`, `three/room-builder.ts`)
Both drawn grids now match the world-centre-anchored snap grid. The 2D grid steps by `GRID_SIZE_METERS` about the origin (was corner-anchored), and the 3D `GridHelper` uses cells of exactly `GRID_SIZE_METERS` (was `max(w,d)*0.075`). `snapToGrid` in `lib/geometry.ts` is unchanged — only the drawn grids were realigned to it.

## Rotated stairs floor holes (`three/wall-openings.ts`, `three/room-builder.ts`)
`FloorOpening` gains a `rotation` field carrying the stairs' rotation, and the floor-hole builder cuts a rotated rectangle matching the true footprint for non-90° angles, so a 45° staircase no longer punches an inflated axis-aligned hole leaving corner gaps. Axis-aligned openings (rotation a multiple of 90°) still merge as AABBs so stacked stairwells fuse cleanly.

## Verification
- `npm run typecheck` clean
- `npm run lint` clean via the documented nested-worktree fallback (`npx eslint --no-eslintrc -c .eslintrc.json --ext .ts,.tsx app components --max-warnings=0`), 0 problems
- `npm run build` succeeds

Fixes #63