### PR TITLE
Cap procedural texture caches with a disposing LRU

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,6 +279,7 @@ components/
     │   ├── roof.ts                      Flat / gable / hipped roof
     │   ├── floor-patterns.ts            Procedural CanvasTexture floors
     │   ├── wall-patterns.ts             Procedural CanvasTexture walls
+    │   ├── texture-lru.ts               LRU cache for texture masters (evict + dispose)
     │   ├── signal-overlay.ts            Wi-Fi / CCTV ring overlays
     │   ├── camera-vision.ts             Directional CCTV vision-cone overlays
     │   ├── lighting.ts                  Sun-arc continuous time of day

--- a/components/room-organizer/three/floor-patterns.ts
+++ b/components/room-organizer/three/floor-patterns.ts
@@ -1,3 +1,4 @@
+import { DisposableLruCache } from './texture-lru';
 import { getMaxAnisotropy } from './texture-settings';
 import type { FloorPattern } from '../lib/types';
 import type * as ThreeNS from 'three';
@@ -140,10 +141,11 @@ export interface BuildFloorPatternOptions {
  * drawing depends only on those; the per-room `repeat` is applied to a clone.
  * Regenerating the carpet pattern alone redraws 1200 speckles per rebuild.
  * Each caller gets a `.clone()` sharing the cached canvas image (cheap) that is
- * independently disposable; the cached master is never disposed, so the shared
- * GPU image is never freed while cached (a freed-then-reused texture is black).
+ * independently disposable. The cache is LRU-capped because `color` is
+ * user-pickable: evicted masters are disposed, which is safe for live clones
+ * (see texture-lru.ts), while cached masters keep the shared GPU image alive.
  */
-const floorTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+const floorTextureCache = new DisposableLruCache<ThreeNS.CanvasTexture>();
 
 export function buildFloorMaterial(
   THREE: ThreeModule,
@@ -162,8 +164,8 @@ export function buildFloorMaterial(
 
   // Clone per material so each floor owns a disposable copy sharing the cached
   // canvas image; per-room `repeat` is set on the clone, not the master.
+  // (`Texture.clone()` already flags needsUpdate, so no explicit re-upload.)
   const texture = master.clone();
-  texture.needsUpdate = true;
   texture.repeat.set(
     options.roomWidth * renderer.repeatPerMeter,
     options.roomDepth * renderer.repeatPerMeter

--- a/components/room-organizer/three/item-labels.ts
+++ b/components/room-organizer/three/item-labels.ts
@@ -1,4 +1,5 @@
 import { disposeObject } from './builder-utils';
+import { DisposableLruCache } from './texture-lru';
 import type { FurnitureItem } from '../lib/types';
 import type * as ThreeNS from 'three';
 
@@ -11,10 +12,11 @@ const LABEL_TAG = 'item-label';
  * canvas + CanvasTexture on every scene rebuild is wasteful when the item
  * names haven't changed. Each caller gets a `.clone()` of the cached master
  * so the clone shares the underlying canvas image (cheap) yet is independently
- * disposable — the master stays resident and is never disposed, so the shared
- * GPU image can't be freed while still cached (which would render black).
+ * disposable. The cache is LRU-capped because label text is user-authored:
+ * evicted masters are disposed, which is safe for live clones (see
+ * texture-lru.ts), while cached masters keep the shared GPU image alive.
  */
-const labelTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+const labelTextureCache = new DisposableLruCache<ThreeNS.CanvasTexture>();
 
 export function clearItemLabels(scene: ThreeNS.Scene): void {
   for (const obj of scene.children.filter((child) => child.userData.type === LABEL_TAG)) {
@@ -43,9 +45,8 @@ export function renderItemLabels(
 function createLabelSprite(THREE: ThreeModule, text: string): ThreeNS.Sprite {
   const master = getLabelTexture(THREE, text);
   // Clone per sprite so each mesh owns a disposable copy sharing the cached
-  // canvas image; the cached master is never disposed.
+  // canvas image. (`Texture.clone()` already flags needsUpdate.)
   const texture = master.clone();
-  texture.needsUpdate = true;
 
   const material = new THREE.SpriteMaterial({ map: texture, transparent: true, depthWrite: false });
   const sprite = new THREE.Sprite(material);

--- a/components/room-organizer/three/roof.ts
+++ b/components/room-organizer/three/roof.ts
@@ -1,4 +1,5 @@
 import { removeAndDispose } from './builder-utils';
+import { DisposableLruCache } from './texture-lru';
 import { getMaxAnisotropy } from './texture-settings';
 import type { RoofSpec, RoofStyle } from '../lib/types';
 import type * as ThreeNS from 'three';
@@ -12,10 +13,11 @@ export const ROOF_TAG = 'roof';
  * depends only on colour; the 256px size is fixed). Per-surface `repeat` and
  * the `side` flag live on the clone/material, not the master. Each roof gets a
  * `.clone()` sharing the cached canvas image (cheap) that is independently
- * disposable; the cached master is never disposed, so the shared GPU image is
- * never freed while cached (a freed-then-reused texture renders black).
+ * disposable. The cache is LRU-capped because the colour is user-pickable:
+ * evicted masters are disposed, which is safe for live clones (see
+ * texture-lru.ts), while cached masters keep the shared GPU image alive.
  */
-const shingleTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+const shingleTextureCache = new DisposableLruCache<ThreeNS.CanvasTexture>();
 
 /** Eaves: how far the roof overhangs past the wall plane (metres). */
 const EAVE_OVERHANG = 0.35;
@@ -239,8 +241,8 @@ function buildShingleMaterial(
 
   // Clone per roof so each surface owns a disposable copy sharing the cached
   // canvas image; per-surface `repeat` is set on the clone, not the master.
+  // (`Texture.clone()` already flags needsUpdate, so no explicit re-upload.)
   const texture = master.clone();
-  texture.needsUpdate = true;
   // Aim for ~3 shingle rows per metre of slope.
   texture.repeat.set(Math.max(1, surfaceWidth * 0.6), Math.max(1, surfaceLength * 0.6));
 

--- a/components/room-organizer/three/texture-lru.test.ts
+++ b/components/room-organizer/three/texture-lru.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from 'vitest';
+import { DisposableLruCache, TEXTURE_CACHE_CAPACITY } from './texture-lru';
+
+class FakeTexture {
+  disposed = false;
+  dispose(): void {
+    this.disposed = true;
+  }
+}
+
+describe('DisposableLruCache', () => {
+  it('stores and retrieves values under capacity without disposing', () => {
+    const cache = new DisposableLruCache<FakeTexture>(3);
+    const a = new FakeTexture();
+    const b = new FakeTexture();
+    cache.set('a', a);
+    cache.set('b', b);
+
+    expect(cache.get('a')).toBe(a);
+    expect(cache.get('b')).toBe(b);
+    expect(cache.get('missing')).toBeUndefined();
+    expect(cache.size).toBe(2);
+    expect(a.disposed).toBe(false);
+    expect(b.disposed).toBe(false);
+  });
+
+  it('evicts and disposes the least-recently-inserted entry beyond capacity', () => {
+    const cache = new DisposableLruCache<FakeTexture>(2);
+    const a = new FakeTexture();
+    const b = new FakeTexture();
+    const c = new FakeTexture();
+    cache.set('a', a);
+    cache.set('b', b);
+    cache.set('c', c); // evicts 'a'
+
+    expect(a.disposed).toBe(true);
+    expect(cache.get('a')).toBeUndefined();
+    expect(cache.get('b')).toBe(b);
+    expect(cache.get('c')).toBe(c);
+    expect(cache.size).toBe(2);
+  });
+
+  it('treats get() as a use: recently read entries survive eviction', () => {
+    const cache = new DisposableLruCache<FakeTexture>(2);
+    const a = new FakeTexture();
+    const b = new FakeTexture();
+    const c = new FakeTexture();
+    cache.set('a', a);
+    cache.set('b', b);
+    cache.get('a'); // refresh 'a' → 'b' is now LRU
+    cache.set('c', c); // evicts 'b'
+
+    expect(b.disposed).toBe(true);
+    expect(a.disposed).toBe(false);
+    expect(cache.get('a')).toBe(a);
+    expect(cache.get('b')).toBeUndefined();
+    expect(cache.get('c')).toBe(c);
+  });
+
+  it('re-setting an existing key refreshes recency without disposing the old value', () => {
+    const cache = new DisposableLruCache<FakeTexture>(2);
+    const a1 = new FakeTexture();
+    const a2 = new FakeTexture();
+    const b = new FakeTexture();
+    const c = new FakeTexture();
+    cache.set('a', a1);
+    cache.set('b', b);
+    cache.set('a', a2); // overwrite: 'b' becomes LRU; a1 is NOT auto-disposed
+    cache.set('c', c); // evicts 'b'
+
+    expect(a1.disposed).toBe(false);
+    expect(b.disposed).toBe(true);
+    expect(cache.get('a')).toBe(a2);
+    expect(cache.get('c')).toBe(c);
+  });
+
+  it('rejects a capacity below one', () => {
+    expect(() => new DisposableLruCache(0)).toThrow();
+  });
+
+  it('exposes a default capacity suited to per-colour texture caches', () => {
+    expect(TEXTURE_CACHE_CAPACITY).toBe(32);
+    const cache = new DisposableLruCache<FakeTexture>();
+    const textures: FakeTexture[] = [];
+    for (let i = 0; i < TEXTURE_CACHE_CAPACITY + 1; i += 1) {
+      const t = new FakeTexture();
+      textures.push(t);
+      cache.set(`#${i.toString(16).padStart(6, '0')}`, t);
+    }
+    expect(cache.size).toBe(TEXTURE_CACHE_CAPACITY);
+    expect(textures[0]?.disposed).toBe(true);
+    expect(textures[1]?.disposed).toBe(false);
+  });
+});

--- a/components/room-organizer/three/texture-lru.ts
+++ b/components/room-organizer/three/texture-lru.ts
@@ -1,0 +1,52 @@
+/**
+ * Tiny LRU cache for procedural texture masters (floor/wall/roof/label
+ * CanvasTextures). The caches are keyed partly on user-pickable colours, so
+ * without a cap, dragging a colour input leaks one permanent 256px canvas +
+ * GPU texture per unique colour for the whole session. On insert beyond the
+ * cap the least-recently-used master is evicted and `.dispose()`d.
+ *
+ * Evicting a master is safe for meshes already on screen: callers receive
+ * `.clone()`s, and in three.js the GL texture behind a shared `Source` is
+ * refcounted per user (`WebGLTextures.deallocateTexture` decrements
+ * `usedTimes` and only deletes at zero), so disposing the evicted master
+ * never frees an image a live clone still renders.
+ */
+
+/** Default cap per texture cache — comfortably above the handful of
+ * pattern/colour combos a real layout uses at once. */
+export const TEXTURE_CACHE_CAPACITY = 32;
+
+export class DisposableLruCache<T extends { dispose(): void }> {
+  /** Map iteration order doubles as recency order: oldest entry first. */
+  private readonly entries = new Map<string, T>();
+
+  constructor(private readonly capacity: number = TEXTURE_CACHE_CAPACITY) {
+    if (capacity < 1) throw new Error('DisposableLruCache capacity must be >= 1');
+  }
+
+  /** Returns the cached value (marking it most-recently-used) or undefined. */
+  get(key: string): T | undefined {
+    const value = this.entries.get(key);
+    if (value !== undefined) {
+      this.entries.delete(key);
+      this.entries.set(key, value);
+    }
+    return value;
+  }
+
+  /** Inserts as most-recently-used; evicts + disposes the LRU entry beyond capacity. */
+  set(key: string, value: T): void {
+    this.entries.delete(key);
+    this.entries.set(key, value);
+    while (this.entries.size > this.capacity) {
+      const oldestKey = this.entries.keys().next().value as string;
+      const oldest = this.entries.get(oldestKey);
+      this.entries.delete(oldestKey);
+      oldest?.dispose();
+    }
+  }
+
+  get size(): number {
+    return this.entries.size;
+  }
+}

--- a/components/room-organizer/three/wall-patterns.ts
+++ b/components/room-organizer/three/wall-patterns.ts
@@ -1,3 +1,4 @@
+import { DisposableLruCache } from './texture-lru';
 import { getMaxAnisotropy } from './texture-settings';
 import type { WallPattern } from '../lib/types';
 import type * as ThreeNS from 'three';
@@ -154,10 +155,11 @@ export interface BuildWallMaterialOptions {
  * built ×4 per shell rebuild; the canvas drawing depends only on those keys,
  * while the per-wall `repeat` is applied to a clone. Each caller gets a
  * `.clone()` sharing the cached canvas image (cheap) that is independently
- * disposable; the cached master is never disposed, so the shared GPU image is
- * never freed while cached (a freed-then-reused texture renders black).
+ * disposable. The cache is LRU-capped because `color` is user-pickable:
+ * evicted masters are disposed, which is safe for live clones (see
+ * texture-lru.ts), while cached masters keep the shared GPU image alive.
  */
-const wallTextureCache = new Map<string, ThreeNS.CanvasTexture>();
+const wallTextureCache = new DisposableLruCache<ThreeNS.CanvasTexture>();
 
 export function buildWallMaterial(
   THREE: ThreeModule,
@@ -188,8 +190,8 @@ export function buildWallMaterial(
 
   // Clone per material so each wall owns a disposable copy sharing the cached
   // canvas image; per-wall `repeat` is set on the clone, not the master.
+  // (`Texture.clone()` already flags needsUpdate, so no explicit re-upload.)
   const texture = master.clone();
-  texture.needsUpdate = true;
   texture.repeat.set(options.width * renderer.repeatPerMeter, options.height * renderer.repeatPerMeter * 0.6);
 
   return new THREE.MeshStandardMaterial({


### PR DESCRIPTION
Fixes #106

## Part 1 — unbounded per-colour caches

The module-level texture caches in `three/floor-patterns.ts`, `three/wall-patterns.ts`, `three/roof.ts` (shingles), and `three/item-labels.ts` are keyed partly on user-pickable hex colours (or user-authored label text), and cached masters were never disposed. Dragging a colour input added a permanent 256px CanvasTexture master per unique colour for the whole session.

All four caches now use one shared helper, `three/texture-lru.ts`: a tiny `DisposableLruCache` (default cap **32**, `TEXTURE_CACHE_CAPACITY`) backed by a `Map` whose insertion order doubles as recency order — `get()` refreshes recency, `set()` beyond the cap evicts the least-recently-used master and calls `.dispose()` on it. Cache keys are unchanged.

**Why evicting a master is safe for on-screen meshes:** callers receive `.clone()`s, and in three 0.169 `Texture.copy()` shares the master's `Source` (`src/textures/Texture.js:105`). `WebGLTextures.deallocateTexture` refcounts the GL texture per source (`usedTimes--`, delete only at 0), so disposing an evicted master never frees an image a live clone still renders — no black textures after eviction. If the master itself was never rendered (only clones are handed to materials), its deallocation is a no-op entirely.

The helper is duck-typed over `{ dispose(): void }` (no three import), so it has a plain unit test: `three/texture-lru.test.ts` (6 tests covering hit/miss, eviction + dispose, get-refreshes-recency, overwrite semantics, capacity validation, default cap).

## Part 2 — redundant `needsUpdate` on clones

The issue flagged the explicit `texture.needsUpdate = true` after `master.clone()` at the four clone sites. Verified against `three@0.169.0` in node_modules: `Texture.clone()` calls `copy()`, which **unconditionally** sets `this.needsUpdate = true` as its last statement (`src/textures/Texture.js:139`). The explicit flag was therefore a redundant duplicate — the clone still gets its upload request from `clone()` itself — so the four lines are removed. Rendering is unaffected.

## Verification

- `npm run test` — 173 passed (167 existing + 6 new LRU tests)
- `npm run typecheck` — clean
- eslint `--max-warnings=0` — clean
- `npm run build` — succeeds

Also added `texture-lru.ts` to the README module layout per the repo convention.