### PR TITLE
Refuse self-colliding scaled sets (#127); auto-organize keeps unpackable items in place (#128)

### DIFF
--- a/components/room-organizer/lib/furniture-sets.test.ts
+++ b/components/room-organizer/lib/furniture-sets.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { FURNITURE_SETS, buildFurnitureSet, setFitsRoom } from './furniture-sets';
+import { itemsOverlap } from './geometry';
+
+const setByKey = (key: string) => FURNITURE_SETS.find((s) => s.key === key)!;
+
+/** Overlapping pairs the authored (unscaled) layout does not contain. */
+function scalingIntroducedOverlaps(items: ReturnType<typeof buildFurnitureSet>, authored: ReturnType<typeof buildFurnitureSet>) {
+  const pairs: Array<[string, string]> = [];
+  for (let i = 0; i < items.length; i++) {
+    for (let j = i + 1; j < items.length; j++) {
+      if (itemsOverlap(items[i]!, items[j]!) && !itemsOverlap(authored[i]!, authored[j]!)) {
+        pairs.push([items[i]!.id, items[j]!.id]);
+      }
+    }
+  }
+  return pairs;
+}
+
+describe('buildFurnitureSet — scaled sets must not self-collide (#127)', () => {
+  it('places the dining set unscaled in a large room with no new overlaps', () => {
+    const set = setByKey('dining');
+    const items = buildFurnitureSet(set, { idPrefix: 'd', roomWidth: 8, roomDepth: 8 });
+    expect(items).toHaveLength(set.items.length);
+    const authored = buildFurnitureSet(set, { idPrefix: 'd' });
+    expect(scalingIntroducedOverlaps(items, authored)).toEqual([]);
+  });
+
+  it('refuses the dining set in a 3×3 room instead of embedding the chairs in the table', () => {
+    expect(buildFurnitureSet(setByKey('dining'), { idPrefix: 'd', roomWidth: 3, roomDepth: 3 })).toEqual([]);
+  });
+
+  it('refuses the bedroom set in a room narrow enough to embed the nightstands in the bed', () => {
+    expect(buildFurnitureSet(setByKey('bedroom'), { idPrefix: 'b', roomWidth: 3.2, roomDepth: 4 })).toEqual([]);
+  });
+
+  it('keeps the office set placeable despite its authored on-desk overlaps', () => {
+    // The computer and lamp sit ON the desk by design; those overlaps must
+    // never trigger the refusal, even when the set is scaled down a little.
+    const items = buildFurnitureSet(setByKey('home-office'), { idPrefix: 'o', roomWidth: 4, roomDepth: 4 });
+    expect(items.length).toBeGreaterThan(0);
+  });
+
+  it('every shipped set either fits or is refused — no set ever returns a self-colliding layout', () => {
+    for (const set of FURNITURE_SETS) {
+      for (const size of [2.5, 3, 3.5, 4, 5, 8]) {
+        if (!setFitsRoom(set, size, size)) continue;
+        const items = buildFurnitureSet(set, { idPrefix: set.key, roomWidth: size, roomDepth: size });
+        if (items.length === 0) continue; // refused: acceptable
+        const authored = buildFurnitureSet(set, { idPrefix: set.key });
+        expect(scalingIntroducedOverlaps(items, authored)).toEqual([]);
+      }
+    }
+  });
+});

--- a/components/room-organizer/lib/furniture-sets.ts
+++ b/components/room-organizer/lib/furniture-sets.ts
@@ -1,4 +1,5 @@
 import { FURNITURE_CATALOG } from './constants';
+import { itemsOverlap } from './geometry';
 import { randomSuffix } from './ids';
 import type { CatalogItem, FurnitureItem, Vec2 } from './types';
 
@@ -166,10 +167,31 @@ export function buildFurnitureSet(set: FurnitureSet, options: BuildSetOptions = 
 
   const scale = roomWidth != null && roomDepth != null ? fitScale(specs, roomWidth, roomDepth) : 1;
 
-  return specs.map(({ spec, catalog }, index) => ({
-    ...catalog,
-    id: `${idPrefix}-${index}`,
-    position: { x: center.x + spec.offset.x * scale, z: center.z + spec.offset.z * scale },
-    rotation: spec.rotation ?? 0,
-  }));
+  const place = (s: number): FurnitureItem[] =>
+    specs.map(({ spec, catalog }, index) => ({
+      ...catalog,
+      id: `${idPrefix}-${index}`,
+      position: { x: center.x + spec.offset.x * s, z: center.z + spec.offset.z * s },
+      rotation: spec.rotation ?? 0,
+    }));
+
+  const items = place(scale);
+
+  // fitScale shrinks the offsets but not the item sizes, so a tight room can
+  // slide pieces into each other. Some overlaps are authored (the office
+  // computer and lamp sit ON the desk), so only an overlap that does NOT
+  // exist in the unscaled layout means the room is too narrow — refuse the
+  // set rather than stamp furniture embedded in furniture (#127).
+  if (scale < 1) {
+    const authored = place(1);
+    for (let i = 0; i < items.length; i++) {
+      for (let j = i + 1; j < items.length; j++) {
+        if (itemsOverlap(items[i]!, items[j]!) && !itemsOverlap(authored[i]!, authored[j]!)) {
+          return [];
+        }
+      }
+    }
+  }
+
+  return items;
 }

--- a/components/room-organizer/lib/geometry.test.ts
+++ b/components/room-organizer/lib/geometry.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import { makeItem } from './__testfixtures__/fixtures';
 import {
+  autoOrganize,
   boundingRadius,
   hasCollisions,
   itemInBounds,
@@ -149,5 +150,38 @@ describe('hasCollisions', () => {
 
   it('returns false for a positionless item', () => {
     expect(hasCollisions(makeItem({ position: undefined }), [], W, D)).toBe(false);
+  });
+});
+
+describe('autoOrganize — overflow handling (#128)', () => {
+  const items = (count: number) =>
+    Array.from({ length: count }, (_, i) =>
+      makeItem({ id: `i${i}`, width: 1, depth: 1, position: { x: 3 + i, z: 2 }, rotation: 1.1 })
+    );
+
+  it('packs what fits and leaves overflow items at their original position and rotation', () => {
+    // 3×3 room, margin 0.3: each row holds 2 items across 2 rows → 4 fit, 2 overflow.
+    const result = autoOrganize(items(6), 3, 3);
+    const placed = result.slice(0, 4);
+    const overflow = result.slice(4);
+    for (const item of placed) expect(item.rotation).toBe(0);
+    expect(overflow.map((i) => i.position)).toEqual([
+      { x: 3 + 4, z: 2 },
+      { x: 3 + 5, z: 2 },
+    ]);
+    for (const item of overflow) expect(item.rotation).toBe(1.1);
+  });
+
+  it('never stacks two overflow items on the same spot', () => {
+    const result = autoOrganize(items(8), 3, 3);
+    const keys = result.map((i) => `${i.position!.x},${i.position!.z}`);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  it('leaves an item wider than the room at its original position instead of protruding', () => {
+    const wide = makeItem({ id: 'sofa', width: 2.0, depth: 0.9, position: { x: 0.1, z: 0.2 }, rotation: 0.5 });
+    const result = autoOrganize([wide], 2.2, 4);
+    expect(result[0]!.position).toEqual({ x: 0.1, z: 0.2 });
+    expect(result[0]!.rotation).toBe(0.5);
   });
 });

--- a/components/room-organizer/lib/geometry.ts
+++ b/components/room-organizer/lib/geometry.ts
@@ -161,17 +161,24 @@ export function autoOrganize(
       rowMaxDepth = 0;
     }
 
-    const fits = cursorZ + item.depth + margin <= roomDepth / 2;
+    // An item the grid can't hold — wider than the room even on a fresh row,
+    // or the rows have consumed the remaining depth — keeps its original spot
+    // and rotation: packing what fits beats stacking every leftover in an
+    // overlapping pile at the origin (#128).
+    const fitsWidth = cursorX + item.width + margin <= roomWidth / 2;
+    const fitsDepth = cursorZ + item.depth + margin <= roomDepth / 2;
+    if (!fitsWidth || !fitsDepth) {
+      organized.push(item);
+      continue;
+    }
+
     organized.push({
       ...item,
-      position: fits ? { x: cursorX + item.width / 2, z: cursorZ + item.depth / 2 } : { x: 0, z: 0 },
+      position: { x: cursorX + item.width / 2, z: cursorZ + item.depth / 2 },
       rotation: 0,
     });
-
-    if (fits) {
-      cursorX += item.width + margin;
-      rowMaxDepth = Math.max(rowMaxDepth, item.depth);
-    }
+    cursorX += item.width + margin;
+    rowMaxDepth = Math.max(rowMaxDepth, item.depth);
   }
 
   return organized;


### PR DESCRIPTION
## #127 — furniture sets self-collided in narrow rooms

`fitScale` shrinks a set's offsets but not its item sizes, so tight rooms slid pieces into the centerpiece (dining set in 3×3 m: all four chairs inside the table; bedroom set under ~3.7 m: nightstands inside the bed — and Surprise-me stamps the same broken layouts). The issue's fix sketch ("refuse on any pairwise overlap") turned out to be too blunt: the Office Set *authors* overlaps deliberately (computer and lamp on the desk). `buildFurnitureSet` now compares the scaled placement against the unscaled layout and refuses only overlaps **introduced by scaling**. Surprise-me already degrades gracefully to decor-only on refusal.

New `furniture-sets.test.ts`: dining refused at 3×3, bedroom refused at 3.2 m, office placeable despite authored overlaps, plus a sweep of every shipped set at six room sizes asserting no set ever returns a self-colliding layout.

Fixes #127

## #128 — auto-organize stacked overflow at the origin

Items the packing grid couldn't hold were all dropped at (0,0) with rotation wiped, forming one overlapping tower; and after a row wrap the width was never re-checked, so an item wider than the room protruded through the wall. Both cases now keep the item at its original position and rotation — auto-organize packs what fits.

New tests: 4-of-6 packed in a 3×3 with the overflow untouched, no two items ever share a spot, and a 2 m sofa in a 2.2 m room stays put.

Fixes #128

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` all pass — 194 tests (186 + 8 new).