### PR TITLE
Recover from stale chunks after a redeploy (fixes the live loading hang)

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,9 +13,42 @@ export const viewport = {
   userScalable: false,
 };
 
+// Stale-chunk recovery for the GitHub Pages static export. index.html is cached
+// for ~10 min, so a returning visitor within that window loads cached HTML whose
+// hashed `_next/static/chunks/*.js` URLs were replaced by the new deploy and now
+// 404 — breaking the app before any React code runs. Two guarded recovery paths,
+// inline in <head> so they run before the app chunks:
+//   1. A capture-phase resource-error / unhandledrejection listener (fast path).
+//   2. A watchdog: if the editor hasn't signalled ready in time (the stuck
+//      "Loading the lot…" state), reload once. This catches failures the error
+//      events miss. `window.__pcReady` is set once the editor module loads
+//      (see app/page.tsx). The sessionStorage guard prevents a reload loop.
+const CHUNK_RECOVERY_SCRIPT = `(function(){
+  var K='pc-chunk-reload';
+  function reloadOnce(){
+    try{ if(sessionStorage.getItem(K)==='1') return; sessionStorage.setItem(K,'1'); }catch(e){}
+    location.reload();
+  }
+  window.addEventListener('error',function(e){
+    var t=e&&e.target;
+    if(t&&(t.tagName==='SCRIPT'||t.tagName==='LINK')){
+      var u=t.src||t.href||'';
+      if(u.indexOf('/_next/static/')!==-1) reloadOnce();
+    }
+  },true);
+  window.addEventListener('unhandledrejection',function(e){
+    var r=e&&e.reason, m=r?(r.name+' '+r.message):String(r||'');
+    if(/ChunkLoadError|Loading chunk|dynamically imported module/i.test(m)) reloadOnce();
+  });
+  setTimeout(function(){ if(!window.__pcReady) reloadOnce(); }, 12000);
+})();`;
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
+      <head>
+        <script dangerouslySetInnerHTML={{ __html: CHUNK_RECOVERY_SCRIPT }} />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,9 +1,34 @@
 'use client';
 
 import dynamic from 'next/dynamic';
+import {
+  clearChunkReloadGuard,
+  reloadOnceForChunkError,
+} from '@/components/room-organizer/lib/chunk-reload';
 
 const RoomOrganizer = dynamic(
-  () => import('@/components/room-organizer').then((module) => module.RoomOrganizer),
+  () =>
+    import('@/components/room-organizer')
+      .then((module) => {
+        // Editor chunk loaded — signal the head watchdog and clear the guard.
+        clearChunkReloadGuard();
+        if (typeof window !== 'undefined') {
+          (window as unknown as { __pcReady?: boolean }).__pcReady = true;
+        }
+        return module.RoomOrganizer;
+      })
+      .catch((err) => {
+        // A returning visitor after a redeploy can load cached HTML whose
+        // hashed editor chunk now 404s; next/dynamic would otherwise show the
+        // loading fallback forever. Reload once to fetch fresh assets.
+        if (reloadOnceForChunkError(err)) {
+          // A reload is navigating away — render nothing in the meantime.
+          return function ChunkReloading(): null {
+            return null;
+          };
+        }
+        throw err; // persistent failure → error boundary (offers a reset)
+      }),
   {
     ssr: false,
     loading: () => (

--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { reloadOnceForChunkError } from '../lib/chunk-reload';
 import { attachDragHandlers } from '../three/drag-handlers';
 import { addLights } from '../three/lighting';
 import { setMaxAnisotropy } from '../three/texture-settings';
@@ -127,6 +128,10 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
         setModuleLoaded(true);
       } catch (err) {
         if (cancelled) return;
+        // A stale Three.js chunk after a redeploy is a transient 404 — reload
+        // once to fetch fresh assets instead of stranding the user on the
+        // "Failed to load 3D engine" message.
+        if (reloadOnceForChunkError(err)) return;
         setError(messageOf(err, 'Failed to load 3D engine.'));
       }
     })();

