### PR TITLE
Fix render color management: sRGB CanvasTextures + tone-mapped UI overlays

### DIFF
--- a/components/room-organizer/three/camera-vision.ts
+++ b/components/room-organizer/three/camera-vision.ts
@@ -218,6 +218,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const wedge = new THREE.Mesh(wedgeGeo, wedgeMat);
   wedge.renderOrder = 991;
@@ -233,6 +234,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const volume = new THREE.Mesh(volumeGeo, volumeMat);
   volume.renderOrder = 990;
@@ -251,6 +253,7 @@ function buildCone(
       opacity: 0.7,
       depthWrite: false,
       depthTest: false,
+      toneMapped: false,
     })
   );
   outline.renderOrder = 992;
@@ -267,6 +270,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const scan = new THREE.Mesh(scanGeo, scanMat);
   scan.renderOrder = 993;

--- a/components/room-organizer/three/measurement.ts
+++ b/components/room-organizer/three/measurement.ts
@@ -32,6 +32,7 @@ export function renderMeasurement(
     color: 0x10b981,
     emissive: 0x10b981,
     emissiveIntensity: 0.4,
+    toneMapped: false,
   });
   for (const point of points) {
     const sphere = new THREE.Mesh(sphereGeo, sphereMat);
@@ -41,7 +42,7 @@ export function renderMeasurement(
   }
 
   if (points.length >= 2) {
-    const lineMat = new THREE.LineBasicMaterial({ color: 0x10b981, linewidth: 2 });
+    const lineMat = new THREE.LineBasicMaterial({ color: 0x10b981, linewidth: 2, toneMapped: false });
     const lineGeo = new THREE.BufferGeometry().setFromPoints([
       new THREE.Vector3(points[0]!.x, yOffset + 0.05, points[0]!.z),
       new THREE.Vector3(points[1]!.x, yOffset + 0.05, points[1]!.z),

--- a/components/room-organizer/three/outdoor.ts
+++ b/components/room-organizer/three/outdoor.ts
@@ -198,6 +198,8 @@ function getBirchBarkTexture(THREE: ThreeModule): ThreeNS.CanvasTexture | null {
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Tag sRGB (CanvasTextures default to linear) so the bark isn't washed out.
+  texture.colorSpace = THREE.SRGBColorSpace;
   birchBarkTextureCache = texture;
   return texture;
 }

--- a/components/room-organizer/three/roof.ts
+++ b/components/room-organizer/three/roof.ts
@@ -1,4 +1,5 @@
 import { removeAndDispose } from './builder-utils';
+import { getMaxAnisotropy } from './texture-settings';
 import type { RoofSpec, RoofStyle } from '../lib/types';
 import type * as ThreeNS from 'three';
 
@@ -263,6 +264,10 @@ function buildShingleMaterial(
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Albedo CanvasTextures default to NoColorSpace (linear); tag sRGB so it's
+  // decoded before lighting instead of rendering washed-out under sRGB output.
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = getMaxAnisotropy();
   // Aim for ~3 shingle rows per metre of slope.
   texture.repeat.set(Math.max(1, surfaceWidth * 0.6), Math.max(1, surfaceLength * 0.6));
 

--- a/components/room-organizer/three/signal-overlay.ts
+++ b/components/room-organizer/three/signal-overlay.ts
@@ -43,10 +43,16 @@ function addRings(
       transparent: true,
       opacity: startOpacity - (i - 1) * opacityFalloff,
       side: THREE.DoubleSide,
+      // UI overlay: bypass ACES tone mapping so the range-ring colour coding
+      // hits its exact hex, and don't write depth so concentric/overlapping
+      // rings from nearby sources don't punch holes in each other.
+      toneMapped: false,
+      depthWrite: false,
     });
     const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(position.x, yOffset + 0.01, position.z);
     mesh.rotation.x = -Math.PI / 2;
+    mesh.renderOrder = 980;
     mesh.userData.type = ROOM_OBJECT_TAGS.Signal;
     scene.add(mesh);
   }


### PR DESCRIPTION
Rendering-quality fixes from a Three.js-focused audit (all verified in code; 153 tests + build green).

### sRGB color space on CanvasTextures
Roof-shingle (`three/roof.ts`) and birch-bark (`three/outdoor.ts`) CanvasTextures were missing `colorSpace = SRGBColorSpace`. CanvasTextures default to linear/NoColorSpace, so under the renderer's sRGB output they rendered washed-out and too light next to the correctly-tagged floor/wall patterns. Tagged both sRGB; added max anisotropy to the roof texture (viewed at grazing angles).

### toneMapped:false on UI overlays
ACES tone mapping was desaturating hand-picked overlay colors. Set `toneMapped:false` on the camera vision cones (cyan/alert red), the WiFi/CCTV range rings, and the measurement markers so they hit their exact intended hex. Also gave the transparent signal rings `depthWrite:false` + a `renderOrder` so concentric/overlapping rings stop punching holes in each other.

No behavior/logic change — purely material properties; the 153-test suite is unaffected.

Fixes #94