### PR TITLE
Confirm before Surprise-me wipes a furnished floor; small logic roundup

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,10 +19,12 @@ export const viewport = {
 // 404 — breaking the app before any React code runs. Two guarded recovery paths,
 // inline in <head> so they run before the app chunks:
 //   1. A capture-phase resource-error / unhandledrejection listener (fast path).
-//   2. A watchdog: if the editor hasn't signalled ready in time (the stuck
+//   2. A watchdog: if the editor hasn't signalled ready within 20 s (the stuck
 //      "Loading the lot…" state), reload once. This catches failures the error
 //      events miss. `window.__pcReady` is set once the editor module loads
-//      (see app/page.tsx). The sessionStorage guard prevents a reload loop.
+//      (see app/page.tsx). The generous timeout avoids spurious reloads on
+//      slow connections, and the sessionStorage guard makes the reload
+//      one-shot either way.
 const CHUNK_RECOVERY_SCRIPT = `(function(){
   var K='pc-chunk-reload';
   function reloadOnce(){
@@ -40,7 +42,7 @@ const CHUNK_RECOVERY_SCRIPT = `(function(){
     var r=e&&e.reason, m=r?(r.name+' '+r.message):String(r||'');
     if(/ChunkLoadError|Loading chunk|dynamically imported module/i.test(m)) reloadOnce();
   });
-  setTimeout(function(){ if(!window.__pcReady) reloadOnce(); }, 12000);
+  setTimeout(function(){ if(!window.__pcReady) reloadOnce(); }, 20000);
 })();`;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/components/room-organizer/hooks/layout-reducer.test.ts
+++ b/components/room-organizer/hooks/layout-reducer.test.ts
@@ -392,13 +392,41 @@ describe('layoutReducer — floor / building operations', () => {
 
   it('duplicateFloor clones items with fresh ids and activates the copy', () => {
     const base = stateWith([makeItem({ id: 'orig', type: 'chair' })], 1);
-    const state = layoutReducer(base, { type: 'duplicateFloor', sourceIndex: 0, newId: 'copy' });
+    const state = layoutReducer(base, {
+      type: 'duplicateFloor',
+      sourceIndex: 0,
+      newId: 'copy',
+      idSuffix: 'aaaa',
+    });
     expect(state.layout.floors).toHaveLength(2);
     expect(state.activeFloorIndex).toBe(1);
     const copy = state.layout.floors[1]!;
     expect(copy.name).toBe('Floor 0 copy');
     expect(copy.items).toHaveLength(1);
     expect(copy.items[0]!.id).not.toBe('orig');
+  });
+
+  it('duplicateFloor keys cloned ids on the per-duplication idSuffix so same-millisecond copies never collide', () => {
+    const base = stateWith([makeItem({ id: 'orig', type: 'chair' })], 1);
+    const first = layoutReducer(base, {
+      type: 'duplicateFloor',
+      sourceIndex: 0,
+      newId: 'copy-a',
+      idSuffix: 'aaaa',
+    });
+    const second = layoutReducer(first, {
+      type: 'duplicateFloor',
+      sourceIndex: 0,
+      newId: 'copy-b',
+      idSuffix: 'bbbb',
+    });
+    const idsA = first.layout.floors[1]!.items.map((item) => item.id);
+    const idsB = second.layout.floors[2]!.items.map((item) => item.id);
+    expect(idsA[0]).toContain('aaaa');
+    expect(idsB[0]).toContain('bbbb');
+    // Even when both duplications land on the same Date.now() stamp, the
+    // suffix keeps every cloned id unique.
+    expect(new Set([...idsA, ...idsB]).size).toBe(idsA.length + idsB.length);
   });
 
   it('renameFloor renames the target floor without changing the active one', () => {

--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -54,7 +54,7 @@ export type LayoutAction =
   // floor / building operations
   | { type: 'setActiveFloorIndex'; index: number }
   | { type: 'addFloor'; floor: Omit<FloorLayout, 'name'> & { name?: string } }
-  | { type: 'duplicateFloor'; sourceIndex: number; newId: string }
+  | { type: 'duplicateFloor'; sourceIndex: number; newId: string; idSuffix: string }
   | { type: 'removeFloor'; index: number }
   | { type: 'renameFloor'; index: number; name: string }
   | { type: 'reorderFloor'; from: number; to: number }
@@ -349,14 +349,18 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
       if (state.layout.floors.length >= MAX_FLOORS) return state;
       const source = state.layout.floors[action.sourceIndex];
       if (!source) return state;
+      // `action.idSuffix` is a per-duplication random tag generated OUTSIDE the
+      // reducer (see use-layout-store.ts) — the reducer stays deterministic in
+      // its inputs, while two duplications within the same millisecond can no
+      // longer clone colliding item/wall ids.
       const stamp = Date.now();
       const clonedItems: FurnitureItem[] = source.items.map((item, idx) => ({
         ...item,
-        id: `${item.type}-${stamp}-${idx}`,
+        id: `${item.type}-${stamp}-${action.idSuffix}-${idx}`,
       }));
       const clonedWalls: InteriorWall[] | undefined = source.interiorWalls?.map((wall, idx) => ({
         ...wall,
-        id: `wall-${stamp}-${idx}`,
+        id: `wall-${stamp}-${action.idSuffix}-${idx}`,
       }));
       const floor: FloorLayout = {
         ...source,

--- a/components/room-organizer/hooks/use-layout-store.react.test.ts
+++ b/components/room-organizer/hooks/use-layout-store.react.test.ts
@@ -1,0 +1,62 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { makeCatalogItem } from '../lib/__testfixtures__/fixtures';
+import { INITIAL_LAYOUT } from './layout-reducer';
+import { layoutStore, useActiveFloor, useLayoutStore } from './use-layout-store';
+
+// React-facing tests for the Zustand store hooks. The wiring smoke tests in
+// use-layout-store.test.ts only exercise `getState().actions`; these cover the
+// hook layer itself: Zustand v5 requires selectors to return referentially
+// stable snapshots (or useSyncExternalStore loops), and atomic selectors must
+// re-render subscribers only when their own slice changes.
+
+// React's act() warns unless the environment opts in.
+(globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+
+function reset(): void {
+  layoutStore.setState({ layout: INITIAL_LAYOUT, activeFloorIndex: 0 });
+}
+
+describe('use-layout-store — React hook layer', () => {
+  beforeEach(reset);
+
+  it('useActiveFloor returns a referentially stable floor across an unrelated dispatch', () => {
+    const { result } = renderHook(() => useActiveFloor());
+    const before = result.current;
+
+    act(() => {
+      layoutStore.getState().actions.setName('Renamed Villa');
+    });
+
+    // setName replaces layout but not the floors array, so the active floor
+    // snapshot must keep its identity — Zustand v5 loops otherwise.
+    expect(result.current).toBe(before);
+  });
+
+  it('a layout.name subscriber re-renders on setName but not on moveItem', () => {
+    const itemId = layoutStore.getState().actions.addCatalogItem(makeCatalogItem(), { x: 0, z: 0 });
+
+    let renders = 0;
+    const { result } = renderHook(() => {
+      renders += 1;
+      return useLayoutStore((s) => s.layout.name);
+    });
+    const rendersAfterMount = renders;
+
+    act(() => {
+      layoutStore.getState().actions.setName('Atomic House');
+    });
+    expect(result.current).toBe('Atomic House');
+    expect(renders).toBe(rendersAfterMount + 1);
+
+    act(() => {
+      layoutStore.getState().actions.moveItem(itemId, 3, 4);
+    });
+    // The move really happened…
+    const moved = layoutStore.getState().layout.floors[0]!.items.find((i) => i.id === itemId);
+    expect(moved?.position).toEqual({ x: 3, z: 4 });
+    // …but the name subscriber did not re-render for it.
+    expect(renders).toBe(rendersAfterMount + 1);
+  });
+});

--- a/components/room-organizer/hooks/use-layout-store.ts
+++ b/components/room-organizer/hooks/use-layout-store.ts
@@ -21,7 +21,7 @@
 // ---------------------------------------------------------------------------
 
 import { createStore, useStore } from 'zustand';
-import { randomId } from '../lib/ids';
+import { randomId, randomSuffix } from '../lib/ids';
 import {
   layoutReducer,
   INITIAL_GROUND_FLOOR,
@@ -116,7 +116,10 @@ export const layoutStore = createStore<LayoutStoreState>()((set) => {
     },
     duplicateFloor: (sourceIndex) => {
       const newId = nextId('floor');
-      dispatch({ type: 'duplicateFloor', sourceIndex, newId });
+      // Randomness lives here, not in the reducer: the reducer must stay pure
+      // (StrictMode double-invokes updaters), so the per-duplication suffix
+      // that de-collides cloned item/wall ids is passed in via the action.
+      dispatch({ type: 'duplicateFloor', sourceIndex, newId, idSuffix: randomSuffix() });
       return newId;
     },
     removeFloor: (index) => dispatch({ type: 'removeFloor', index }),

--- a/components/room-organizer/lib/furniture-sets.ts
+++ b/components/room-organizer/lib/furniture-sets.ts
@@ -97,8 +97,13 @@ interface ResolvedSpec {
  * small as 2×2 m while the sets assume up to ~4.4 m, so without this clamp
  * items land through the walls (#73).
  */
+// Inset from the EXTERIOR half-width used when clamping generated placements.
+// The room dimensions are exterior measurements, so ~0.35 m (wall thickness
+// plus a small margin) keeps pieces from sitting under or inside the walls.
+const WALL_INSET = 0.35;
+
 function fitScale(specs: readonly ResolvedSpec[], roomWidth: number, roomDepth: number): number {
-  const MARGIN = 0.1;
+  const MARGIN = WALL_INSET;
   const usableHalfW = Math.max(0, roomWidth / 2 - MARGIN);
   const usableHalfD = Math.max(0, roomDepth / 2 - MARGIN);
   // Scale only the offsets: the item half-extents are fixed, so solve
@@ -123,7 +128,7 @@ function fitScale(specs: readonly ResolvedSpec[], roomWidth: number, roomDepth: 
  * if it doesn't, the set can't be placed here at all.
  */
 export function setFitsRoom(set: FurnitureSet, roomWidth: number, roomDepth: number): boolean {
-  const MARGIN = 0.1;
+  const MARGIN = WALL_INSET;
   for (const spec of set.items) {
     const catalog = FURNITURE_CATALOG.find((entry) => entry.type === spec.type);
     if (!catalog) continue;

--- a/components/room-organizer/lib/library.test.ts
+++ b/components/room-organizer/lib/library.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { slugify } from './library';
+
+describe('slugify', () => {
+  it('keeps short names unchanged (existing library saves keep their ids)', () => {
+    expect(slugify('Beach House')).toBe('beach-house');
+    expect(slugify('  My Cozy Loft!  ')).toBe('my-cozy-loft');
+  });
+
+  it('is stable for the same short name', () => {
+    expect(slugify('Villa')).toBe(slugify('Villa'));
+  });
+
+  it('gives distinct slugs to two 60-char names sharing a 40-char prefix', () => {
+    const prefix = 'a'.repeat(40);
+    const nameA = `${prefix}${'b'.repeat(20)}`;
+    const nameB = `${prefix}${'c'.repeat(20)}`;
+    expect(nameA).toHaveLength(60);
+    expect(nameB).toHaveLength(60);
+
+    const slugA = slugify(nameA);
+    const slugB = slugify(nameB);
+    expect(slugA).not.toBe(slugB);
+    // Both keep the readable truncated prefix and stay deterministic.
+    expect(slugA.startsWith(prefix)).toBe(true);
+    expect(slugB.startsWith(prefix)).toBe(true);
+    expect(slugify(nameA)).toBe(slugA);
+    expect(slugify(nameB)).toBe(slugB);
+  });
+
+  it('does not append a hash to a name exactly at the cap', () => {
+    const name = 'a'.repeat(40);
+    expect(slugify(name)).toBe(name);
+  });
+
+  it('falls back to a layout-* slug for names with no usable characters', () => {
+    expect(slugify('!!!')).toMatch(/^layout-\d+$/);
+  });
+});

--- a/components/room-organizer/lib/library.ts
+++ b/components/room-organizer/lib/library.ts
@@ -32,15 +32,33 @@ function layoutKey(id: string): string {
   return `${LIBRARY_KEY_PREFIX}${id}`;
 }
 
+const SLUG_MAX_LENGTH = 40;
+
+/**
+ * Deterministic 6-char base36 digest, used to keep truncated slugs distinct.
+ * Not cryptographic — just enough that two long names sharing a 40-char
+ * prefix don't silently map to the same save slot.
+ */
+function shortHash(input: string): string {
+  let hash = 0;
+  for (let i = 0; i < input.length; i++) {
+    hash = (hash * 31 + input.charCodeAt(i)) | 0;
+  }
+  return (hash >>> 0).toString(36).padStart(6, '0').slice(0, 6);
+}
+
 export function slugify(name: string): string {
-  return (
-    name
-      .trim()
-      .toLowerCase()
-      .replace(/[^a-z0-9]+/g, '-')
-      .replace(/^-+|-+$/g, '')
-      .slice(0, 40) || `layout-${Date.now()}`
-  );
+  const base = name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  if (!base) return `layout-${Date.now()}`;
+  // Short names keep their historical slug unchanged, so existing library
+  // saves are unaffected. Only when truncation would discard part of the name
+  // do we append a hash of the FULL name to disambiguate.
+  if (base.length <= SLUG_MAX_LENGTH) return base;
+  return `${base.slice(0, SLUG_MAX_LENGTH)}-${shortHash(base)}`;
 }
 
 export function layoutSlugExists(name: string): boolean {

--- a/components/room-organizer/lib/surprise.ts
+++ b/components/room-organizer/lib/surprise.ts
@@ -111,12 +111,15 @@ function randomPosition(
   candidate: CatalogItem,
   existing: readonly FurnitureItem[]
 ): { x: number; z: number } | null {
+  // Room dimensions are exterior measurements; inset by ~wall thickness plus a
+  // small margin so decor never spawns under or inside the exterior walls.
+  const WALL_INSET = 0.35;
   const halfW = candidate.width / 2;
   const halfD = candidate.depth / 2;
-  const minX = -roomWidth / 2 + halfW;
-  const maxX = roomWidth / 2 - halfW;
-  const minZ = -roomDepth / 2 + halfD;
-  const maxZ = roomDepth / 2 - halfD;
+  const minX = -roomWidth / 2 + WALL_INSET + halfW;
+  const maxX = roomWidth / 2 - WALL_INSET - halfW;
+  const minZ = -roomDepth / 2 + WALL_INSET + halfD;
+  const maxZ = roomDepth / 2 - WALL_INSET - halfD;
   if (minX > maxX || minZ > maxZ) return null;
 
   for (let attempt = 0; attempt < 30; attempt++) {

--- a/components/room-organizer/panels/actions-panel.tsx
+++ b/components/room-organizer/panels/actions-panel.tsx
@@ -77,6 +77,14 @@ export function ActionsPanel(props: ActionsPanelProps): JSX.Element {
           </div>
           <Button
             onClick={() => {
+              // Surprise replaces the whole floor — never wipe placed furniture
+              // without asking (#105). An empty floor proceeds silently.
+              if (
+                hasItems &&
+                !window.confirm('Replace everything on this floor with a surprise layout?')
+              ) {
+                return;
+              }
               const items = surpriseLayout({ roomWidth: layout.width, roomDepth: layout.height });
               actions.replaceItems(items);
               setSelectedItemId(null);

--- a/components/room-organizer/panels/bottom-hud.tsx
+++ b/components/room-organizer/panels/bottom-hud.tsx
@@ -23,7 +23,7 @@ export interface BottomHudProps {
 }
 
 export function BottomHud({ selectedWall, onSelectedWallChange, onOrbit, onZoom, onFit, placeCatalogItem }: BottomHudProps): JSX.Element {
-  const { layout, actions, view, toggle, setView, isReady, error, gameMode, setGameMode, playCue } = useRoomEditor();
+  const { layout, activeFloor, actions, view, toggle, setView, isReady, error, gameMode, setGameMode, playCue } = useRoomEditor();
   const { setSelectedItemId, setExtraSelectedIds } = useSelection();
   const [buildToolCategory, setBuildToolCategory] = useState<BuildToolCategory>('seating');
 
@@ -143,6 +143,14 @@ export function BottomHud({ selectedWall, onSelectedWallChange, onOrbit, onZoom,
           }
         }}
         onSurprise={() => {
+          // Surprise replaces the whole floor — never wipe placed furniture
+          // without asking (#105). An empty floor proceeds silently.
+          if (
+            activeFloor.items.length > 0 &&
+            !window.confirm('Replace everything on this floor with a surprise layout?')
+          ) {
+            return;
+          }
           const items = surpriseLayout({
             roomWidth: layout.width,
             roomDepth: layout.height,

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,8 @@
         "zustand": "^5.0.15"
       },
       "devDependencies": {
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.3",
         "@types/node": "^20.16.11",
         "@types/react": "^18.3.11",
         "@types/react-dom": "^18.3.0",
@@ -30,6 +32,7 @@
         "autoprefixer": "^10.4.20",
         "eslint": "^8.57.1",
         "eslint-config-next": "^15.5.23",
+        "jsdom": "^30.0.1",
         "postcss": "^8.5.10",
         "tailwindcss": "^3.4.13",
         "tailwindcss-animate": "^1.0.7",
@@ -48,6 +51,227 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "6.0.7",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-6.0.7.tgz",
+      "integrity": "sha512-vC/bk1Lz7Tn/EfU9/apOTBk80/8dyGyWMowPoV1tJ52muDGsDqt2HPT2klrFUiY60MQmQv9q8yIht15JnBgDGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.3.0",
+        "@csstools/css-color-parser": "^4.1.10",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-8.3.2.tgz",
+      "integrity": "sha512-93Z1N+BQNXysodoicpOIyNh2drHfz/CTf9nnT0FEx72GJcIiwgydD7tGAr78j41LsYn3hlRn+LdGPuBLn1Bl8Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.2.1",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2"
+      },
+      "engines": {
+        "node": "^22.13.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.1.1.tgz",
+      "integrity": "sha512-gLNsunvwf3mCi5u5o46/Z/JcJMnhbHSaZ69rkgPzNM3J4s8hWwpPUQB6/tt0EDFyCiWzxANlx+2LJwpYj4zS1w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.3.0.tgz",
+      "integrity": "sha512-c5ihYsPkdG6JCkU2zTMm4+k6r7RXuGxtWYhu5DHMIiF1FHzrfmHL5so11AoFpUv/tu61xfcmT4AmKoFfMPoqdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.2.2.tgz",
+      "integrity": "sha512-3QKjR/vxyjcSXBLgb6lP0S3MGdvwbmqSsvLPbYdVORqPDc8FX1HAJ0Spk38bxaRXgvENTA47tlhhbb5Z2e8hEg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.1.1",
+        "@csstools/css-calc": "^3.3.0"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.12.tgz",
+      "integrity": "sha512-3vLQK+dXxhBMR2Wx99PTCifE+vHtW2ndZWyla8yK813ev6oGhyn8Lja8jCyGAWTJ+LEYZK7EVtJxrDj8ztevJw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -144,6 +368,24 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@floating-ui/core": {
@@ -2130,6 +2372,64 @@
         "tslib": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.3",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.3.tgz",
+      "integrity": "sha512-Uo193NgQbPMz6lrrhtRQQFcMC6Re/ELLFbbuVL30WDlZxlpZf9/lMHTAVxPRLw1q1iu9OJmR1c2BLiENRstdBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tweenjs/tween.js": {
       "version": "23.1.3",
       "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
@@ -2147,6 +2447,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -3402,6 +3709,16 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
+    },
     "node_modules/binary-extensions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
@@ -3714,6 +4031,20 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -3740,6 +4071,35 @@
       "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
       "dev": true,
       "license": "BSD-2-Clause"
+    },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
     },
     "node_modules/data-view-buffer": {
       "version": "1.0.2",
@@ -3813,6 +4173,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3854,6 +4221,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/detect-libc": {
@@ -3899,6 +4276,13 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -3927,6 +4311,19 @@
       "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+      "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
     },
     "node_modules/es-abstract": {
       "version": "1.24.2",
@@ -5130,6 +5527,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5481,6 +5891,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
@@ -5695,6 +6112,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "30.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-30.0.1.tgz",
+      "integrity": "sha512-52v7mUVUfNQVYYqE1lcdaymWL0njO7lTLUog6ZvW2U5KsbiLk/GnZlVJ+qx0xfNJZ6Gn+KSpPNE52vurbxZwrA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^6.0.5",
+        "@asamuzakjp/dom-selector": "^8.3.0",
+        "@bramus/specificity": "^2.4.2",
+        "@csstools/css-syntax-patches-for-csstree": "^1.1.7",
+        "@exodus/bytes": "^1.15.1",
+        "css-tree": "^3.2.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.5.2",
+        "parse5": "^8.0.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.2",
+        "undici": "^8.9.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^17.1.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.2.3"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/json-buffer": {
@@ -6119,6 +6577,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "11.5.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.2.tgz",
+      "integrity": "sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/lucide-react": {
       "version": "0.453.0",
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.453.0.tgz",
@@ -6126,6 +6594,16 @@
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -6147,6 +6625,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -6601,6 +7086,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+      "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^8.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -6866,6 +7364,41 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -7077,6 +7610,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.12",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
@@ -7257,6 +7800,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -7747,6 +8303,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tailwind-merge": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.1.tgz",
@@ -7916,6 +8479,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.4.11.tgz",
+      "integrity": "sha512-aBiNayCfTQxuIJBm06M+xR14cYaYlDlSXZbgsnKzKNxDKUVq7KFwTjwBSsb7m9Y5xO8WfPnBc63WaYFMTGlvqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.4.11"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.4.11",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.4.11.tgz",
+      "integrity": "sha512-CW3WN2rIIE/Of21mulhgnGOwoDyEFNygyIBOONSdyAuSATgMMUCpLeUlB+E8sAwA5xRV9hYPl+kyZ9citHCaKg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -7927,6 +8510,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.2.tgz",
+      "integrity": "sha512-exgYmnmL/sJpR3upZfXG5PoatXQii55xAiXGXzY+sROLZ/Y+SLcp9PgJNI9Vz37HpQ74WvDcLT8eqm+kV3FzrA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -8103,6 +8712,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/undici": {
+      "version": "8.10.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.10.1.tgz",
+      "integrity": "sha512-YQ3WlbqjYMmNpdvDH64jAgLjxuAR9+649calDWhbshYaeQGO2bR4nI94ORJmwI3J9YhoKQnpyGOK+0zlWS5N5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "node_modules/undici-types": {
@@ -8435,6 +9054,54 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-17.1.0.tgz",
+      "integrity": "sha512-3GeworPmc2ZfEEHP7lEbUfBX/L75wdEsi0rLNhXcXxnoN5jyq0SL5gCy06SGW2cyTIZdTvWIDQNQoza++vKeaw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.15.1",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^22.14.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -8573,6 +9240,23 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,8 @@
     "postcss": "^8.5.10"
   },
   "devDependencies": {
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.3",
     "@types/node": "^20.16.11",
     "@types/react": "^18.3.11",
     "@types/react-dom": "^18.3.0",
@@ -39,6 +41,7 @@
     "autoprefixer": "^10.4.20",
     "eslint": "^8.57.1",
     "eslint-config-next": "^15.5.23",
+    "jsdom": "^30.0.1",
     "postcss": "^8.5.10",
     "tailwindcss": "^3.4.13",
     "tailwindcss-animate": "^1.0.7",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,8 +2,10 @@ import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
   test: {
-    // Modules under test are React-free and Three.js-free pure logic, so the
-    // fast Node environment is sufficient — no jsdom needed.
+    // Most modules under test are React-free and Three.js-free pure logic, so
+    // the fast Node environment is the default. The few React-facing suites
+    // (e.g. use-layout-store.react.test.ts) opt into jsdom per-file via a
+    // `// @vitest-environment jsdom` comment.
     environment: 'node',
     globals: false,
     include: ['components/**/*.test.ts'],


