### PR TITLE
Landscape/short-viewport responsive layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,8 +415,10 @@ components/
 - A large floor-plan image stored as base64 can exhaust the ~5 MB
   `localStorage` quota; the save call catches and warns instead of crashing.
 - Walkthrough requires a click on the canvas to engage pointer lock.
-- The bottom glass panels can overlap on viewports narrower than ~1100 px;
-  there is no dedicated mobile layout.
+- The UI is responsive down to phone sizes — the HUD reflows, the item
+  editor becomes a bottom sheet, the sidebar goes full-screen, and short /
+  landscape viewports compact the floating chrome — but it isn't a
+  mobile-first redesign; very small screens stay dense.
 - No "rooms from enclosed walls" detection — interior walls are just
   drawn segments, not space-bounding entities.
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -241,3 +241,63 @@
     display: none !important;
   }
 }
+
+/* ================================================================
+   Responsive: short viewport / landscape phone (height < 500px)
+   Wide-but-short screens (landscape phones, short desktop windows)
+   fall past the width breakpoints into the roomy layout but lack the
+   vertical space for the tall floating chrome — compact it the way
+   the narrow layout does so nothing overflows off the bottom edge.
+   ================================================================ */
+@media (max-height: 500px) {
+  /* Touch orbit/zoom (and the TouchModeToggle) cover this — the vertical
+     camera d-pad just overflows a short viewport. */
+  .pc-camera-pad {
+    display: none !important;
+  }
+  /* Live stats are non-essential here; the budget still shows in the mode
+     panel, and hiding this frees the cramped top band. */
+  .pc-header-stats {
+    display: none !important;
+  }
+  /* Tighter bottom HUD so it doesn't eat the whole short viewport. */
+  .pc-bottom-hud {
+    padding: 6px !important;
+    gap: 6px !important;
+  }
+  /* Build tools collapse to a horizontal scrollable icon strip. */
+  .pc-build-tools {
+    width: auto !important;
+    padding: 6px !important;
+  }
+  .pc-build-tools-header {
+    display: none !important;
+  }
+  .pc-build-tools-grid {
+    display: flex !important;
+    overflow-x: auto !important;
+    gap: 3px !important;
+    padding: 4px !important;
+    scrollbar-width: none;
+  }
+  .pc-build-tools-grid::-webkit-scrollbar {
+    display: none;
+  }
+  .pc-build-tools-grid .pc-tile {
+    height: 36px !important;
+    width: 36px !important;
+    min-width: 36px !important;
+    padding: 4px !important;
+    border-radius: 8px !important;
+  }
+  .pc-build-tools-label {
+    display: none !important;
+  }
+  /* The right-edge item editor can be taller than a short viewport — pin it
+     near the top and let it scroll instead of running off the bottom. */
+  .pc-item-popover {
+    top: 8px !important;
+    max-height: calc(100vh - 16px) !important;
+    overflow-y: auto !important;
+  }
+}


### PR DESCRIPTION
The portrait mobile layout (phone/tablet) was already solid — verified with Playwright that the HUD reflows, the item editor becomes a bottom sheet, and the catalog/mode/sidebar all work down to 360px wide. The real gap was **landscape / short viewports**: wide-but-short screens (landscape phones, short desktop windows) fall past the width-based breakpoints into the roomy layout but lack the vertical room, so the camera d-pad and header stats overflowed off the bottom.

Added a `@media (max-height: 500px)` breakpoint that compacts the floating chrome — hides the camera d-pad (touch orbit + the touch-mode toggle cover it) and the header stats, collapses build-tools to a scrollable icon strip, and pins the item editor near the top with scroll.

**Verified (Playwright):** zero elements overflow the viewport at 844×390 landscape (was overflowing the camera pad before); portrait phone/tablet unaffected; typecheck + 157 tests + lint + build all green.

Also refreshed the stale README "Known limitations" note (it claimed there was no mobile layout).

Fixes #98