### PR TITLE
Fix the two round-5 highs: save-wiping room dimensions (#113) and walkthrough camera fight (#114)

### DIFF
--- a/components/room-organizer/hooks/layout-reducer.test.ts
+++ b/components/room-organizer/hooks/layout-reducer.test.ts
@@ -25,6 +25,19 @@ describe('layoutReducer — building properties', () => {
     expect(state.layout.width).toBe(12);
     expect(state.layout.height).toBe(14);
   });
+
+  it('setWidth / setHeight clamp out-of-range values so the save stays schema-valid (#113)', () => {
+    let state = stateWith([]);
+    state = layoutReducer(state, { type: 'setWidth', width: MAX_ROOM_DIMENSION + 100 });
+    expect(state.layout.width).toBe(MAX_ROOM_DIMENSION);
+    state = layoutReducer(state, { type: 'setWidth', width: -3 });
+    expect(state.layout.width).toBeGreaterThan(0);
+    state = layoutReducer(state, { type: 'setHeight', height: Number.POSITIVE_INFINITY });
+    expect(state.layout.height).toBeLessThanOrEqual(MAX_ROOM_DIMENSION);
+    state = layoutReducer(state, { type: 'setHeight', height: Number.NaN });
+    expect(Number.isFinite(state.layout.height)).toBe(true);
+    expect(state.layout.height).toBeGreaterThan(0);
+  });
 });
 
 describe('layoutReducer — item CRUD', () => {

--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -101,10 +101,14 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
     // -- building-level properties ------------------------------------------
     case 'setName':
       return withLayout(state, (layout) => ({ ...layout, name: action.name }));
+    // Width/height must be clamped here, not only in normaliseLayout: an
+    // out-of-range dimension that reaches localStorage fails schema validation
+    // on the next load, and the fallback layout then autosaves over the
+    // user's house (#113).
     case 'setWidth':
-      return withLayout(state, (layout) => ({ ...layout, width: action.width }));
+      return withLayout(state, (layout) => ({ ...layout, width: clampRoomDimension(action.width) }));
     case 'setHeight':
-      return withLayout(state, (layout) => ({ ...layout, height: action.height }));
+      return withLayout(state, (layout) => ({ ...layout, height: clampRoomDimension(action.height) }));
 
     // -- floor-scoped finishes ----------------------------------------------
     case 'setFloorColor':

--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react';
 import { AUTOSAVE_DEBOUNCE_MS } from '../lib/constants';
-import { loadLayout, saveLayout } from '../lib/persistence';
+import { backupUnreadableLayout, loadLayout, saveLayout } from '../lib/persistence';
 import { decodeShareUrl, isShareHash } from '../lib/share';
 import type { RoomLayout } from '../lib/types';
 
@@ -88,6 +88,11 @@ export function useLayoutPersistence({
         console.warn('Failed to apply saved layout:', error);
         hydrationBaseRef.current = null;
       }
+    } else {
+      // A blob that exists but failed to load would otherwise be overwritten
+      // by the autosave of the fallback layout ~debounceMs after mount —
+      // permanent data loss. Stash a copy first (#113).
+      backupUnreadableLayout();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- one-shot hydration; `layout` is only read as the pre-hydration baseline
   }, [onHydrate]);

--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -238,7 +238,12 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
         // OrbitControls.update() returns true while the camera is moving
         // (including damping glide). Skip rendering entirely when nothing
         // changed — an editor sits idle most of the time.
-        const controlsMoved = controls.update();
+        // During walkthrough the camera belongs to PointerLockControls;
+        // OrbitControls.update() has no `enabled` guard (three r0.169) and
+        // would re-aim the camera at the stale orbit target and clamp it back
+        // into the polar cone before every render (#114). Walkthrough marks
+        // frames dirty itself, so skipping update() here loses nothing.
+        const controlsMoved = handlersRef.current.walkthroughActive ? false : controls.update();
         if (contextLost) return;
         if (!controlsMoved && !dirtyRef.current) return;
         dirtyRef.current = false;

--- a/components/room-organizer/hooks/use-walkthrough.ts
+++ b/components/room-organizer/hooks/use-walkthrough.ts
@@ -161,10 +161,19 @@ export function useWalkthrough(options: UseWalkthroughOptions): void {
       const requestLock = () => controls?.lock();
       canvas.addEventListener('click', requestLock);
       cleanup.push(() => canvas.removeEventListener('click', requestLock));
+      // Release pointer lock BEFORE disconnecting: an exit path that tears the
+      // mode down while still locked would otherwise leave the cursor captured
+      // with no mousemove handler attached (#114). No-op when already unlocked.
+      cleanup.push(() => controls?.unlock());
       cleanup.push(() => controls?.disconnect());
       cleanup.push(() => {
         if (savedCameraPosition) camera.position.copy(savedCameraPosition);
+        invalidateRef.current?.();
       });
+      // Paint the eye-level starting pose. The main RAF tick no longer calls
+      // OrbitControls.update() in this mode (#114), so nothing else marks the
+      // first walkthrough frame dirty.
+      invalidateRef.current?.();
 
       const forward = new THREE.Vector3();
       const right = new THREE.Vector3();

--- a/components/room-organizer/lib/persistence.test.ts
+++ b/components/room-organizer/lib/persistence.test.ts
@@ -1,0 +1,38 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+import { makeLayout } from './__testfixtures__/fixtures';
+import { MAX_ROOM_DIMENSION, STORAGE_KEY } from './constants';
+import { RECOVERY_STORAGE_KEY, backupUnreadableLayout, loadLayout, saveLayout } from './persistence';
+
+describe('persistence — unreadable-save recovery (#113)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('round-trips a valid layout without touching the recovery key', () => {
+    const layout = makeLayout({ name: 'Round trip' });
+    expect(saveLayout(layout)).toBe(true);
+    expect(loadLayout()).toEqual(layout);
+    expect(window.localStorage.getItem(RECOVERY_STORAGE_KEY)).toBeNull();
+  });
+
+  it('stashes a schema-invalid blob under the recovery key', () => {
+    const corrupt = JSON.stringify(makeLayout({ width: MAX_ROOM_DIMENSION + 100 }));
+    window.localStorage.setItem(STORAGE_KEY, corrupt);
+    expect(loadLayout()).toBeNull();
+    backupUnreadableLayout();
+    expect(window.localStorage.getItem(RECOVERY_STORAGE_KEY)).toBe(corrupt);
+  });
+
+  it('stashes a non-JSON blob under the recovery key', () => {
+    window.localStorage.setItem(STORAGE_KEY, '{not json');
+    expect(loadLayout()).toBeNull();
+    backupUnreadableLayout();
+    expect(window.localStorage.getItem(RECOVERY_STORAGE_KEY)).toBe('{not json');
+  });
+
+  it('does nothing when no blob is stored', () => {
+    backupUnreadableLayout();
+    expect(window.localStorage.getItem(RECOVERY_STORAGE_KEY)).toBeNull();
+  });
+});