### PR DESCRIPTION
## Summary

Fixes two issues on one branch: the destructive "Surprise me" behavior (#105) and the small logic roundup (#107).

### #105 — "Surprise me" silently wipes a furnished floor
- Both call sites (`panels/bottom-hud.tsx` and `panels/actions-panel.tsx`) now ask `Replace everything on this floor with a surprise layout?` when the active floor has items, and bail if declined.
- An empty floor proceeds without a prompt. No new UI components — same `window.confirm` style as the library overwrite/delete confirms.

### #107 — logic roundup
1. **`duplicateFloor` id collisions** — the actions facade in `hooks/use-layout-store.ts` now passes a per-duplication `idSuffix` (from `randomSuffix()` in `lib/ids.ts`) in the action, and the reducer keys cloned item/wall ids on `stamp-suffix-idx`. The reducer stays pure (all randomness arrives via the action). Reducer tests updated, plus a new test asserting two same-millisecond duplications can't collide.
2. **Set/Surprise placement inset** — the clamp inset from the exterior half-width is bumped from 0.1 m to 0.35 m (wall thickness + margin) in `lib/furniture-sets.ts` (`fitScale`, `setFitsRoom`) and `lib/surprise.ts` (`randomPosition`), so generated pieces no longer sit under/inside exterior walls.
3. **Library slug collisions** — `slugify` in `lib/library.ts` appends a deterministic 6-char base36 hash of the full sanitized name when truncating past 40 chars, so distinct long names get distinct save slots. Short names keep their historical slugs (no migration needed). New `lib/library.test.ts` covers both cases.
4. **Store React-layer tests** — new `hooks/use-layout-store.react.test.ts` using `renderHook` from `@testing-library/react` with a per-file `// @vitest-environment jsdom` override: (a) `useActiveFloor()` returns a referentially stable floor across an unrelated `setName` dispatch (Zustand v5 snapshot requirement); (b) a `layout.name` subscriber re-renders on `setName` but not on `moveItem`. Adds `@testing-library/react`, `@testing-library/dom`, and `jsdom` as devDependencies (lockfile updated).
5. **Chunk watchdog tuning** — `app/layout.tsx` watchdog bumped from 12 s to 20 s to reduce spurious reloads on slow connections; the sessionStorage guard keeps it one-shot.

## Testing

- `npm run test` — 11 files, 175 tests passed (167 existing + 8 new)
- `npm run typecheck` — clean
- `eslint --max-warnings=0` — clean
- `npm run build` — succeeds

Fixes #105
Fixes #107