--- a/components/room-organizer/lib/chunk-reload.test.ts
+++ b/components/room-organizer/lib/chunk-reload.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { isChunkLoadError } from './chunk-reload';
+
+describe('isChunkLoadError', () => {
+  it('matches webpack ChunkLoadError by name', () => {
+    const err = new Error('Loading chunk 367 failed.');
+    err.name = 'ChunkLoadError';
+    expect(isChunkLoadError(err)).toBe(true);
+  });
+
+  it('matches "Loading chunk N failed" messages', () => {
+    expect(isChunkLoadError(new Error('Loading chunk 42 failed. (error: /_next/x.js)'))).toBe(true);
+  });
+
+  it('matches native dynamic-import failures', () => {
+    expect(isChunkLoadError(new Error('Failed to fetch dynamically imported module: /x.js'))).toBe(true);
+    expect(isChunkLoadError(new Error('error loading dynamically imported module'))).toBe(true);
+  });
+
+  it('matches CSS chunk failures', () => {
+    expect(isChunkLoadError(new Error('Loading CSS chunk 5 failed'))).toBe(true);
+  });
+
+  it('does NOT match unrelated errors', () => {
+    expect(isChunkLoadError(new Error('Cannot read properties of undefined'))).toBe(false);
+    expect(isChunkLoadError(new TypeError('x is not a function'))).toBe(false);
+    expect(isChunkLoadError('some string')).toBe(false);
+    expect(isChunkLoadError(null)).toBe(false);
+  });
+});

--- a/components/room-organizer/lib/chunk-reload.ts
+++ b/components/room-organizer/lib/chunk-reload.ts
@@ -1,0 +1,48 @@
+// Recovery for stale hashed chunks after a redeploy.
+//
+// The app is a static export on GitHub Pages, which caches index.html for ~10
+// minutes. A returning visitor within that window loads cached HTML whose
+// hashed `_next/static/chunks/*.js` URLs were replaced by the new deploy and
+// now 404. Those chunks are loaded lazily (the editor via `next/dynamic`, and
+// Three.js via a runtime `import()`), so the failure surfaces as a
+// ChunkLoadError — and `next/dynamic`'s loading fallback otherwise swallows it,
+// stranding the user on "Loading the lot…" forever. Reloading once fetches
+// fresh HTML + chunk hashes and recovers.
+
+const CHUNK_RELOAD_KEY = 'pc-chunk-reload';
+
+/** Recognise the various shapes a failed dynamic-chunk load can take. */
+export function isChunkLoadError(err: unknown): boolean {
+  const s = err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+  return /ChunkLoadError|Loading chunk\s+\S+\s+failed|Loading CSS chunk|Failed to fetch dynamically imported module|error loading dynamically imported module|importing a module script failed/i.test(
+    s
+  );
+}
+
+/**
+ * If `err` is a stale-chunk failure, reload the page ONCE to fetch fresh assets
+ * and return `true`. A `sessionStorage` guard prevents a reload loop when the
+ * chunk still fails after reloading (a genuinely missing asset / broken
+ * deploy) — in that case this returns `false` so the caller can surface a real
+ * error instead of looping.
+ */
+export function reloadOnceForChunkError(err: unknown): boolean {
+  if (!isChunkLoadError(err) || typeof window === 'undefined') return false;
+  try {
+    if (window.sessionStorage.getItem(CHUNK_RELOAD_KEY) === '1') return false;
+    window.sessionStorage.setItem(CHUNK_RELOAD_KEY, '1');
+  } catch {
+    // sessionStorage unavailable (private mode / disabled) — reload best-effort.
+  }
+  window.location.reload();
+  return true;
+}
+
+/** Clear the one-shot guard after a successful load so future reloads aren't blocked. */
+export function clearChunkReloadGuard(): void {
+  try {
+    window.sessionStorage.removeItem(CHUNK_RELOAD_KEY);
+  } catch {
+    // ignore
+  }
+}


### PR DESCRIPTION
**Fixes the live-site "broken" report.** Diagnosed: the GitHub Pages static export caches `index.html` for ~10 min, so a returning visitor within that window loads cached HTML whose hashed chunk URLs were replaced by the newer deploy and now 404. The webpack/route/editor chunks fail before any React runs, `next/dynamic`'s loading fallback swallows it, and the #97 error-boundary reload never fires — so the user is stuck on "Loading the lot…" forever.

**Fix:** an inline `<head>` recovery script (runs before the app chunks) — a capture-phase resource-error + `unhandledrejection` fast path, plus a **watchdog** that reloads once if the editor hasn't set `window.__pcReady` within 12s (the watchdog is what actually catches the initial-chunk failures the error events miss). A `sessionStorage` guard prevents a reload loop; the guard clears + `__pcReady` sets when the editor module loads. The in-effect Three.js import routes a stale chunk through the same one-shot reload instead of the dead-end "Failed to load 3D engine" message.

**Verified (Playwright, local static build):** 404-ing the webpack, editor, and Three.js chunks each now reloads and recovers to a visible canvas (was hanging). New unit tests for the chunk-error matcher; typecheck + 162 tests + lint + build green.

> Note: merging deploys the fix; it only helps visitors *after* they've loaded the new HTML once — but from then on every future redeploy self-heals.

Fixes #100