### PR TITLE
perf: Three.js render-loop optimizations (scene core)

### DIFF
--- a/components/room-organizer/hooks/use-npcs.ts
+++ b/components/room-organizer/hooks/use-npcs.ts
@@ -27,6 +27,11 @@ export interface UseNpcsOptions {
   floorY: number;
   /** Request a render on the next animation frame (render-on-demand). */
   invalidate?: () => void;
+  /**
+   * Recompute the static shadow map. NPCs cast shadows, so while they're
+   * actually walking their shadows must keep updating — but only then.
+   */
+  requestShadowUpdate?: () => void;
 }
 
 /**
@@ -35,7 +40,7 @@ export interface UseNpcsOptions {
  * down all NPC meshes and the RAF loop on every dependency change.
  */
 export function useNpcs(options: UseNpcsOptions): void {
-  const { enabled, count = 3, threeModuleRef, sceneRef, roomWidth, roomDepth, floorY, invalidate } = options;
+  const { enabled, count = 3, threeModuleRef, sceneRef, roomWidth, roomDepth, floorY, invalidate, requestShadowUpdate } = options;
   const stateRef = useRef<NpcState[]>([]);
 
   useEffect(() => {
@@ -62,8 +67,14 @@ export function useNpcs(options: UseNpcsOptions): void {
       const now = performance.now();
       const delta = Math.min(0.1, (now - lastTime) / 1000);
       lastTime = now;
-      stepNpcs(stateRef.current, delta, halfW, halfD, floorY);
-      invalidate?.();
+      // Only request a repaint (and a shadow-map recompute) when an NPC
+      // actually moved this frame. When every NPC is idling at its target the
+      // render loop stays parked instead of pinning the GPU at refresh rate.
+      const moved = stepNpcs(stateRef.current, delta, halfW, halfD, floorY);
+      if (moved) {
+        requestShadowUpdate?.();
+        invalidate?.();
+      }
     };
     rafId = requestAnimationFrame(tick);
 
@@ -75,7 +86,7 @@ export function useNpcs(options: UseNpcsOptions): void {
       }
       stateRef.current = [];
     };
-  }, [enabled, count, invalidate, threeModuleRef, sceneRef, roomWidth, roomDepth, floorY]);
+  }, [enabled, count, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, roomWidth, roomDepth, floorY]);
 }
 
 function createNpc(
@@ -141,22 +152,32 @@ function createNpc(
   };
 }
 
