### PR TITLE
Fix 'Reset saved layout' recovery (Zustand singleton survived soft reset)

### DIFF
--- a/app/error.tsx
+++ b/app/error.tsx
@@ -19,7 +19,7 @@ function isChunkLoadError(error: Error): boolean {
   return error.name === 'ChunkLoadError' || /loading chunk|loading css chunk|dynamically imported module/i.test(error.message);
 }
 
-export default function Error({ error, reset }: { error: Error & { digest?: string }; reset: () => void }): JSX.Element {
+export default function Error({ error }: { error: Error & { digest?: string }; reset: () => void }): JSX.Element {
   useEffect(() => {
     if (isChunkLoadError(error)) {
       window.location.reload();
@@ -30,9 +30,14 @@ export default function Error({ error, reset }: { error: Error & { digest?: stri
     try {
       window.localStorage.removeItem(STORAGE_KEY);
     } catch {
-      // Ignore — worst case the reset button just reloads without clearing.
+      // Ignore — worst case the reload happens without clearing.
     }
-    reset();
+    // Hard reload rather than the soft `reset()`: the layout lives in a
+    // module-level Zustand singleton, so a soft remount would keep the
+    // crash-causing layout in memory (loadLayout() is now null, so hydration
+    // wouldn't overwrite it) and immediately re-crash. A full document reload
+    // re-evaluates the module with a fresh store seeded from INITIAL_LAYOUT.
+    window.location.reload();
   };
 
   return (

--- a/app/global-error.tsx
+++ b/app/global-error.tsx
@@ -17,7 +17,7 @@ function isChunkLoadError(error: Error): boolean {
   return error.name === 'ChunkLoadError' || /loading chunk|loading css chunk|dynamically imported module/i.test(error.message);
 }
 
-export default function GlobalError({ error, reset }: { error: Error & { digest?: string }; reset: () => void }): JSX.Element {
+export default function GlobalError({ error }: { error: Error & { digest?: string }; reset: () => void }): JSX.Element {
   useEffect(() => {
     if (isChunkLoadError(error)) {
       window.location.reload();
@@ -28,9 +28,12 @@ export default function GlobalError({ error, reset }: { error: Error & { digest?
     try {
       window.localStorage.removeItem(STORAGE_KEY);
     } catch {
-      // Ignore — fall through to reload/reset even if storage is unavailable.
+      // Ignore — fall through to reload even if storage is unavailable.
     }
-    reset();
+    // Hard reload rather than the soft `reset()`: the layout is a module-level
+    // Zustand singleton, so a soft remount would keep the crash-causing layout
+    // in memory and re-crash. A full reload re-evaluates the module fresh.
+    window.location.reload();
   };
 
   return (


### PR DESCRIPTION
**Fixes #102.** After the Zustand POC (#89) moved layout into a module-level store singleton, the error boundaries' "Reset saved layout" button broke: it cleared localStorage then called Next's **soft** `reset()`, which remounts the editor without re-evaluating the module — so the singleton kept the crash-causing layout in memory (`loadLayout()` returns null after clearing, so hydration never overwrites it), and the app re-crashed on every click. An infinite "Something went sideways" loop; regresses the #70 recovery.

Both `app/error.tsx` and `app/global-error.tsx` now **hard-reload** after clearing storage — a full document load re-evaluates the module with a fresh store seeded from `INITIAL_LAYOUT`. (`reset` is no longer used, dropped from the destructure; the chunk-error path already hard-reloaded.)

Verified: typecheck + 162 tests + lint + build green.