### PR TITLE
Fix cutout-wall/floor texture tiling (#125) and upper-floor focus framing (#126)

### DIFF
--- a/components/room-organizer/hooks/use-camera-presets.ts
+++ b/components/room-organizer/hooks/use-camera-presets.ts
@@ -27,7 +27,7 @@ export interface UseCameraPresetsOptions {
 
 export function useCameraPresets({ cameraRef, controlsRef, roomSize, buildingHeight = 3, invalidate }: UseCameraPresetsOptions): {
   applyPreset(preset: CameraPreset): void;
-  focusOn(target: { x: number; z: number }, distance?: number): void;
+  focusOn(target: { x: number; z: number }, distance?: number, floorY?: number): void;
   fitToRoom(): void;
 } {
   const applyPreset = useCallback(
@@ -50,16 +50,19 @@ export function useCameraPresets({ cameraRef, controlsRef, roomSize, buildingHei
   );
 
   const focusOn = useCallback(
-    (target: { x: number; z: number }, distance = 3) => {
+    // `floorY` lifts both the camera and the orbit target onto the item's
+    // floor plane — without it, focusing an upper-floor item dives the camera
+    // into the storey below and frames empty floor (#126).
+    (target: { x: number; z: number }, distance = 3, floorY = 0) => {
       const camera = cameraRef.current;
       const controls = controlsRef.current;
       if (!camera) return;
 
-      camera.position.set(target.x + distance * 0.6, distance * 0.8, target.z + distance * 0.6);
-      camera.lookAt(target.x, 0, target.z);
+      camera.position.set(target.x + distance * 0.6, floorY + distance * 0.8, target.z + distance * 0.6);
+      camera.lookAt(target.x, floorY, target.z);
 
       if (controls) {
-        controls.target.set(target.x, 0, target.z);
+        controls.target.set(target.x, floorY, target.z);
         controls.update();
       }
       invalidate?.();

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -631,7 +631,7 @@ export function RoomOrganizer(): JSX.Element {
         setExtraSelectedIds(new Set());
       },
       focusOnSelection: () => {
-        if (selectedItem?.position) focusOn(selectedItem.position);
+        if (selectedItem?.position) focusOn(selectedItem.position, undefined, activeFloorY);
       },
       advanceTime: (deltaHours: number) => {
         setView((v) => ({ ...v, timeOfDay: (((v.timeOfDay + deltaHours) % 24) + 24) % 24 }));
@@ -660,6 +660,7 @@ export function RoomOrganizer(): JSX.Element {
       actions,
       activeFloor.items,
       activeFloorIndex,
+      activeFloorY,
       layout.floors.length,
       toggle,
       history.undo,

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -509,6 +509,26 @@ function addBaseboard(
   scene.add(base);
 }
 
+/**
+ * ShapeGeometry emits UVs equal to the raw shape vertex coordinates, while the
+ * pattern materials calibrate `texture.repeat` for PlaneGeometry's [0,1] UV
+ * span — feeding one into the other multiplies the tiling by the shape's size
+ * (#125). Rescale an origin-centred span×span shape to the plane convention so
+ * both geometry types tile identically.
+ */
+function normalizeShapeUvs(
+  geometry: ThreeNS.BufferGeometry,
+  spanX: number,
+  spanY: number
+): ThreeNS.BufferGeometry {
+  const uv = geometry.getAttribute('uv');
+  for (let i = 0; i < uv.count; i++) {
+    uv.setXY(i, uv.getX(i) / spanX + 0.5, uv.getY(i) / spanY + 0.5);
+  }
+  uv.needsUpdate = true;
+  return geometry;
+}
+
 function buildWallGeometryWithCutouts(
   THREE: ThreeModule,
   wallWidth: number,
@@ -547,8 +567,7 @@ function buildWallGeometryWithCutouts(
     shape.holes.push(hole);
   }
 
-  const geometry = new THREE.ShapeGeometry(shape);
-  return geometry;
+  return normalizeShapeUvs(new THREE.ShapeGeometry(shape), wallWidth, wallHeight);
 }
 
 /**
@@ -640,7 +659,7 @@ function buildFloorGeometryWithOpenings(
     shape.holes.push(hole);
   }
 
-  return new THREE.ShapeGeometry(shape);
+  return normalizeShapeUvs(new THREE.ShapeGeometry(shape), roomWidth, roomDepth);
 }
 
 /**


### PR DESCRIPTION
## #125 — patterned walls/floors with cutouts tiled ~size× too dense

`ShapeGeometry` emits UVs equal to the raw shape vertex coordinates, while `buildWallMaterial`/floor pattern materials calibrate `texture.repeat` for PlaneGeometry's [0,1] UV span. Any door/window on a patterned wall (or stairwell opening in a patterned floor) multiplied the tiling by the surface's size. New `normalizeShapeUvs` helper rescales the UV attribute to the plane convention in both cutout geometry builders.

Verified with Playwright screenshots (brick pattern, 10×8 room, one door): before, the door wall renders as fine stripe-mush; after, its brick coursing matches the neighbouring walls.

Fixes #125

## #126 — focus-on-selection framed the wrong floor

`focusOn` hardcoded its target at `y=0`, so focusing an upper-floor item dove the camera into the storey below. It now takes a `floorY` parameter lifting both the camera and orbit target onto the item's floor plane; `focusOnSelection` passes `activeFloorY` (added to the handler memo's deps to keep exhaustive-deps clean).

Fixes #126

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` (181 tests) all pass.