### PR TITLE
Enforce item locks everywhere (#115); settle wall-mounted items on every movement path (#116)

### DIFF
--- a/components/room-organizer/hooks/layout-reducer.test.ts
+++ b/components/room-organizer/hooks/layout-reducer.test.ts
@@ -90,6 +90,31 @@ describe('layoutReducer — item CRUD', () => {
     expect(items[1]).toMatchObject({ id: 'a-copy', position: { x: 1.5, z: 2.5 } });
   });
 
+  it('duplicateItem clamps the copy inside the room footprint (#116)', () => {
+    const state = layoutReducer(stateWith([makeItem({ id: 'a', position: { x: 3.4, z: 3.4 } })]), {
+      type: 'duplicateItem',
+      sourceId: 'a',
+      newId: 'a-copy',
+    });
+    // 8×8 room, 1×1 item: centre can reach at most ±3.5.
+    expect(activeItems(state)[1]!.position).toEqual({ x: 3.5, z: 3.5 });
+  });
+
+  it('duplicateItem re-snaps a door onto its wall instead of stranding it mid-room (#116)', () => {
+    const door = makeItem({ id: 'd', type: 'door', width: 0.9, depth: 0.12, position: { x: 0, z: -4 }, rotation: 0 });
+    const state = layoutReducer(stateWith([door]), { type: 'duplicateItem', sourceId: 'd', newId: 'd-copy' });
+    const copy = activeItems(state)[1]!;
+    // The +0.5 offset slides the copy along the north wall, not into the room.
+    expect(copy.position).toEqual({ x: 0.5, z: -4 });
+    expect(copy.rotation).toBe(0);
+  });
+
+  it('duplicateItem keeps the raw offset for outdoor items (they belong outside)', () => {
+    const tree = makeItem({ id: 't', type: 'tree', category: 'outdoor', position: { x: 7, z: 0 } });
+    const state = layoutReducer(stateWith([tree]), { type: 'duplicateItem', sourceId: 't', newId: 't-copy' });
+    expect(activeItems(state)[1]!.position).toEqual({ x: 7.5, z: 0.5 });
+  });
+
   it('duplicateItem is a no-op when the source is missing', () => {
     const before = stateWith([makeItem({ id: 'a' })]);
     const after = layoutReducer(before, { type: 'duplicateItem', sourceId: 'zzz', newId: 'x' });
@@ -177,6 +202,25 @@ describe('layoutReducer — bulk item operations', () => {
     expect(activeItems(state).every((i) => i.locked === true)).toBe(true);
     state = layoutReducer(state, { type: 'setLockAll', locked: false });
     expect(activeItems(state).every((i) => i.locked === false)).toBe(true);
+  });
+
+  it('bulkSetPositions never moves locked items (#115)', () => {
+    const state = layoutReducer(
+      stateWith([
+        makeItem({ id: 'a', position: { x: 0, z: 0 } }),
+        makeItem({ id: 'b', position: { x: 1, z: 1 }, locked: true }),
+      ]),
+      {
+        type: 'bulkSetPositions',
+        positions: new Map([
+          ['a', { x: 5, z: 5 }],
+          ['b', { x: 5, z: 5 }],
+        ]),
+      }
+    );
+    const items = activeItems(state);
+    expect(items.find((i) => i.id === 'a')!.position).toEqual({ x: 5, z: 5 });
+    expect(items.find((i) => i.id === 'b')!.position).toEqual({ x: 1, z: 1 });
   });
 
   it('bulkSetPositions moves only listed items and leaves others untouched', () => {

--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -1,4 +1,6 @@
 import { MAX_FLOORS, MAX_ROOM_DIMENSION } from '../lib/constants';
+import { rotatedHalfExtents } from '../lib/geometry';
+import { settleWallMountedItem } from '../lib/opening-snap';
 import type {
   CatalogItem,
   FloorLayout,
@@ -185,11 +187,29 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
         const source = floor.items.find((item) => item.id === action.sourceId);
         if (!source) return floor;
         const position = source.position ?? { x: 0, z: 0 };
-        const copy: FurnitureItem = {
-          ...source,
-          id: action.newId,
-          position: { x: position.x + 0.5, z: position.z + 0.5 },
-        };
+        const offset = { x: position.x + 0.5, z: position.z + 0.5 };
+        // The raw +0.5/+0.5 offset stranded duplicated doors/windows/cameras
+        // off their wall and pushed copies near the +x/+z walls outside the
+        // room (#116): wall-mounted copies re-snap onto the wall (shifted
+        // along it) and indoor items clamp to the footprint. Outdoor items
+        // belong outside and keep the raw offset.
+        const settled = settleWallMountedItem(
+          source,
+          offset,
+          state.layout.width,
+          state.layout.height,
+          floor.interiorWalls ?? []
+        );
+        const copy: FurnitureItem = settled
+          ? { ...source, id: action.newId, ...settled }
+          : {
+              ...source,
+              id: action.newId,
+              position:
+                source.category === 'outdoor'
+                  ? offset
+                  : clampToFootprint(source, offset, state.layout.width, state.layout.height),
+            };
         return { ...floor, items: [...floor.items, copy] };
       });
 
@@ -237,6 +257,9 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
       return withActiveFloor(state, (floor) => ({
         ...floor,
         items: floor.items.map((item) => {
+          // Locked items are immune to bulk moves (group drag, align,
+          // distribute) — enforced here so no caller can shove them (#115).
+          if (item.locked) return item;
           const next = action.positions.get(item.id);
           return next ? { ...item, position: { x: next.x, z: next.z } } : item;
         }),
@@ -468,6 +491,22 @@ function patchItem(
 function clampRoomDimension(value: number): number {
   if (!Number.isFinite(value) || value <= 0) return 1;
   return Math.min(value, MAX_ROOM_DIMENSION);
+}
+
+/** Clamp a position so the item's rotated footprint stays inside the room. */
+function clampToFootprint(
+  item: Pick<FurnitureItem, 'width' | 'depth' | 'rotation'>,
+  position: { x: number; z: number },
+  roomWidth: number,
+  roomDepth: number
+): { x: number; z: number } {
+  const { halfW, halfD } = rotatedHalfExtents(item);
+  const maxX = Math.max(0, roomWidth / 2 - halfW);
+  const maxZ = Math.max(0, roomDepth / 2 - halfD);
+  return {
+    x: Math.min(maxX, Math.max(-maxX, position.x)),
+    z: Math.min(maxZ, Math.max(-maxZ, position.z)),
+  };
 }
 
 function normaliseLayout(layout: RoomLayout): RoomLayout {

--- a/components/room-organizer/hooks/use-item-drag.ts
+++ b/components/room-organizer/hooks/use-item-drag.ts
@@ -1,7 +1,6 @@
 import { useCallback, useRef, type MutableRefObject } from 'react';
-import { CAMERA_BRACKET_ARM } from '../lib/constants';
 import { hasCollisions } from '../lib/geometry';
-import { isOpening, reseatWallMountedItem, snapOpeningToWall, snapWallMountedItem } from '../lib/opening-snap';
+import { settleWallMountedItem } from '../lib/opening-snap';
 import type { LayoutActions } from './use-layout-state';
 import type { FloorLayout } from '../lib/types';
 import type * as ThreeNS from 'three';
@@ -111,7 +110,13 @@ export function useItemDrag({
       const origins = new Map<string, { x: number; z: number }>();
       for (const id of ids) {
         const item = activeFloor.items.find((entry) => entry.id === id);
-        if (item?.position) origins.set(id, { x: item.position.x, z: item.position.z });
+        if (!item?.position) continue;
+        // Locked co-selected items stay put during a group drag — only the
+        // session's members are translated and committed (#115). The primary
+        // is always unlocked: the canvas handler refuses to start a drag on a
+        // locked item.
+        if (item.locked && id !== primaryId) continue;
+        origins.set(id, { x: item.position.x, z: item.position.z });
       }
       dragSessionRef.current = { primaryId, origins, latest: new Map(origins) };
     },
@@ -176,64 +181,30 @@ export function useItemDrag({
         // Single dispatch for the whole gesture; the rebuild effect runs once.
         actions.bulkSetPositions(session.latest);
       }
-      if (!moved) return;
-      // Lock the item after a real drag so it can't be accidentally moved.
-      actions.setLocked(id, true);
-      // On release, click a security camera onto the nearest wall and turn it to
-      // face into the room. Doing this on drop (not per drag frame) keeps the
-      // drag itself smooth instead of flipping between walls. Note: read the
-      // position from the drag session — state is one dispatch behind here.
-      const item = activeFloor.items.find((entry) => entry.id === id);
-      const releasePos = finalPos ?? item?.position;
-      // Doors/windows: snapPosition force-snaps only the POSITION each drag
-      // frame, so an opening dragged from one wall to another keeps its stale
-      // rotation (slab perpendicular, sticking through the new wall — #62).
-      // Re-derive the wall-aligned rotation (and settle the snapped position)
-      // on drop, the same way the camera path does.
-      if (item && isOpening(item.type) && releasePos) {
-        const snapped = snapOpeningToWall({
-          position: releasePos,
-          itemWidth: item.width,
+      if (!moved || !session) return;
+      // Lock every dragged item after a real drag so it can't be accidentally
+      // moved — previously only the primary was locked, so co-dragged items
+      // stayed silently movable (#115).
+      for (const movedId of session.latest.keys()) actions.setLocked(movedId, true);
+      // On release, settle every wall-mounted item in the commit — doors and
+      // windows re-snap their position AND wall-aligned rotation (a drag to a
+      // different wall otherwise keeps the stale rotation, #62; a group drag
+      // otherwise strands them mid-room, #116), and cameras additionally
+      // record the wall's inward-normal yaw and re-seat for their mount
+      // style. Doing this on drop (not per drag frame) keeps the drag itself
+      // smooth instead of flipping between walls. Note: read positions from
+      // the drag session — state is one dispatch behind here.
+      for (const [movedId, releasePos] of session.latest) {
+        const item = activeFloor.items.find((entry) => entry.id === movedId);
+        if (!item) continue;
+        const settled = settleWallMountedItem(
+          item,
+          releasePos,
           roomWidth,
           roomDepth,
-          interiorWalls: activeFloor.interiorWalls ?? [],
-        });
-        actions.moveItem(id, snapped.position.x, snapped.position.z);
-        if (Math.abs((item.rotation ?? 0) - snapped.rotation) > 1e-3) {
-          actions.setRotation(id, snapped.rotation);
-        }
-        return;
-      }
-      if (item?.type === 'security-camera' && releasePos) {
-        const snapped = snapWallMountedItem({
-          position: releasePos,
-          itemWidth: item.width,
-          itemDepth: item.depth,
-          roomWidth,
-          roomDepth,
-          interiorWalls: activeFloor.interiorWalls ?? [],
-        });
-        // Record the wall's inward-normal yaw so rotation can be locked to the
-        // in/out axis, then re-seat for the camera's current mount style.
-        actions.updateItem(id, { wallRotation: snapped.rotation });
-        if (item.cameraBracket) {
-          const pos = reseatWallMountedItem({
-            position: releasePos,
-            itemWidth: item.width,
-            itemDepth: item.depth,
-            roomWidth,
-            roomDepth,
-            interiorWalls: activeFloor.interiorWalls ?? [],
-            rotation: item.rotation ?? snapped.rotation,
-            bracketArm: CAMERA_BRACKET_ARM,
-          });
-          actions.moveItem(id, pos.x, pos.z);
-        } else {
-          actions.moveItem(id, snapped.position.x, snapped.position.z);
-          if (Math.abs((item.rotation ?? 0) - snapped.rotation) > 1e-3) {
-            actions.setRotation(id, snapped.rotation);
-          }
-        }
+          activeFloor.interiorWalls ?? []
+        );
+        if (settled) actions.updateItem(movedId, settled);
       }
     },
     [activeFloor.items, activeFloor.interiorWalls, roomWidth, roomDepth, actions, findFurnitureGroup, setDragCollisionTint]

--- a/components/room-organizer/hooks/use-keyboard-shortcuts.ts
+++ b/components/room-organizer/hooks/use-keyboard-shortcuts.ts
@@ -103,8 +103,10 @@ export function useKeyboardShortcuts({
 
       if ((event.key === 'Delete' || event.key === 'Backspace') && selectedItem) {
         event.preventDefault();
-        // Locked items can't be deleted from the keyboard, matching 3D drag.
-        if (!selectedItem.locked) handlers.removeItem(selectedItem.id);
+        // Lock enforcement lives in the handler: it must see the whole
+        // selection, not just the primary — gating on the primary's lock here
+        // blocked deleting unlocked extras and let locked extras through (#115).
+        handlers.removeItem(selectedItem.id);
         return;
       }
 

--- a/components/room-organizer/lib/opening-snap.test.ts
+++ b/components/room-organizer/lib/opening-snap.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { settleWallMountedItem } from './opening-snap';
+
+// 8×8 room throughout: walls at x = ±4, z = ±4.
+const W = 8;
+const D = 8;
+
+describe('settleWallMountedItem (#116)', () => {
+  it('returns null for items that do not mount on walls', () => {
+    expect(settleWallMountedItem({ type: 'sofa', width: 2, depth: 0.9, rotation: 0 }, { x: 1, z: 1 }, W, D)).toBeNull();
+  });
+
+  it('snaps a door back onto the nearest wall and re-aligns its rotation', () => {
+    const settled = settleWallMountedItem(
+      { type: 'door', width: 0.9, depth: 0.12, rotation: Math.PI / 2 },
+      { x: 0.3, z: -3.2 },
+      W,
+      D
+    );
+    expect(settled).not.toBeNull();
+    // North wall (z = -4) is nearest; its aligned rotation is 0.
+    expect(settled!.position).toEqual({ x: 0.3, z: -4 });
+    expect(settled!.rotation).toBe(0);
+  });
+
+  it('omits the rotation patch when the opening is already wall-aligned', () => {
+    const settled = settleWallMountedItem(
+      { type: 'window', width: 1.2, depth: 0.12, rotation: 0 },
+      { x: -1, z: -3.5 },
+      W,
+      D
+    );
+    expect(settled!.position).toEqual({ x: -1, z: -4 });
+    expect(settled!.rotation).toBeUndefined();
+  });
+
+  it('seats a flush camera against the nearest wall and records the wall rotation', () => {
+    const settled = settleWallMountedItem(
+      { type: 'security-camera', width: 0.3, depth: 0.2, rotation: 0 },
+      { x: 3.5, z: 0.5 },
+      W,
+      D
+    );
+    // East wall (x = 4): inward normal rotation is -π/2; body inset by
+    // depth/2 + 0.02 so the back face rests on the wall.
+    expect(settled!.wallRotation).toBeCloseTo(-Math.PI / 2, 10);
+    expect(settled!.position.x).toBeCloseTo(4 - 0.12, 10);
+    expect(settled!.position.z).toBeCloseTo(0.5, 10);
+    expect(settled!.rotation).toBeCloseTo(-Math.PI / 2, 10);
+  });
+
+  it('clamps the settled opening within the wall ends', () => {
+    const settled = settleWallMountedItem(
+      { type: 'door', width: 0.9, depth: 0.12, rotation: 0 },
+      { x: 7.5, z: -3.9 },
+      W,
+      D
+    );
+    // x is clamped so the whole 0.9 m door stays on the 8 m wall.
+    expect(settled!.position.x).toBeCloseTo(4 - 0.45, 10);
+    expect(settled!.position.z).toBe(-4);
+  });
+});

--- a/components/room-organizer/lib/opening-snap.ts
+++ b/components/room-organizer/lib/opening-snap.ts
@@ -5,6 +5,7 @@
  * or interior wall on placement and on drag.
  */
 
+import { CAMERA_BRACKET_ARM } from './constants';
 import type { InteriorWall } from './types';
 
 export type WallKind = 'exterior' | 'interior';
@@ -238,4 +239,72 @@ export function reseatWallMountedItem(
     x: snap.position.x + inwardX * side * inset,
     z: snap.position.z + inwardZ * side * inset,
   };
+}
+
+export interface SettledPlacement {
+  position: { x: number; z: number };
+  /** Present only when the item's rotation must change to stay wall-aligned. */
+  rotation?: number;
+  /** Present for surface-mounted items (cameras): the wall's inward-normal yaw. */
+  wallRotation?: number;
+}
+
+/**
+ * Settle a wall-mounted item's committed position back onto its wall — the
+ * single re-snap rule shared by drag release, group-drag commits, keyboard
+ * nudges, and duplication, so no code path can strand an opening off its
+ * wall (#116). Returns null for items that don't mount on walls.
+ */
+export function settleWallMountedItem(
+  item: {
+    type: string;
+    width: number;
+    depth: number;
+    rotation?: number;
+    cameraBracket?: boolean;
+  },
+  position: { x: number; z: number },
+  roomWidth: number,
+  roomDepth: number,
+  interiorWalls: readonly InteriorWall[] = []
+): SettledPlacement | null {
+  if (isOpening(item.type)) {
+    const snapped = snapOpeningToWall({
+      position,
+      itemWidth: item.width,
+      roomWidth,
+      roomDepth,
+      interiorWalls,
+    });
+    const patch: SettledPlacement = { position: snapped.position };
+    if (Math.abs((item.rotation ?? 0) - snapped.rotation) > 1e-3) patch.rotation = snapped.rotation;
+    return patch;
+  }
+  if (item.type === 'security-camera') {
+    const snapped = snapWallMountedItem({
+      position,
+      itemWidth: item.width,
+      itemDepth: item.depth,
+      roomWidth,
+      roomDepth,
+      interiorWalls,
+    });
+    if (item.cameraBracket) {
+      const reseated = reseatWallMountedItem({
+        position,
+        itemWidth: item.width,
+        itemDepth: item.depth,
+        roomWidth,
+        roomDepth,
+        interiorWalls,
+        rotation: item.rotation ?? snapped.rotation,
+        bracketArm: CAMERA_BRACKET_ARM,
+      });
+      return { position: reseated, wallRotation: snapped.rotation };
+    }
+    const patch: SettledPlacement = { position: snapped.position, wallRotation: snapped.rotation };
+    if (Math.abs((item.rotation ?? 0) - snapped.rotation) > 1e-3) patch.rotation = snapped.rotation;
+    return patch;
+  }
+  return null;
 }

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -20,7 +20,7 @@ import { useThreeScene } from './hooks/use-three-scene';
 import { useWalkthrough } from './hooks/use-walkthrough';
 import { CAMERA_BRACKET_ARM, FURNITURE_CATALOG } from './lib/constants';
 import { hasCollisions } from './lib/geometry';
-import { reseatWallMountedItem } from './lib/opening-snap';
+import { reseatWallMountedItem, settleWallMountedItem } from './lib/opening-snap';
 import { playSound, type SoundCue } from './lib/sounds';
 import { FLOOR_HEIGHT_METERS } from './lib/types';
 import { snapWallEndpoint } from './lib/wall-snap';
@@ -336,13 +336,23 @@ export function RoomOrganizer(): JSX.Element {
     [activeFloor.items, activeFloor.interiorWalls, layout.width, layout.height, actions]
   );
 
+  // Locked items are immune to rotation — group rotates orbit items around
+  // the centroid, so rotating a set containing a locked item would move it
+  // (#115). The unlocked subset still rotates about its own centroid.
+  const unlockedSelectedIds = useCallback(() => {
+    const lockedIds = new Set(activeFloor.items.filter((item) => item.locked).map((item) => item.id));
+    return new Set(Array.from(allSelectedIds).filter((id) => !lockedIds.has(id)));
+  }, [activeFloor.items, allSelectedIds]);
+
   const rotateItemHandler = useCallback(
     (id: string) => {
       if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
-        actions.rotateSelection(allSelectedIds, Math.PI / 2);
+        const unlocked = unlockedSelectedIds();
+        if (unlocked.size > 0) actions.rotateSelection(unlocked, Math.PI / 2);
         return;
       }
       const item = activeFloor.items.find((entry) => entry.id === id);
+      if (item?.locked) return;
       if (item?.type === 'security-camera') {
         // A flush camera can only face into the room or straight out, so Rotate
         // flips 180° along its wall's in/out axis. A bracketed camera pans freely.
@@ -355,7 +365,7 @@ export function RoomOrganizer(): JSX.Element {
       const next = ((item?.rotation ?? 0) + Math.PI / 2) % (Math.PI * 2);
       actions.setRotation(id, next);
     },
-    [allSelectedIds, activeFloor.items, actions, reseatCamera]
+    [allSelectedIds, unlockedSelectedIds, activeFloor.items, actions, reseatCamera]
   );
 
   // Toggle a camera's stand-off bracket. Enabling it keeps the current facing
@@ -392,9 +402,11 @@ export function RoomOrganizer(): JSX.Element {
   );
 
   const removeSelected = useCallback(() => {
-    const ids = Array.from(allSelectedIds);
-    if (ids.length === 0) return;
-    const remaining = activeFloor.items.filter((item) => !allSelectedIds.has(item.id));
+    if (allSelectedIds.size === 0) return;
+    // Locked items survive a group delete — the same immunity the single-item
+    // Delete gate gives them (#115).
+    const remaining = activeFloor.items.filter((item) => !allSelectedIds.has(item.id) || item.locked);
+    if (remaining.length === activeFloor.items.length) return;
     actions.replaceItems(remaining);
     setSelectedItemId(null);
     setExtraSelectedIds(new Set());
@@ -596,26 +608,41 @@ export function RoomOrganizer(): JSX.Element {
   const shortcutHandlers = useMemo(
     () => ({
       removeItem: (id: string) => {
+        // A multi-select delete removes the unlocked members even when the
+        // primary is locked; a single locked item can't be deleted from the
+        // keyboard, matching 3D drag (#115).
         if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
           removeSelected();
-        } else {
-          removeItem(id);
+          return;
         }
+        const item = activeFloor.items.find((entry) => entry.id === id);
+        if (!item?.locked) removeItem(id);
       },
       duplicateItem: duplicateSelected,
       rotateItem: rotateItemHandler,
       rotateItemBy: (id: string, radians: number) => {
         if (allSelectedIds.size > 1 && allSelectedIds.has(id)) {
-          actions.rotateSelection(allSelectedIds, radians);
+          const unlocked = unlockedSelectedIds();
+          if (unlocked.size > 0) actions.rotateSelection(unlocked, radians);
           return;
         }
         const item = activeFloor.items.find((entry) => entry.id === id);
-        if (!item) return;
+        if (!item || item.locked) return;
         const next = ((item.rotation ?? 0) + radians) % (Math.PI * 2);
         actions.setRotation(id, next);
         reseatCamera(id, next);
       },
-      moveItem: actions.moveItem,
+      moveItem: (id: string, x: number, z: number) => {
+        // Arrow nudges settle wall-mounted items back onto their wall the way
+        // drag release does — a nudged door slides along its wall instead of
+        // translating into the room as a free slab (#116).
+        const item = activeFloor.items.find((entry) => entry.id === id);
+        const settled = item
+          ? settleWallMountedItem(item, { x, z }, layout.width, layout.height, activeFloor.interiorWalls ?? [])
+          : null;
+        if (settled) actions.updateItem(id, settled);
+        else actions.moveItem(id, x, z);
+      },
       toggle2D: () => toggle('view2D'),
       toggleMeasurements: () => toggle('showMeasurements'),
       toggleSnap: () => toggle('snapToGrid'),
@@ -659,9 +686,13 @@ export function RoomOrganizer(): JSX.Element {
       allSelectedIds,
       actions,
       activeFloor.items,
+      activeFloor.interiorWalls,
       activeFloorIndex,
       activeFloorY,
       layout.floors.length,
+      layout.width,
+      layout.height,
+      unlockedSelectedIds,
       toggle,
       history.undo,
       history.redo,


### PR DESCRIPTION
One commit covering both issues — they overlap in `use-item-drag.ts`, `layout-reducer.ts`, and `room-organizer.tsx`, so a per-issue split wasn't clean.

## #115 — lock enforcement

Semantics (as proposed in the issue): **locked = immune to move, rotate, and delete; duplicate stays allowed.**

- Multi-select Delete removes only unlocked members. The lock gate moved from the keyboard (which only saw the primary) into the handler, also fixing the inverse asymmetry where a locked primary blocked deleting unlocked extras.
- Group drag excludes locked items from the drag session (their meshes never move), and `bulkSetPositions` refuses to move locked items at the reducer level — which also protects them from align/distribute.
- R / Shift+R: a locked single item is a no-op; group rotates spin the **unlocked subset** about its own centroid (a centroid rotation would have moved the locked item).
- A real drag now locks **every** dragged item on release, not just the primary.

## #116 — wall-mount tear-off

The drag-release re-snap logic is now a shared pure helper, `settleWallMountedItem` (`lib/opening-snap.ts`): openings re-snap position + wall-aligned rotation; cameras record the wall's inward-normal yaw and re-seat for their bracket style. It runs on every path that can move a wall-mounted item:

- **Group-drag commit** settles all moved doors/windows/cameras (previously only the primary).
- **Arrow nudges** slide openings along their wall instead of translating them into the room as free slabs.
- **Ctrl+D**: wall-mounted copies re-snap onto the wall shifted along it; indoor copies clamp inside the room footprint (rotation-aware via `rotatedHalfExtents`); outdoor copies keep the raw offset since they belong outside.

## Tests

9 new — reducer coverage for the locked `bulkSetPositions` guard and the three duplicate behaviours, plus a new `opening-snap.test.ts` for the settle helper (door re-snap + rotation realign, no-op rotation patch, camera seating/inset, wall-end clamp), chipping away at the #123 opening-snap gap. `npm run typecheck`, `npm run lint`, `npm run test` all pass — 203 tests. Note: multi-select gestures can't be driven headless, so the group-drag path is covered at the unit/reducer level.

Fixes #115
Fixes #116