--- a/components/room-organizer/lib/persistence.ts
+++ b/components/room-organizer/lib/persistence.ts
@@ -15,6 +15,30 @@ export function loadLayout(): RoomLayout | null {
   }
 }
 
+/**
+ * Where a stored blob that exists but can no longer be read (JSON or schema
+ * failure) is stashed before the autosave loop can overwrite it with the
+ * fallback layout — the user's house survives for manual recovery (#113).
+ */
+export const RECOVERY_STORAGE_KEY = `${STORAGE_KEY}-recovery`;
+
+/**
+ * Call only after loadLayout() returned null: if a raw blob exists at all, it
+ * is unreadable — copy it aside before it gets clobbered. Best-effort; a
+ * quota failure here must not break the mount.
+ */
+export function backupUnreadableLayout(): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    window.localStorage.setItem(RECOVERY_STORAGE_KEY, raw);
+    console.warn(`Saved layout is unreadable; a copy was kept under "${RECOVERY_STORAGE_KEY}".`);
+  } catch (error) {
+    console.warn('Failed to back up unreadable layout:', error);
+  }
+}
+
 /** Returns true when the layout was persisted, false on any storage failure. */
 export function saveLayout(layout: RoomLayout): boolean {
   if (typeof window === 'undefined') return false;


### PR DESCRIPTION
## #113 — out-of-range room dimensions could permanently wipe the saved house

- `setWidth`/`setHeight` now clamp through `clampRoomDimension` in the reducer, so a bad value can never reach localStorage.
- New `backupUnreadableLayout()` in `lib/persistence.ts`: when a stored blob exists but fails to load (JSON or schema), the hydration path copies it to `standalone-room-organizer-layout-recovery` before the autosave of the fallback layout can overwrite it — containing any future validation mismatch instead of amplifying it into data loss.
- Tests: reducer clamp cases (over-max / negative / Infinity / NaN) and a new `lib/persistence.test.ts` (round-trip, schema-invalid blob, non-JSON blob, empty storage).
- Runtime-verified with Playwright: seeded a `width: 200` layout, loaded the app, waited past the autosave debounce — the corrupt blob survives byte-for-byte under the recovery key; the main key holds a schema-valid fallback.

Fixes #113

## #114 — OrbitControls.update() fought the walkthrough camera every frame

- The RAF tick skips `controls.update()` while `walkthroughActive` (read from the existing `handlersRef`) — in three r0.169 `update()` has no `enabled` guard and was re-aiming/polar-clamping the camera between PointerLockControls updates.
- The walkthrough hook now invalidates the initial eye-level pose and the camera restore on exit (the tick no longer paints for it), and cleanup calls `controls.unlock()` before `disconnect()` so no exit path strands a captured cursor.
- Trace-verified only: headless Chromium can't hold pointer lock, so a quick manual walkthrough check is worthwhile before release.

Fixes #114

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` all pass — 186 tests (181 + 5 new).