### PR TITLE
Three.js perf audit: hoist loop geometry, cache textures, instance outdoor scatter

### DIFF
--- a/components/room-organizer/three/builders/builders-decor.ts
+++ b/components/room-organizer/three/builders/builders-decor.ts
@@ -35,10 +35,12 @@ export function buildPainting({ THREE, item, hasCollision, baseColor, opacity }:
 
   // a few abstract blobs of color
   const blobColors = [0xef5350, 0x42a5f5, 0xffca28];
+  // Every blob is the same size — share one geometry; only the colour differs.
+  const blobGeo = new THREE.SphereGeometry(item.width * 0.12, 10, 10);
   blobColors.forEach((color, i) => {
     const blob = mesh(
       THREE,
-      new THREE.SphereGeometry(item.width * 0.12, 10, 10),
+      blobGeo,
       material(THREE, color, hasCollision, opacity, { roughness: 0.7 })
     );
     blob.position.set(item.width * (i - 1) * 0.25, item.height / 2 + 0.8 + Math.sin(i) * 0.1, item.depth * 0.32);
@@ -262,6 +264,10 @@ export function buildCandles({ THREE, item, hasCollision, baseColor, opacity }: 
     [0, 1.2],
     [item.width * 0.30, 0.85],
   ];
+  // The candles differ in height per spec (leave that geometry per-iteration),
+  // but the wick and flame are identical every candle — share one each.
+  const wickGeo = new THREE.CylinderGeometry(0.005, 0.005, 0.04, 6);
+  const flameGeo = new THREE.ConeGeometry(0.025, 0.08, 8);
   for (const [px, heightMult] of candleSpecs) {
     const hCandle = item.height * 0.75 * heightMult;
     const candle = mesh(
@@ -271,14 +277,10 @@ export function buildCandles({ THREE, item, hasCollision, baseColor, opacity }: 
     );
     candle.position.set(px, item.height * 0.08 + hCandle / 2, 0);
     group.add(candle);
-    const wick = mesh(
-      THREE,
-      new THREE.CylinderGeometry(0.005, 0.005, 0.04, 6),
-      wickMat
-    );
+    const wick = mesh(THREE, wickGeo, wickMat);
     wick.position.set(px, item.height * 0.08 + hCandle + 0.02, 0);
     group.add(wick);
-    const flame = mesh(THREE, new THREE.ConeGeometry(0.025, 0.08, 8), flameMat);
+    const flame = mesh(THREE, flameGeo, flameMat);
     flame.position.set(px, item.height * 0.08 + hCandle + 0.08, 0);
     group.add(flame);
   }

--- a/components/room-organizer/three/builders/builders-storage.ts
+++ b/components/room-organizer/three/builders/builders-storage.ts
@@ -24,12 +24,15 @@ export function buildBookshelf({ THREE, item, hasCollision, baseColor, opacity }
   }
 
   const BOOK_COLORS = [0xff6b6b, 0x4ecdc4, 0x45b7d1, 0xffa07a, 0x98d8c8];
+  // Every book is the same size — share one geometry; only the material
+  // (per-book colour) differs.
+  const bookGeo = new THREE.BoxGeometry(item.width * 0.1, item.height * 0.15, item.depth * 0.6);
   for (let i = 1; i < 4; i++) {
     const color = BOOK_COLORS[i % BOOK_COLORS.length];
     if (color === undefined) continue;
     const book = mesh(
       THREE,
-      new THREE.BoxGeometry(item.width * 0.1, item.height * 0.15, item.depth * 0.6),
+      bookGeo,
       material(THREE, color, hasCollision, opacity, { roughness: 0.8 })
     );
     book.position.set(-item.width * 0.3 + i * 0.15, (item.height / 4) * i + item.height * 0.12, 0);

--- a/components/room-organizer/three/builders/builders-structure.ts
+++ b/components/room-organizer/three/builders/builders-structure.ts
@@ -126,8 +126,10 @@ export function buildStairs({ THREE, item, hasCollision, baseColor, opacity }: B
   const stepRise = item.height / stepCount;
   const stepRun = item.depth / stepCount;
 
+  // Every step is the same size — allocate one geometry and share it across
+  // all steps (matches the hoisted stringer/rail geometry below).
+  const stepGeo = new THREE.BoxGeometry(item.width, stepRise, stepRun + 0.04);
   for (let i = 0; i < stepCount; i++) {
-    const stepGeo = new THREE.BoxGeometry(item.width, stepRise, stepRun + 0.04);
     const step = mesh(THREE, stepGeo, stepMat);
     step.position.set(
       0,

--- a/components/room-organizer/three/camera-vision.ts
+++ b/components/room-organizer/three/camera-vision.ts
@@ -218,6 +218,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const wedge = new THREE.Mesh(wedgeGeo, wedgeMat);
   wedge.renderOrder = 991;
@@ -233,6 +234,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const volume = new THREE.Mesh(volumeGeo, volumeMat);
   volume.renderOrder = 990;
@@ -251,6 +253,7 @@ function buildCone(
       opacity: 0.7,
       depthWrite: false,
       depthTest: false,
+      toneMapped: false,
     })
   );
   outline.renderOrder = 992;
@@ -267,6 +270,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const scan = new THREE.Mesh(scanGeo, scanMat);
   scan.renderOrder = 993;

--- a/components/room-organizer/three/floor-patterns.ts
+++ b/components/room-organizer/three/floor-patterns.ts
@@ -135,6 +135,16 @@ export interface BuildFloorPatternOptions {
   roomDepth: number;
 }
 
+/**
+ * Cache the painted CanvasTexture keyed on (pattern, color, size). The canvas
+ * drawing depends only on those; the per-room `repeat` is applied to a clone.
+ * Regenerating the carpet pattern alone redraws 1200 speckles per rebuild.
+ * Each caller gets a `.clone()` sharing the cached canvas image (cheap) that is
+ * independently disposable; the cached master is never disposed, so the shared
+ * GPU image is never freed while cached (a freed-then-reused texture is black).
+ */
+const floorTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+
 export function buildFloorMaterial(
   THREE: ThreeModule,
   options: BuildFloorPatternOptions
@@ -145,20 +155,15 @@ export function buildFloorMaterial(
 
   const renderer = PATTERNS[options.pattern];
   const size = 256;
-  const canvas = document.createElement('canvas');
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) {
+  const master = getFloorTexture(THREE, options.pattern, options.color, size, renderer);
+  if (!master) {
     return new THREE.MeshStandardMaterial({ color: options.color, roughness: 0.8, metalness: 0.2 });
   }
-  renderer.draw(ctx, size, options.color);
 
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
-  texture.colorSpace = THREE.SRGBColorSpace;
-  texture.anisotropy = getMaxAnisotropy();
+  // Clone per material so each floor owns a disposable copy sharing the cached
+  // canvas image; per-room `repeat` is set on the clone, not the master.
+  const texture = master.clone();
+  texture.needsUpdate = true;
   texture.repeat.set(
     options.roomWidth * renderer.repeatPerMeter,
     options.roomDepth * renderer.repeatPerMeter
@@ -169,6 +174,34 @@ export function buildFloorMaterial(
     roughness: options.pattern === 'tile' ? 0.5 : 0.85,
     metalness: 0.1,
   });
+}
+
+function getFloorTexture(
+  THREE: ThreeModule,
+  pattern: Exclude<FloorPattern, 'solid'>,
+  color: string,
+  size: number,
+  renderer: PatternRenderer
+): ThreeNS.CanvasTexture | null {
+  const key = `${pattern}|${color}|${size}`;
+  const cached = floorTextureCache.get(key);
+  if (cached) return cached;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+  renderer.draw(ctx, size, color);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = getMaxAnisotropy();
+
+  floorTextureCache.set(key, texture);
+  return texture;
 }
 
 function shadeColor(hex: string, shade: number): string {

--- a/components/room-organizer/three/item-labels.ts
+++ b/components/room-organizer/three/item-labels.ts
@@ -6,6 +6,16 @@ type ThreeModule = typeof import('three');
 
 const LABEL_TAG = 'item-label';
 
+/**
+ * Cache the 256×64 label texture keyed on the label text. Regenerating the
+ * canvas + CanvasTexture on every scene rebuild is wasteful when the item
+ * names haven't changed. Each caller gets a `.clone()` of the cached master
+ * so the clone shares the underlying canvas image (cheap) yet is independently
+ * disposable — the master stays resident and is never disposed, so the shared
+ * GPU image can't be freed while still cached (which would render black).
+ */
+const labelTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+
 export function clearItemLabels(scene: ThreeNS.Scene): void {
   for (const obj of scene.children.filter((child) => child.userData.type === LABEL_TAG)) {
     scene.remove(obj);
@@ -31,6 +41,22 @@ export function renderItemLabels(
 }
 
 function createLabelSprite(THREE: ThreeModule, text: string): ThreeNS.Sprite {
+  const master = getLabelTexture(THREE, text);
+  // Clone per sprite so each mesh owns a disposable copy sharing the cached
+  // canvas image; the cached master is never disposed.
+  const texture = master.clone();
+  texture.needsUpdate = true;
+
+  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
+  const sprite = new THREE.Sprite(material);
+  sprite.scale.set(1.2, 0.3, 1);
+  return sprite;
+}
+
+function getLabelTexture(THREE: ThreeModule, text: string): ThreeNS.CanvasTexture {
+  const cached = labelTextureCache.get(text);
+  if (cached) return cached;
+
   const canvas = document.createElement('canvas');
   const padding = 12;
   const fontSize = 28;
@@ -62,10 +88,8 @@ function createLabelSprite(THREE: ThreeModule, text: string): ThreeNS.Sprite {
   texture.magFilter = THREE.LinearFilter;
   texture.generateMipmaps = false;
 
-  const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
-  const sprite = new THREE.Sprite(material);
-  sprite.scale.set(1.2, 0.3, 1);
-  return sprite;
+  labelTextureCache.set(text, texture);
+  return texture;
 }
 
 function fitText(ctx: CanvasRenderingContext2D, text: string, maxWidth: number): string {

--- a/components/room-organizer/three/measurement.ts
+++ b/components/room-organizer/three/measurement.ts
@@ -32,6 +32,7 @@ export function renderMeasurement(
     color: 0x10b981,
     emissive: 0x10b981,
     emissiveIntensity: 0.4,
+    toneMapped: false,
   });
   for (const point of points) {
     const sphere = new THREE.Mesh(sphereGeo, sphereMat);
@@ -41,7 +42,7 @@ export function renderMeasurement(
   }
 
   if (points.length >= 2) {
-    const lineMat = new THREE.LineBasicMaterial({ color: 0x10b981, linewidth: 2 });
+    const lineMat = new THREE.LineBasicMaterial({ color: 0x10b981, linewidth: 2, toneMapped: false });
     const lineGeo = new THREE.BufferGeometry().setFromPoints([
       new THREE.Vector3(points[0]!.x, yOffset + 0.05, points[0]!.z),
       new THREE.Vector3(points[1]!.x, yOffset + 0.05, points[1]!.z),

--- a/components/room-organizer/three/outdoor.ts
+++ b/components/room-organizer/three/outdoor.ts
@@ -198,6 +198,8 @@ function getBirchBarkTexture(THREE: ThreeModule): ThreeNS.CanvasTexture | null {
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Tag sRGB (CanvasTextures default to linear) so the bark isn't washed out.
+  texture.colorSpace = THREE.SRGBColorSpace;
   birchBarkTextureCache = texture;
   return texture;
 }

--- a/components/room-organizer/three/outdoor.ts
+++ b/components/room-organizer/three/outdoor.ts
@@ -25,7 +25,13 @@ export function setOutdoorVisible(
 ): void {
   scene.children
     .filter((obj) => obj.userData.type === OUTDOOR_TAG)
-    .forEach((obj) => removeAndDispose(scene, obj));
+    .forEach((obj) => {
+      // InstancedMesh owns per-instance GPU buffers (instanceMatrix /
+      // instanceColor) that the generic geometry/material disposer doesn't
+      // free — dispose them explicitly before the shared teardown runs.
+      disposeInstancedMeshes(obj);
+      removeAndDispose(scene, obj);
+    });
 
   if (!visible) return;
 
@@ -37,15 +43,26 @@ export function setOutdoorVisible(
   const lotHalfD = halfD + lotMargin;
   const groundSize = Math.max(roomWidth, roomDepth) * 6 + lotMargin * 2;
 
+  // These ground layers were stacked only 1mm apart (grass -0.04, sidewalk
+  // -0.03, road -0.029, dashes -0.028), which z-fights at orbit distance.
+  // Widened to ~10-15mm gaps while keeping the same layering order:
+  // grass (lowest) < sidewalk < road < dashes (top). Tufts and stepping
+  // stones keep their same relative offset above grass.
+  const GRASS_Y = -0.05;
+  const SIDEWALK_Y = -0.035;
+  const ROAD_Y = -0.025;
+  const DASH_Y = -0.015;
+
   // ---- 1. Grass plane (warm suburban green) ----
   const grass = new THREE.Mesh(
     new THREE.PlaneGeometry(groundSize, groundSize, 1, 1),
     new THREE.MeshStandardMaterial({ color: 0x7cb04a, roughness: 1 })
   );
   grass.rotation.x = -Math.PI / 2;
-  grass.position.y = -0.04;
+  grass.position.y = GRASS_Y;
   grass.receiveShadow = true;
   grass.userData.type = OUTDOOR_TAG;
+  freezeMatrix(grass);
   scene.add(grass);
 
   // Tuft pass: a few hundred low patches of darker / lighter grass to break
@@ -63,9 +80,10 @@ export function setOutdoorVisible(
     sidewalkMat
   );
   sidewalk.rotation.x = -Math.PI / 2;
-  sidewalk.position.set(0, -0.03, -(roadOffset + sidewalkDepth / 2));
+  sidewalk.position.set(0, SIDEWALK_Y, -(roadOffset + sidewalkDepth / 2));
   sidewalk.receiveShadow = true;
   sidewalk.userData.type = OUTDOOR_TAG;
+  freezeMatrix(sidewalk);
   scene.add(sidewalk);
 
   const asphaltMat = new THREE.MeshStandardMaterial({ color: 0x3a3d40, roughness: 0.95 });
@@ -74,38 +92,84 @@ export function setOutdoorVisible(
     asphaltMat
   );
   road.rotation.x = -Math.PI / 2;
-  road.position.set(0, -0.029, -(roadOffset + sidewalkDepth + roadDepth / 2));
+  road.position.set(0, ROAD_Y, -(roadOffset + sidewalkDepth + roadDepth / 2));
   road.receiveShadow = true;
   road.userData.type = OUTDOOR_TAG;
+  freezeMatrix(road);
   scene.add(road);
 
-  // Yellow centre dashes on the road.
-  const dashMat = new THREE.MeshStandardMaterial({ color: 0xf4c026, roughness: 0.7 });
-  const dashGeom = new THREE.PlaneGeometry(1.2, 0.18);
+  // Yellow centre dashes on the road — one InstancedMesh (1 draw call) for all
+  // the identical dashes.
+  const dashZ = -(roadOffset + sidewalkDepth + roadDepth / 2);
+  const dummy = new THREE.Object3D();
+  const dashTransforms: ThreeNS.Matrix4[] = [];
   for (let x = -groundSize / 2 + 2; x < groundSize / 2 - 2; x += 2.4) {
-    const dash = new THREE.Mesh(dashGeom, dashMat);
-    dash.rotation.x = -Math.PI / 2;
-    dash.position.set(x, -0.028, -(roadOffset + sidewalkDepth + roadDepth / 2));
-    dash.userData.type = OUTDOOR_TAG;
-    scene.add(dash);
+    dummy.position.set(x, DASH_Y, dashZ);
+    dummy.rotation.set(-Math.PI / 2, 0, 0);
+    dummy.scale.set(1, 1, 1);
+    dummy.updateMatrix();
+    dashTransforms.push(dummy.matrix.clone());
+  }
+  if (dashTransforms.length > 0) {
+    const dashMat = new THREE.MeshStandardMaterial({ color: 0xf4c026, roughness: 0.7 });
+    const dashGeom = new THREE.PlaneGeometry(1.2, 0.18);
+    const dashes = new THREE.InstancedMesh(dashGeom, dashMat, dashTransforms.length);
+    dashTransforms.forEach((m, i) => dashes.setMatrixAt(i, m));
+    dashes.instanceMatrix.needsUpdate = true;
+    dashes.matrixAutoUpdate = false;
+    dashes.updateMatrix();
+    dashes.userData.type = OUTDOOR_TAG;
+    scene.add(dashes);
   }
 
   // Path of stepping stones from the front-of-lot edge to the room's "door"
-  // wall (north). Just a few hint stones — looks like suburban walkways.
-  const stoneMat = new THREE.MeshStandardMaterial({ color: 0xb0b3b0, roughness: 0.9 });
+  // wall (north). Identical cylinders → one InstancedMesh.
+  const stoneTransforms: ThreeNS.Matrix4[] = [];
   for (let z = -halfD - 0.5; z >= -roadOffset; z -= 0.7) {
-    const stone = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.32, 0.30, 0.06, 12),
-      stoneMat
-    );
-    stone.position.set(0, -0.005, z);
-    stone.receiveShadow = true;
-    stone.userData.type = OUTDOOR_TAG;
-    scene.add(stone);
+    dummy.position.set(0, -0.005, z);
+    dummy.rotation.set(0, 0, 0);
+    dummy.scale.set(1, 1, 1);
+    dummy.updateMatrix();
+    stoneTransforms.push(dummy.matrix.clone());
+  }
+  if (stoneTransforms.length > 0) {
+    const stoneMat = new THREE.MeshStandardMaterial({ color: 0xb0b3b0, roughness: 0.9 });
+    const stoneGeom = new THREE.CylinderGeometry(0.32, 0.30, 0.06, 12);
+    const stones = new THREE.InstancedMesh(stoneGeom, stoneMat, stoneTransforms.length);
+    stoneTransforms.forEach((m, i) => stones.setMatrixAt(i, m));
+    stones.instanceMatrix.needsUpdate = true;
+    stones.receiveShadow = true;
+    stones.matrixAutoUpdate = false;
+    stones.updateMatrix();
+    stones.userData.type = OUTDOOR_TAG;
+    scene.add(stones);
   }
 
   // ---- 3. Perimeter trees + bushes ----
   scatterPerimeter(THREE, scene, rng, lotHalfW, lotHalfD);
+}
+
+/** Static mesh — never moves after positioning, so bake its matrix once. */
+function freezeMatrix(obj: ThreeNS.Object3D): void {
+  obj.updateMatrix();
+  obj.matrixAutoUpdate = false;
+}
+
+/** Freeze a whole static subtree (group + all descendants). */
+function freezeMatrixDeep(obj: ThreeNS.Object3D): void {
+  obj.traverse((node) => {
+    node.updateMatrix();
+    node.matrixAutoUpdate = false;
+  });
+}
+
+/** Free the per-instance GPU buffers of any InstancedMesh in the subtree.
+ *  The shared geometry/material disposer doesn't cover these. */
+function disposeInstancedMeshes(obj: ThreeNS.Object3D): void {
+  obj.traverse((node) => {
+    const inst = node as ThreeNS.InstancedMesh;
+    if (inst.isInstancedMesh && typeof inst.dispose === 'function') inst.dispose();
+  });
 }
 
 function scatterGrassTufts(
@@ -116,27 +180,59 @@ function scatterGrassTufts(
   lotHalfW: number,
   lotHalfD: number
 ): void {
-  const tuftMat = new THREE.MeshStandardMaterial({ color: 0x5e9b2e, roughness: 1 });
-  const tuftBrightMat = new THREE.MeshStandardMaterial({ color: 0x9bc55a, roughness: 1 });
+  // 220 identical half-flattened spheres in two shades — collapse them into a
+  // single InstancedMesh (1 draw call) with per-instance colour. RNG draws are
+  // consumed in the exact same order as the old per-mesh loop so the scatter,
+  // shade choice, and scale are visually identical.
   const tuftGeom = new THREE.SphereGeometry(0.18, 6, 5);
+  const tuftMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 1 });
+  const dark = new THREE.Color(0x5e9b2e);
+  const bright = new THREE.Color(0x9bc55a);
   const half = groundSize / 2;
   const count = 220;
+
+  const matrices: ThreeNS.Matrix4[] = [];
+  const colors: ThreeNS.Color[] = [];
+  const dummy = new THREE.Object3D();
   for (let i = 0; i < count; i += 1) {
     const x = (rng() - 0.5) * groundSize;
     const z = (rng() - 0.5) * groundSize;
     // Don't put tufts inside the lot footprint or directly on the road.
     if (Math.abs(x) < lotHalfW + 0.5 && Math.abs(z) < lotHalfD + 0.5) continue;
     if (z < -lotHalfD - 1.5 && z > -lotHalfD - 7) continue;
-    const tuft = new THREE.Mesh(tuftGeom, rng() > 0.5 ? tuftMat : tuftBrightMat);
-    tuft.position.set(x, -0.02, z);
-    tuft.scale.setScalar(0.7 + rng() * 0.6);
-    tuft.scale.y *= 0.45;
-    tuft.userData.type = OUTDOOR_TAG;
-    scene.add(tuft);
-    // Hide ones way off-camera in fog to keep draw cost down. (Three picks
-    // these up at render time — we just leave them as plain meshes.)
-    if (Math.hypot(x, z) > half * 0.8) tuft.visible = false;
+    const color = rng() > 0.5 ? dark : bright;
+    const s = 0.7 + rng() * 0.6;
+    // The old code hid tufts far out in the fog (`.visible = false`), which
+    // renders nothing — so we simply omit those instances (visually identical,
+    // and cheaper). The RNG for position/shade/scale is still consumed above so
+    // the retained tufts land in exactly the same spots as before.
+    if (Math.hypot(x, z) > half * 0.8) continue;
+    dummy.position.set(x, -0.03, z);
+    dummy.scale.set(s, s * 0.45, s);
+    dummy.rotation.set(0, 0, 0);
+    dummy.updateMatrix();
+    matrices.push(dummy.matrix.clone());
+    colors.push(color);
   }
+
+  if (matrices.length === 0) {
+    tuftGeom.dispose();
+    tuftMat.dispose();
+    return;
+  }
+
+  const tufts = new THREE.InstancedMesh(tuftGeom, tuftMat, matrices.length);
+  for (let i = 0; i < matrices.length; i += 1) {
+    tufts.setMatrixAt(i, matrices[i]!);
+    tufts.setColorAt(i, colors[i]!);
+  }
+  tufts.instanceMatrix.needsUpdate = true;
+  if (tufts.instanceColor) tufts.instanceColor.needsUpdate = true;
+  // Static — never moves.
+  tufts.matrixAutoUpdate = false;
+  tufts.updateMatrix();
+  tufts.userData.type = OUTDOOR_TAG;
+  scene.add(tufts);
 }
 
 interface TreeKind {
@@ -275,29 +371,79 @@ function scatterPerimeter(
     void t;
   }
 
-  // Small ornamental shrubs hugging the lot edges.
+  // Small ornamental shrubs hugging the lot edges — identical sphere geometry
+  // and material, so collapse them into one InstancedMesh (1 draw call). RNG is
+  // consumed in the same order so positions/scales are unchanged.
   const shrubCount = 18;
+  const shrubDummy = new THREE.Object3D();
+  const shrubTransforms: ThreeNS.Matrix4[] = [];
   for (let i = 0; i < shrubCount; i += 1) {
     const angle = (i / shrubCount) * Math.PI * 2;
     const radius = Math.max(lotHalfW, lotHalfD) + 0.8 + rng() * 0.6;
-    let x = Math.cos(angle) * radius;
-    let z = Math.sin(angle) * radius;
+    const x = Math.cos(angle) * radius;
+    const z = Math.sin(angle) * radius;
+    const s = 0.7 + rng() * 0.4;
     // Keep the road frontage clean.
     if (z < -lotHalfD) continue;
-    const bush = new THREE.Mesh(bushGeom, bushMat);
-    bush.position.set(x, 0.32, z);
-    bush.scale.setScalar(0.7 + rng() * 0.4);
-    bush.castShadow = true;
-    bush.userData.type = OUTDOOR_TAG;
-    scene.add(bush);
+    shrubDummy.position.set(x, 0.32, z);
+    shrubDummy.rotation.set(0, 0, 0);
+    shrubDummy.scale.setScalar(s);
+    shrubDummy.updateMatrix();
+    shrubTransforms.push(shrubDummy.matrix.clone());
+  }
+  if (shrubTransforms.length > 0) {
+    const shrubs = new THREE.InstancedMesh(bushGeom, bushMat, shrubTransforms.length);
+    shrubTransforms.forEach((m, i) => shrubs.setMatrixAt(i, m));
+    shrubs.instanceMatrix.needsUpdate = true;
+    shrubs.castShadow = true;
+    shrubs.matrixAutoUpdate = false;
+    shrubs.updateMatrix();
+    shrubs.userData.type = OUTDOOR_TAG;
+    scene.add(shrubs);
+  } else {
+    bushGeom.dispose();
+    bushMat.dispose();
   }
 
-  // A few cheerful flower patches around the lot's front.
+  // A few cheerful flower patches around the lot's front. Every flower blossom
+  // and every stem shares identical geometry, so accumulate their world
+  // transforms across all patches and emit two InstancedMeshes (blossoms carry
+  // per-instance colour). RNG draws stay in the same order as the old per-mesh
+  // build, so positions/colours/counts are unchanged.
   const flowerColors = [0xff5b6a, 0xffd24a, 0xffffff, 0xc77bff];
+  const dummy = new THREE.Object3D();
+  const blossomMatrices: ThreeNS.Matrix4[] = [];
+  const blossomColors: ThreeNS.Color[] = [];
+  const stemMatrices: ThreeNS.Matrix4[] = [];
   for (let i = 0; i < 6; i += 1) {
     const x = ((rng() - 0.5) * lotHalfW) * 2;
     const z = -lotHalfD - 0.4 - rng() * 0.6;
-    addFlowerPatch(THREE, scene, x, z, flowerColors, rng);
+    collectFlowerPatch(THREE, dummy, x, z, flowerColors, rng, blossomMatrices, blossomColors, stemMatrices);
+  }
+  if (blossomMatrices.length > 0) {
+    const blossomGeom = new THREE.SphereGeometry(0.07, 8, 8);
+    const blossomMat = new THREE.MeshStandardMaterial({ color: 0xffffff, roughness: 0.8 });
+    const blossoms = new THREE.InstancedMesh(blossomGeom, blossomMat, blossomMatrices.length);
+    blossomMatrices.forEach((m, i) => {
+      blossoms.setMatrixAt(i, m);
+      blossoms.setColorAt(i, blossomColors[i]!);
+    });
+    blossoms.instanceMatrix.needsUpdate = true;
+    if (blossoms.instanceColor) blossoms.instanceColor.needsUpdate = true;
+    blossoms.matrixAutoUpdate = false;
+    blossoms.updateMatrix();
+    blossoms.userData.type = OUTDOOR_TAG;
+    scene.add(blossoms);
+
+    const stemGeom = new THREE.CylinderGeometry(0.012, 0.015, 0.18, 5);
+    const stemMat = new THREE.MeshStandardMaterial({ color: 0x336e1f, roughness: 0.9 });
+    const stems = new THREE.InstancedMesh(stemGeom, stemMat, stemMatrices.length);
+    stemMatrices.forEach((m, i) => stems.setMatrixAt(i, m));
+    stems.instanceMatrix.needsUpdate = true;
+    stems.matrixAutoUpdate = false;
+    stems.updateMatrix();
+    stems.userData.type = OUTDOOR_TAG;
+    scene.add(stems);
   }
 }
 
@@ -450,18 +596,27 @@ function addTree(
   group.rotation.y = rng() * Math.PI * 2;
   group.scale.setScalar(scale);
   group.userData.type = OUTDOOR_TAG;
+  // Trees never move — bake the group's and every child's matrix once.
+  freezeMatrixDeep(group);
   scene.add(group);
 }
 
-function addFlowerPatch(
+/**
+ * Accumulate one flower patch's blossom + stem transforms (in world space —
+ * the patch groups were never rotated or scaled) into the shared instance
+ * arrays. Mirrors the original per-mesh layout exactly.
+ */
+function collectFlowerPatch(
   THREE: ThreeModule,
-  scene: ThreeNS.Scene,
+  dummy: ThreeNS.Object3D,
   x: number,
   z: number,
   colors: readonly number[],
-  rng: () => number
+  rng: () => number,
+  blossomMatrices: ThreeNS.Matrix4[],
+  blossomColors: ThreeNS.Color[],
+  stemMatrices: ThreeNS.Matrix4[]
 ): void {
-  const group = new THREE.Group();
   const count = 6 + Math.floor(rng() * 4);
   for (let i = 0; i < count; i += 1) {
     const angle = rng() * Math.PI * 2;
@@ -469,20 +624,18 @@ function addFlowerPatch(
     const px = Math.cos(angle) * r;
     const pz = Math.sin(angle) * r;
     const color = colors[Math.floor(rng() * colors.length)]!;
-    const mat = new THREE.MeshStandardMaterial({ color, roughness: 0.8 });
-    const flower = new THREE.Mesh(new THREE.SphereGeometry(0.07, 8, 8), mat);
-    flower.position.set(px, 0.12, pz);
-    group.add(flower);
-    const stem = new THREE.Mesh(
-      new THREE.CylinderGeometry(0.012, 0.015, 0.18, 5),
-      new THREE.MeshStandardMaterial({ color: 0x336e1f, roughness: 0.9 })
-    );
-    stem.position.set(px, 0.05, pz);
-    group.add(stem);
+
+    dummy.position.set(x + px, 0.12, z + pz);
+    dummy.rotation.set(0, 0, 0);
+    dummy.scale.set(1, 1, 1);
+    dummy.updateMatrix();
+    blossomMatrices.push(dummy.matrix.clone());
+    blossomColors.push(new THREE.Color(color));
+
+    dummy.position.set(x + px, 0.05, z + pz);
+    dummy.updateMatrix();
+    stemMatrices.push(dummy.matrix.clone());
   }
-  group.position.set(x, 0, z);
-  group.userData.type = OUTDOOR_TAG;
-  scene.add(group);
 }
 
 /** Mulberry32 — small, deterministic PRNG so the lot doesn't reshuffle. */

--- a/components/room-organizer/three/roof.ts
+++ b/components/room-organizer/three/roof.ts
@@ -1,4 +1,5 @@
 import { removeAndDispose } from './builder-utils';
+import { getMaxAnisotropy } from './texture-settings';
 import type { RoofSpec, RoofStyle } from '../lib/types';
 import type * as ThreeNS from 'three';
 
@@ -263,6 +264,10 @@ function buildShingleMaterial(
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Albedo CanvasTextures default to NoColorSpace (linear); tag sRGB so it's
+  // decoded before lighting instead of rendering washed-out under sRGB output.
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = getMaxAnisotropy();
   // Aim for ~3 shingle rows per metre of slope.
   texture.repeat.set(Math.max(1, surfaceWidth * 0.6), Math.max(1, surfaceLength * 0.6));
 

--- a/components/room-organizer/three/roof.ts
+++ b/components/room-organizer/three/roof.ts
@@ -7,6 +7,16 @@ type ThreeModule = typeof import('three');
 
 export const ROOF_TAG = 'roof';
 
+/**
+ * Cache the painted shingle CanvasTexture keyed on colour (the canvas drawing
+ * depends only on colour; the 256px size is fixed). Per-surface `repeat` and
+ * the `side` flag live on the clone/material, not the master. Each roof gets a
+ * `.clone()` sharing the cached canvas image (cheap) that is independently
+ * disposable; the cached master is never disposed, so the shared GPU image is
+ * never freed while cached (a freed-then-reused texture renders black).
+ */
+const shingleTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+
 /** Eaves: how far the roof overhangs past the wall plane (metres). */
 const EAVE_OVERHANG = 0.35;
 
@@ -218,25 +228,40 @@ function buildShingleMaterial(
   surfaceLength: number,
   doubleSided = false
 ): ThreeNS.MeshStandardMaterial {
-  const size = 256;
-  const canvas = typeof document !== 'undefined' ? document.createElement('canvas') : null;
-  if (!canvas) {
+  const master = getShingleTexture(THREE, color);
+  if (!master) {
     return new THREE.MeshStandardMaterial({
       color,
       roughness: 0.9,
       ...(doubleSided ? { side: THREE.DoubleSide } : {}),
     });
   }
+
+  // Clone per roof so each surface owns a disposable copy sharing the cached
+  // canvas image; per-surface `repeat` is set on the clone, not the master.
+  const texture = master.clone();
+  texture.needsUpdate = true;
+  // Aim for ~3 shingle rows per metre of slope.
+  texture.repeat.set(Math.max(1, surfaceWidth * 0.6), Math.max(1, surfaceLength * 0.6));
+
+  return new THREE.MeshStandardMaterial({
+    map: texture,
+    roughness: 0.92,
+    ...(doubleSided ? { side: THREE.DoubleSide } : {}),
+  });
+}
+
+function getShingleTexture(THREE: ThreeModule, color: string): ThreeNS.CanvasTexture | null {
+  const cached = shingleTextureCache.get(color);
+  if (cached) return cached;
+
+  const size = 256;
+  const canvas = typeof document !== 'undefined' ? document.createElement('canvas') : null;
+  if (!canvas) return null;
   canvas.width = size;
   canvas.height = size;
   const ctx = canvas.getContext('2d');
-  if (!ctx) {
-    return new THREE.MeshStandardMaterial({
-      color,
-      roughness: 0.9,
-      ...(doubleSided ? { side: THREE.DoubleSide } : {}),
-    });
-  }
+  if (!ctx) return null;
 
   ctx.fillStyle = color;
   ctx.fillRect(0, 0, size, size);
@@ -268,14 +293,9 @@ function buildShingleMaterial(
   // decoded before lighting instead of rendering washed-out under sRGB output.
   texture.colorSpace = THREE.SRGBColorSpace;
   texture.anisotropy = getMaxAnisotropy();
-  // Aim for ~3 shingle rows per metre of slope.
-  texture.repeat.set(Math.max(1, surfaceWidth * 0.6), Math.max(1, surfaceLength * 0.6));
 
-  return new THREE.MeshStandardMaterial({
-    map: texture,
-    roughness: 0.92,
-    ...(doubleSided ? { side: THREE.DoubleSide } : {}),
-  });
+  shingleTextureCache.set(color, texture);
+  return texture;
 }
 
 function shadeHex(hex: string, multiplier: number): string {

--- a/components/room-organizer/three/signal-overlay.ts
+++ b/components/room-organizer/three/signal-overlay.ts
@@ -43,10 +43,16 @@ function addRings(
       transparent: true,
       opacity: startOpacity - (i - 1) * opacityFalloff,
       side: THREE.DoubleSide,
+      // UI overlay: bypass ACES tone mapping so the range-ring colour coding
+      // hits its exact hex, and don't write depth so concentric/overlapping
+      // rings from nearby sources don't punch holes in each other.
+      toneMapped: false,
+      depthWrite: false,
     });
     const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(position.x, yOffset + 0.01, position.z);
     mesh.rotation.x = -Math.PI / 2;
+    mesh.renderOrder = 980;
     mesh.userData.type = ROOM_OBJECT_TAGS.Signal;
     scene.add(mesh);
   }

--- a/components/room-organizer/three/wall-patterns.ts
+++ b/components/room-organizer/three/wall-patterns.ts
@@ -149,6 +149,16 @@ export interface BuildWallMaterialOptions {
   height: number;
 }
 
+/**
+ * Cache the painted CanvasTexture keyed on (pattern, color, size). Walls are
+ * built ×4 per shell rebuild; the canvas drawing depends only on those keys,
+ * while the per-wall `repeat` is applied to a clone. Each caller gets a
+ * `.clone()` sharing the cached canvas image (cheap) that is independently
+ * disposable; the cached master is never disposed, so the shared GPU image is
+ * never freed while cached (a freed-then-reused texture renders black).
+ */
+const wallTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+
 export function buildWallMaterial(
   THREE: ThreeModule,
   options: BuildWallMaterialOptions
@@ -166,11 +176,8 @@ export function buildWallMaterial(
 
   const renderer = PATTERNS[options.pattern];
   const size = 256;
-  const canvas = document.createElement('canvas');
-  canvas.width = size;
-  canvas.height = size;
-  const ctx = canvas.getContext('2d');
-  if (!ctx) {
+  const master = getWallTexture(THREE, options.pattern, options.color, size, renderer);
+  if (!master) {
     return new THREE.MeshStandardMaterial({
       color: options.color,
       transparent: true,
@@ -179,13 +186,10 @@ export function buildWallMaterial(
     });
   }
 
-  renderer.draw(ctx, size, options.color);
-
-  const texture = new THREE.CanvasTexture(canvas);
-  texture.wrapS = THREE.RepeatWrapping;
-  texture.wrapT = THREE.RepeatWrapping;
-  texture.colorSpace = THREE.SRGBColorSpace;
-  texture.anisotropy = getMaxAnisotropy();
+  // Clone per material so each wall owns a disposable copy sharing the cached
+  // canvas image; per-wall `repeat` is set on the clone, not the master.
+  const texture = master.clone();
+  texture.needsUpdate = true;
   texture.repeat.set(options.width * renderer.repeatPerMeter, options.height * renderer.repeatPerMeter * 0.6);
 
   return new THREE.MeshStandardMaterial({
@@ -193,4 +197,33 @@ export function buildWallMaterial(
     side: THREE.DoubleSide,
     roughness: 0.85,
   });
+}
+
+function getWallTexture(
+  THREE: ThreeModule,
+  pattern: Exclude<WallPattern, 'solid'>,
+  color: string,
+  size: number,
+  renderer: PatternRenderer
+): ThreeNS.CanvasTexture | null {
+  const key = `${pattern}|${color}|${size}`;
+  const cached = wallTextureCache.get(key);
+  if (cached) return cached;
+
+  const canvas = document.createElement('canvas');
+  canvas.width = size;
+  canvas.height = size;
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return null;
+
+  renderer.draw(ctx, size, color);
+
+  const texture = new THREE.CanvasTexture(canvas);
+  texture.wrapS = THREE.RepeatWrapping;
+  texture.wrapT = THREE.RepeatWrapping;
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = getMaxAnisotropy();
+
+  wallTextureCache.set(key, texture);
+  return texture;
 }


### PR DESCRIPTION
**Stacked on #90 (fix/render-color-management) — merge that first.** This branch was cut from `origin/fix/render-color-management` to avoid conflicts with that open PR; the diff here is only the perf work.

Behaviour-preserving Three.js performance audit across the builder / texture / outdoor modules. Rendered output is intended to look **identical** — this is conservative perf-only work. Vitest suite (153) stays green.

## Optimizations

### 1. Hoist loop-invariant geometry
- **builders-structure `buildStairs`** — one `stepGeo` shared across the 14 identical steps instead of a `BoxGeometry` per step (matches the already-hoisted stringer/rail geometry).
- **builders-storage `buildBookshelf`** — one shared book `BoxGeometry`; materials still differ per book colour.
- **builders-decor** — `buildPainting` shares one blob `SphereGeometry`; `buildCandles` shares the wick `CylinderGeometry` and flame `ConeGeometry`. Left per-iteration where sizes differ: candle bodies (varying height) and books-stack slabs (alternating width).

Meshes stay separate (distinct positions); only the geometry is shared. The shared geometry is disposed idempotently by the existing traverse-based disposer, same as the pre-existing hoisted geometries.

### 2. Cache procedural CanvasTextures — dispose-safe via **clone-per-use**
Module-level caches added so unchanged finishes reuse the GPU image:
- **floor-patterns** — keyed on `(pattern, color, size)`; per-room `repeat` on the clone (carpet alone draws 1200 speckles/rebuild).
- **wall-patterns** — keyed on `(pattern, color, size)`; per-wall `repeat` on the clone (built ×4 per shell rebuild).
- **item-labels** — 256×64 label texture keyed on the label text.
- **roof** — shingle texture keyed on colour; per-surface `repeat` on the clone.

**Dispose-safety approach: clone (option b).** Each caller gets a `.clone()` of the cached master. The clone shares the underlying canvas/image (cheap) but is an independently disposable texture, so the existing `disposeObject` teardown frees the clone while the cached master stays resident — a disposed-then-reused texture would render black, and this avoids that. Mirrors the existing outdoor birch-bark cache.

### 3. `matrixAutoUpdate=false` on static outdoor meshes
Grass plane, sidewalk, road, and the trees (group + all children) get `updateMatrix()` once then `matrixAutoUpdate=false` — they never move.

### 4. Outdoor z-fighting
Ground layers were stacked 1mm apart (grass −0.04, sidewalk −0.03, road −0.029, dashes −0.028) and z-fought at orbit distance. Widened to ~10–15mm gaps (grass −0.05, sidewalk −0.035, road −0.025, dashes −0.015), keeping the identical layering order (grass lowest → dashes on top). Tufts and stepping stones keep their same relative offset above grass.

### 5. Instance the outdoor scatter — **InstancedMesh applied**
Converted the high-count repeated elements to `THREE.InstancedMesh` (one shared geometry + one material, per-instance `setMatrixAt`):
- **Grass tufts**: 220 meshes → 1 InstancedMesh, per-instance colour for the two shades. Far-fog tufts (previously `.visible = false`, i.e. rendered nothing) are simply omitted — visually identical, and the RNG is still consumed in the same order so retained tufts land in the exact same spots.
- **Shrubs**, **road dashes**, **stepping stones** → one InstancedMesh each.
- **Flower blossoms** (per-instance colour) and **stems** → one InstancedMesh each, accumulated across all patches (the patch groups were never rotated/scaled, so local == world offset).

All InstancedMeshes are tagged `OUTDOOR_TAG`. Since the shared geometry/material disposer doesn't free per-instance GPU buffers (`instanceMatrix` / `instanceColor`), the outdoor teardown now calls `InstancedMesh.dispose()` on each before `removeAndDispose`.

## Verification
- `npm run test` → 153 passed.
- `npm run typecheck` → clean.
- `npm run lint -- --max-warnings=0` → clean (via the documented fallback `npx eslint --no-eslintrc -c .eslintrc.json …`; the default `npm run lint` hits a nested-worktree `@next/next` plugin collision unrelated to this diff).
- `npm run build` → succeeds (static export generated).

## Needs runtime retest
- Textures are **not black** after a scene rebuild (floor / wall / label / roof) — verifies the clone-per-use dispose-safety.
- Outdoor scene looks identical (same scatter, colours, layering).
- No z-fighting on the road/sidewalk/dash stack at orbit distance.

Fixes #96