+/**
+ * Advances every NPC one frame. Returns true when at least one NPC actually
+ * moved (or its legs bobbed) this frame, so the caller can skip the repaint /
+ * shadow recompute when they're all momentarily idling at their targets.
+ */
 function stepNpcs(
   npcs: NpcState[],
   delta: number,
   halfW: number,
   halfD: number,
   floorY: number
-): void {
+): boolean {
+  let moved = false;
   for (const npc of npcs) {
     const dx = npc.target.x - npc.position.x;
     const dz = npc.target.z - npc.position.z;
     const distance = Math.hypot(dx, dz);
 
     if (distance < 0.15) {
+      // Reached the waypoint: pick a new one but produce no visible motion
+      // this frame (position/legs unchanged).
       npc.target = { x: rand(-halfW, halfW), z: rand(-halfD, halfD) };
       continue;
     }
+
+    moved = true;
 
     const step = npc.speed * delta;
     const nx = npc.position.x + (dx / distance) * step;
@@ -176,6 +197,7 @@ function stepNpcs(
     if (npc.legs[1]) npc.legs[1].position.y = 0.4 - swing;
     npc.group.position.y = floorY + Math.abs(swing) * 0.5;
   }
+  return moved;
 }
 
 function rand(min: number, max: number): number {

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -4,6 +4,7 @@ import { hasCollisions } from '../lib/geometry';
 import { FLOOR_HEIGHT_METERS } from '../lib/types';
 import { disposeObject, removeAndDispose } from '../three/builder-utils';
 import { addVisionCones } from '../three/camera-vision';
+import { FURNITURE_REVISION_KEY } from '../three/drag-handlers';
 import { createFurnitureModel } from '../three/furniture-builders';
 import {
   clearInteriorWalls,
@@ -51,6 +52,8 @@ export interface UseSceneEffectsParams {
   isReady: boolean;
   /** Request a render on the next animation frame (render-on-demand). */
   invalidate: () => void;
+  /** Recompute the static shadow map — call after a shadow caster/sun change. */
+  requestShadowUpdate: () => void;
   threeModuleRef: MutableRefObject<typeof import('three') | null>;
   sceneRef: MutableRefObject<ThreeNS.Scene | null>;
   rendererRef: MutableRefObject<ThreeNS.WebGLRenderer | null>;
@@ -73,6 +76,7 @@ export interface UseSceneEffectsParams {
 export function useSceneEffects({
   isReady,
   invalidate,
+  requestShadowUpdate,
   threeModuleRef,
   sceneRef,
   rendererRef,
@@ -215,13 +219,16 @@ export function useSceneEffects({
     if (camera) {
       applyWallDisplay(scene, camera.position.x, camera.position.z, view.wallDisplay, layout.width, layout.height);
     }
+    // Walls, floor and foundation are shadow casters/receivers — recompute the
+    // static shadow map now that the shell geometry changed.
+    requestShadowUpdate();
     // The shell reads layout.floors/activeFloor but depends on them only
     // through the finishes and openings keys — depending on their identity
     // would rebuild walls, floor meshes, and procedural textures on every
     // item edit.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
-    isReady, invalidate, threeModuleRef, sceneRef, rendererRef, cameraRef,
+    isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, rendererRef, cameraRef,
     layout.width, layout.height, shellFinishesKey, wallOpeningsKey,
     layout.floorPlanImage, layout.floorPlanOpacity, layout.floorPlanFitMode,
     view.floorPlan3DEffect, view.showAllFloors, view.wallDisplay,
@@ -287,8 +294,15 @@ export function useSceneEffects({
         scene.add(group);
       }
     }
+
+    // The furniture set just changed — bump the revision so the drag/hover
+    // raycast pre-filter cache rebuilds its list, and recompute the static
+    // shadow map now that shadow casters were added/removed/moved.
+    scene.userData[FURNITURE_REVISION_KEY] =
+      ((scene.userData[FURNITURE_REVISION_KEY] as number | undefined) ?? 0) + 1;
+    requestShadowUpdate();
   }, [
-    isReady, invalidate, threeModuleRef, sceneRef,
+    isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef,
     layout.floors, layout.width, layout.height,
     activeFloor, activeFloorIndex, view.showAllFloors,
   ]);
@@ -406,10 +420,13 @@ export function useSceneEffects({
     );
 
     applyTimeOfDay(THREE, scene, view.timeOfDay, lampPositions);
+    // The sun's angle/position changed, so the (static) shadow map must be
+    // recomputed or shadows would stay frozen at the previous time of day.
+    requestShadowUpdate();
     // layout.floors is read for lamp positions only; lampsKey covers exactly
     // that, so a non-lamp item edit doesn't rebuild the sky and lights.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isReady, invalidate, threeModuleRef, sceneRef, view.timeOfDay, lampsKey]);
+  }, [isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, view.timeOfDay, lampsKey]);
 
   // Outdoor
   useEffect(() => {
@@ -445,11 +462,14 @@ export function useSceneEffects({
         { openingCandidates: floor.items, roomWidth: layout.width, roomDepth: layout.height }
       );
     }
+    // Interior walls cast shadows — recompute the static shadow map after any
+    // add/remove/re-extrude so their cast shadows don't go stale.
+    requestShadowUpdate();
     // layout.floors/activeFloor are read for the wall segments and the
     // door/window opening candidates only; the two keys cover exactly that,
     // so a furniture edit doesn't re-extrude every interior wall.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isReady, invalidate, threeModuleRef, sceneRef, interiorWallsKey, wallOpeningsKey, activeFloorIndex, view.showAllFloors, layout.width, layout.height]);
+  }, [isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, interiorWallsKey, wallOpeningsKey, activeFloorIndex, view.showAllFloors, layout.width, layout.height]);
 
   // Cyan outline on selected wall. Declared AFTER the shell + interior-wall
   // rebuild effects and keyed on the same rebuild keys, so it always snapshots

--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -19,6 +19,12 @@ export interface UseThreeSceneResult {
   error: string | null;
   /** Mark the scene dirty so the next animation frame renders. */
   invalidate: () => void;
+  /**
+   * Request a one-off recompute of the (otherwise static) shadow map on the
+   * next render. Call this whenever a shadow caster or the sun actually moves
+   * — NOT for pure camera orbit, which never changes cast shadows.
+   */
+  requestShadowUpdate: () => void;
   threeModuleRef: React.MutableRefObject<ThreeModule | null>;
   sceneRef: React.MutableRefObject<ThreeNS.Scene | null>;
   cameraRef: React.MutableRefObject<ThreeNS.PerspectiveCamera | null>;
@@ -55,12 +61,21 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
     dirtyRef.current = true;
   });
 
+  // Shadow map is static by default (autoUpdate = false); we recompute it only
+  // when a shadow caster or the sun actually moves. `requestShadowUpdate` marks
+  // both the shadow map and the frame dirty so the fresh shadows get painted.
+  const rendererRef = useRef<ThreeNS.WebGLRenderer | null>(null);
+  const requestShadowUpdateRef = useRef(() => {
+    const renderer = rendererRef.current;
+    if (renderer) renderer.shadowMap.needsUpdate = true;
+    dirtyRef.current = true;
+  });
+
   const threeModuleRef = useRef<ThreeModule | null>(null);
   const orbitCtorRef = useRef<typeof OrbitControlsType | null>(null);
   const roomEnvCtorRef = useRef<(new () => ThreeNS.Scene) | null>(null);
   const sceneRef = useRef<ThreeNS.Scene | null>(null);
   const cameraRef = useRef<ThreeNS.PerspectiveCamera | null>(null);
-  const rendererRef = useRef<ThreeNS.WebGLRenderer | null>(null);
   const controlsRef = useRef<OrbitControlsType | null>(null);
 
   // Latest-callback refs: capture handlers without making them part of the
@@ -144,7 +159,9 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
       scene.background = new THREE.Color(0xdceefb);
       sceneRef.current = scene;
 
-      const camera = new THREE.PerspectiveCamera(75, canvas.clientWidth / canvas.clientHeight, 0.1, 1000);
+      // Near plane pulled from 0.1 to 0.3 for better depth precision. The
+      // walkthrough eye height is ~1.6m so 0.3 never clips near geometry.
+      const camera = new THREE.PerspectiveCamera(75, canvas.clientWidth / canvas.clientHeight, 0.3, 1000);
       camera.position.set(0, 8, 8);
       camera.lookAt(0, 0, 0);
       cameraRef.current = camera;
@@ -156,11 +173,17 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
         canvas,
         antialias: true,
         failIfMajorPerformanceCaveat: false,
+        powerPreference: 'high-performance',
       });
       renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
       renderer.setSize(canvas.clientWidth, canvas.clientHeight);
       renderer.shadowMap.enabled = true;
       renderer.shadowMap.type = THREE.PCFSoftShadowMap;
+      // The 2048² directional shadow is expensive; keep it static and only
+      // recompute it when a caster or the sun actually moves (via
+      // requestShadowUpdate). Frame 1 needs the initial pass, so start dirty.
+      renderer.shadowMap.autoUpdate = false;
+      renderer.shadowMap.needsUpdate = true;
       // Filmic colour pipeline: ACES tone mapping + explicit sRGB output.
       renderer.toneMapping = THREE.ACESFilmicToneMapping;
       renderer.toneMappingExposure = 1.15;
@@ -199,6 +222,11 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
 
       addLights(THREE, scene);
 
+      // While the GPU context is lost the drawing buffer is gone; rendering
+      // into it throws and/or wastes work. Pause the render half of the loop
+      // until `webglcontextrestored` fires.
+      let contextLost = false;
+
       let rafId = 0;
       const tick = () => {
         rafId = requestAnimationFrame(tick);
@@ -206,12 +234,34 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
         // (including damping glide). Skip rendering entirely when nothing
         // changed — an editor sits idle most of the time.
         const controlsMoved = controls.update();
+        if (contextLost) return;
         if (!controlsMoved && !dirtyRef.current) return;
         dirtyRef.current = false;
         renderer.render(scene, camera);
       };
       rafId = requestAnimationFrame(tick);
       cleanup.push(() => cancelAnimationFrame(rafId));
+
+      // WebGL context loss (GPU reset, driver hiccup, tab backgrounding) would
+      // otherwise blank the canvas forever. preventDefault() lets the browser
+      // restore the context; we pause rendering until it does, then rebuild the
+      // shadow map and repaint from the (still-intact) scene graph.
+      const onContextLost = (event: Event) => {
+        event.preventDefault();
+        contextLost = true;
+      };
+      const onContextRestored = () => {
+        contextLost = false;
+        // GPU resources were dropped — force a fresh shadow pass and a repaint.
+        renderer.shadowMap.needsUpdate = true;
+        invalidateRef.current();
+      };
+      canvas.addEventListener('webglcontextlost', onContextLost as EventListener, false);
+      canvas.addEventListener('webglcontextrestored', onContextRestored as EventListener, false);
+      cleanup.push(() => {
+        canvas.removeEventListener('webglcontextlost', onContextLost as EventListener);
+        canvas.removeEventListener('webglcontextrestored', onContextRestored as EventListener);
+      });
 
       const onResize = () => {
         camera.aspect = canvas.clientWidth / canvas.clientHeight;
@@ -231,6 +281,7 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
         markDirty: () => {
           dirtyRef.current = true;
         },
+        requestShadowUpdate: requestShadowUpdateRef.current,
         controls,
         handlersRef,
       });
@@ -280,6 +331,7 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
     isReady,
     error,
     invalidate: invalidateRef.current,
+    requestShadowUpdate: requestShadowUpdateRef.current,
     threeModuleRef,
     sceneRef,
     cameraRef,

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -462,7 +462,7 @@ export function RoomOrganizer(): JSX.Element {
     view,
   });
 
-  const { isReady, error, invalidate, threeModuleRef, sceneRef, rendererRef, cameraRef, controlsRef, worldPositionFromClient } =
+  const { isReady, error, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, rendererRef, cameraRef, controlsRef, worldPositionFromClient } =
     useThreeScene({
       canvasRef,
       walkthroughActive,
@@ -506,6 +506,7 @@ export function RoomOrganizer(): JSX.Element {
   useSceneEffects({
     isReady,
     invalidate,
+    requestShadowUpdate,
     threeModuleRef,
     sceneRef,
     rendererRef,
@@ -528,6 +529,7 @@ export function RoomOrganizer(): JSX.Element {
   useNpcs({
     enabled: isReady && view.showNpcs && !view.view2D,
     invalidate,
+    requestShadowUpdate,
     threeModuleRef,
     sceneRef,
     roomWidth: layout.width,

--- a/components/room-organizer/three/camera-vision.ts
+++ b/components/room-organizer/three/camera-vision.ts
@@ -218,6 +218,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const wedge = new THREE.Mesh(wedgeGeo, wedgeMat);
   wedge.renderOrder = 991;
@@ -233,6 +234,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const volume = new THREE.Mesh(volumeGeo, volumeMat);
   volume.renderOrder = 990;
@@ -251,6 +253,7 @@ function buildCone(
       opacity: 0.7,
       depthWrite: false,
       depthTest: false,
+      toneMapped: false,
     })
   );
   outline.renderOrder = 992;
@@ -267,6 +270,7 @@ function buildCone(
     depthWrite: false,
     depthTest: false,
     blending: THREE.AdditiveBlending,
+    toneMapped: false,
   });
   const scan = new THREE.Mesh(scanGeo, scanMat);
   scan.renderOrder = 993;

--- a/components/room-organizer/three/drag-handlers.ts
+++ b/components/room-organizer/three/drag-handlers.ts
@@ -43,8 +43,17 @@ export interface DragHandlersOptions {
   scene: ThreeNS.Scene;
   controls: OrbitControlsType;
   markDirty: () => void;
+  /** Recompute the (static) shadow map — the dragged item is a shadow caster. */
+  requestShadowUpdate?: () => void;
   handlersRef: { readonly current: SceneEventHandlers };
 }
+
+/**
+ * `useSceneEffects` bumps this scene-level revision whenever it rebuilds the
+ * furniture set, letting the raycast pre-filter cache below rebuild its list
+ * only when the set actually changed — not on every pointermove.
+ */
+export const FURNITURE_REVISION_KEY = 'furnitureRevision';
 
 // A pointerdown that never travels past this radius (in CSS pixels) is a click,
 // not a drag: it selects the item without opening a drag session, so a plain
@@ -65,12 +74,28 @@ export function attachDragHandlers({
   scene,
   controls,
   markDirty,
+  requestShadowUpdate,
   handlersRef,
 }: DragHandlersOptions): () => void {
   const raycaster = new THREE.Raycaster();
   const pointer = new THREE.Vector2();
   const dragPlane = new THREE.Plane(new THREE.Vector3(0, 1, 0), 0);
   const intersection = new THREE.Vector3();
+
+  // Raycast pre-filter cache. `scene.children.filter(...)` allocated a fresh
+  // array on every pointermove (hover) and every pointerdown. The furniture set
+  // only changes on a rebuild, which bumps scene.userData[FURNITURE_REVISION_KEY];
+  // rebuild the cached list lazily when that revision moves.
+  let furnitureCache: ThreeNS.Object3D[] = [];
+  let furnitureCacheRevision = Number.NaN;
+  const furnitureList = (): ThreeNS.Object3D[] => {
+    const revision = (scene.userData[FURNITURE_REVISION_KEY] as number | undefined) ?? 0;
+    if (revision !== furnitureCacheRevision) {
+      furnitureCache = scene.children.filter((obj) => obj.userData.type === 'furniture');
+      furnitureCacheRevision = revision;
+    }
+    return furnitureCache;
+  };
 
   // A "pending" drag is a pointerdown that landed on a movable item but hasn't
   // yet travelled past DRAG_THRESHOLD_PX. Until it does, no drag session is
@@ -118,7 +143,7 @@ export function attachDragHandlers({
 
     setPointerFromEvent(event);
     raycaster.setFromCamera(pointer, camera);
-    const furniture = scene.children.filter((obj) => obj.userData.type === 'furniture');
+    const furniture = furnitureList();
     const hits = raycaster.intersectObjects(furniture, true);
     if (hits.length === 0) {
       // Walls get a chance to claim the click before we fall through to the
@@ -179,7 +204,7 @@ export function attachDragHandlers({
     if (!hoverCallback) return;
     setPointerFromEvent(event);
     raycaster.setFromCamera(pointer, camera);
-    const furniture = scene.children.filter((obj) => obj.userData.type === 'furniture');
+    const furniture = furnitureList();
     const hits = raycaster.intersectObjects(furniture, true);
     const target = ascendToFurniture(hits[0]?.object);
     const id = target ? (target.userData.id as string) : null;
@@ -232,6 +257,9 @@ export function attachDragHandlers({
     dragTarget.position.x = snapped.x;
     dragTarget.position.z = snapped.z;
     markDirty();
+    // The item is a shadow caster; recompute the static shadow map so its cast
+    // shadow tracks the drag instead of freezing at the drag-start position.
+    requestShadowUpdate?.();
     handlersRef.current.onItemDrag(itemId, snapped.x, snapped.z);
   };
 

--- a/components/room-organizer/three/measurement.ts
+++ b/components/room-organizer/three/measurement.ts
@@ -32,6 +32,7 @@ export function renderMeasurement(
     color: 0x10b981,
     emissive: 0x10b981,
     emissiveIntensity: 0.4,
+    toneMapped: false,
   });
   for (const point of points) {
     const sphere = new THREE.Mesh(sphereGeo, sphereMat);
@@ -41,7 +42,7 @@ export function renderMeasurement(
   }
 
   if (points.length >= 2) {
-    const lineMat = new THREE.LineBasicMaterial({ color: 0x10b981, linewidth: 2 });
+    const lineMat = new THREE.LineBasicMaterial({ color: 0x10b981, linewidth: 2, toneMapped: false });
     const lineGeo = new THREE.BufferGeometry().setFromPoints([
       new THREE.Vector3(points[0]!.x, yOffset + 0.05, points[0]!.z),
       new THREE.Vector3(points[1]!.x, yOffset + 0.05, points[1]!.z),

--- a/components/room-organizer/three/outdoor.ts
+++ b/components/room-organizer/three/outdoor.ts
@@ -198,6 +198,8 @@ function getBirchBarkTexture(THREE: ThreeModule): ThreeNS.CanvasTexture | null {
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Tag sRGB (CanvasTextures default to linear) so the bark isn't washed out.
+  texture.colorSpace = THREE.SRGBColorSpace;
   birchBarkTextureCache = texture;
   return texture;
 }

--- a/components/room-organizer/three/roof.ts
+++ b/components/room-organizer/three/roof.ts
@@ -1,4 +1,5 @@
 import { removeAndDispose } from './builder-utils';
+import { getMaxAnisotropy } from './texture-settings';
 import type { RoofSpec, RoofStyle } from '../lib/types';
 import type * as ThreeNS from 'three';
 
@@ -263,6 +264,10 @@ function buildShingleMaterial(
   const texture = new THREE.CanvasTexture(canvas);
   texture.wrapS = THREE.RepeatWrapping;
   texture.wrapT = THREE.RepeatWrapping;
+  // Albedo CanvasTextures default to NoColorSpace (linear); tag sRGB so it's
+  // decoded before lighting instead of rendering washed-out under sRGB output.
+  texture.colorSpace = THREE.SRGBColorSpace;
+  texture.anisotropy = getMaxAnisotropy();
   // Aim for ~3 shingle rows per metre of slope.
   texture.repeat.set(Math.max(1, surfaceWidth * 0.6), Math.max(1, surfaceLength * 0.6));
 

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -8,6 +8,18 @@ import type * as ThreeNS from 'three';
 
 type ThreeModule = typeof import('three');
 
+/**
+ * Freeze an object's transform: the room shell (walls, floor, baseboards,
+ * foundation, grid) never moves after it's built — a change rebuilds the whole
+ * shell, and applyWallDisplay only toggles `.visible`. Disabling matrixAutoUpdate
+ * (after a single updateMatrix()) skips the per-frame matrix recompute for every
+ * one of these meshes.
+ */
+function makeStatic(object: ThreeNS.Object3D): void {
+  object.updateMatrix();
+  object.matrixAutoUpdate = false;
+}
+
 export const ROOM_OBJECT_TAGS = {
   Floor: 'floor',
   Wall: 'wall',
@@ -159,6 +171,7 @@ export function buildRoom(THREE: ThreeModule, options: RoomBuilderOptions): void
   floor.position.y = yOffset;
   floor.receiveShadow = true;
   floor.userData.type = ROOM_OBJECT_TAGS.Floor;
+  makeStatic(floor);
   options.scene.add(floor);
 
   // Concrete foundation plinth — only on the ground floor. build-mode houses sit on
@@ -234,6 +247,7 @@ function addFoundation(
   foundation.receiveShadow = true;
   foundation.castShadow = true;
   foundation.userData.type = ROOM_OBJECT_TAGS.Floor;
+  makeStatic(foundation);
   scene.add(foundation);
 }
 
@@ -428,6 +442,7 @@ function buildWalls(
     wall.position.set(spec.position[0], spec.position[1], spec.position[2]);
     wall.userData.type = ROOM_OBJECT_TAGS.Wall;
     wall.userData.wallId = spec.id;
+    makeStatic(wall);
     scene.add(wall);
 
     // Dark wood baseboard along the floor of every wall — the build-mode-style
@@ -447,6 +462,7 @@ function buildWalls(
     const size = divisions * GRID_SIZE_METERS;
     const grid = new THREE.GridHelper(size, divisions);
     grid.userData.type = ROOM_OBJECT_TAGS.Wall;
+    makeStatic(grid);
     scene.add(grid);
   }
 }
@@ -489,6 +505,7 @@ function addBaseboard(
   base.receiveShadow = true;
   base.userData.type = ROOM_OBJECT_TAGS.Wall;
   base.userData.wallId = spec.id;
+  makeStatic(base);
   scene.add(base);
 }
 

--- a/components/room-organizer/three/signal-overlay.ts
+++ b/components/room-organizer/three/signal-overlay.ts
@@ -43,10 +43,16 @@ function addRings(
       transparent: true,
       opacity: startOpacity - (i - 1) * opacityFalloff,
       side: THREE.DoubleSide,
+      // UI overlay: bypass ACES tone mapping so the range-ring colour coding
+      // hits its exact hex, and don't write depth so concentric/overlapping
+      // rings from nearby sources don't punch holes in each other.
+      toneMapped: false,
+      depthWrite: false,
     });
     const mesh = new THREE.Mesh(geometry, material);
     mesh.position.set(position.x, yOffset + 0.01, position.z);
     mesh.rotation.x = -Math.PI / 2;
+    mesh.renderOrder = 980;
     mesh.userData.type = ROOM_OBJECT_TAGS.Signal;
     scene.add(mesh);
   }


### PR DESCRIPTION
## Stacked PR

**Stacked on #90 (fix/render-color-management) — merge that first.** This branch was cut from `fix/render-color-management`, not `main`, to avoid file conflicts with that open PR.

## Summary

Behavior-preserving render-loop performance fixes for the room-organizer 3D scene. The rendered output is intended to look **identical** and all interactions still work — these are pure perf optimizations.

## Optimizations

1. **WebGL context-loss handling** (`use-three-scene.ts`) — added `webglcontextlost` (preventDefault + pause the render half of the RAF loop) and `webglcontextrestored` (resume, force a shadow-map pass, invalidate) listeners, registered/unregistered in the init effect cleanup. A GPU reset now recovers instead of leaving the canvas blank forever.
2. **Static shadow map** (`use-three-scene.ts` + `use-scene-effects.ts` + `drag-handlers.ts` + `use-npcs.ts`) — `renderer.shadowMap.autoUpdate = false`; the 2048² directional shadow is recomputed only when a caster or the sun actually changes, via a shared `requestShadowUpdate()` exposed from `useThreeScene`. Triggered after a shell/furniture/interior-wall rebuild, after `applyTimeOfDay`, on drag move, and in the NPC tick only when an NPC moved. Pure camera orbit no longer recomputes shadows.
3. **NPC render-on-demand** (`use-npcs.ts`) — `stepNpcs` now returns whether any NPC moved; `invalidate()` and the shadow request fire only on a real move, skipped when all NPCs idle at their targets (mirrors `use-camera-vision.ts`). Stops pinning the GPU at refresh rate when NPCs are on.
4. **matrixAutoUpdate on static meshes** (`room-builder.ts`) — the room shell (walls, floor, baseboards, foundation, grid) gets `matrixAutoUpdate=false` + one `updateMatrix()` after positioning (`applyWallDisplay` only toggles `.visible`, never transforms). **Furniture deliberately keeps `matrixAutoUpdate` ON** because the multi-select group-drag fast-path in `use-item-drag.ts` (outside this batch's editable file set) mutates non-primary furniture group positions without `updateMatrix()`; freezing furniture would render those stale during a group drag. Flagged for retest.
5. **Raycast pre-filter cache** (`drag-handlers.ts`) — the furniture list is cached and rebuilt only when the scene furniture revision (`scene.userData[FURNITURE_REVISION_KEY]`, bumped by the furniture-rebuild effect) changes, instead of allocating a fresh `scene.children.filter(...)` array on every pointermove/pointerdown. Hover/drag/wall-pick behavior unchanged.
6. **Camera near-plane + renderer flags** (`use-three-scene.ts`) — near plane `0.1 → 0.3` (better depth precision; safe below the ~1.6m walkthrough eye height) and `powerPreference: 'high-performance'`. `antialias` and `sortObjects` left untouched (out of scope).

## Verification

- `npm run test` — 153/153 green (pure-logic suite, unaffected).
- `npm run typecheck` — clean.
- Lint — clean via `npx eslint --no-eslintrc -c .eslintrc.json --ext .ts,.tsx app components --max-warnings=0` (the plain `npm run lint`/build lint step hits a `@next/next` plugin-duplication error that is an artifact of the nested git-worktree `node_modules`, not this code).
- `npm run build` — compiles, generates, and exports all pages successfully.

## Needs runtime retest

- **Shadows not stale** — after moving/adding furniture, dragging, changing time-of-day, and editing interior walls, shadows update; during pure camera orbit they do **not** recompute.
- **Drag still moves** — single-item drag and multi-select group drag both move items visually (furniture matrix stays live).
- **NPC still animates** — NPCs walk smoothly and stop repainting when idle.
- **Context-loss recovery** — force a WebGL context loss (e.g. `WEBGL_lose_context`) and confirm the canvas repaints with correct shadows after restore.

Fixes #95