### PR TITLE
Fix scene-effect staleness (#119) and ghost multi-selects (#117)

### DIFF
--- a/components/room-organizer/contexts/selection-context.tsx
+++ b/components/room-organizer/contexts/selection-context.tsx
@@ -10,6 +10,14 @@ export interface SelectionContextValue {
   readonly extraSelectedIds: ReadonlySet<string>;
   readonly setExtraSelectedIds: Dispatch<SetStateAction<ReadonlySet<string>>>;
   readonly allSelectedIds: ReadonlySet<string>;
+  /**
+   * Make `id` the sole selection (null clears it). Panels must use this —
+   * not raw setSelectedItemId — when reacting to an add/load/click, or the
+   * previous multi-select's extras silently survive into the next group
+   * operation (#117). Raw setters remain for the orchestrator's own
+   * toggle/promote logic.
+   */
+  readonly selectOnly: (id: string | null) => void;
 }
 
 const SelectionContext = createContext<SelectionContextValue | null>(null);
@@ -36,6 +44,7 @@ export function SelectionProvider({ value, children }: SelectionProviderProps): 
     value.extraSelectedIds,
     value.setExtraSelectedIds,
     value.allSelectedIds,
+    value.selectOnly,
   ]);
   return <SelectionContext.Provider value={memoised}>{children}</SelectionContext.Provider>;
 }

--- a/components/room-organizer/hooks/use-npcs.ts
+++ b/components/room-organizer/hooks/use-npcs.ts
@@ -85,6 +85,11 @@ export function useNpcs(options: UseNpcsOptions): void {
         disposeObject(npc.group);
       }
       stateRef.current = [];
+      // Nothing else consumes showNpcs, so without an explicit repaint (and a
+      // shadow-map refresh — walkers cast) the removed NPCs stay painted in
+      // the last frame until something unrelated invalidates (#119).
+      requestShadowUpdate?.();
+      invalidate?.();
     };
   }, [enabled, count, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, roomWidth, roomDepth, floorY]);
 }

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -17,7 +17,7 @@ import { applyTimeOfDay } from '../three/lighting';
 import { clearMeasurement, renderMeasurement } from '../three/measurement';
 import { setOutdoorVisible } from '../three/outdoor';
 import { buildRoof, removeRoof } from '../three/roof';
-import { ROOM_OBJECT_TAGS, applyWallDisplay, buildRoom, removeTagged } from '../three/room-builder';
+import { ROOM_OBJECT_TAGS, applyWallDisplay, buildRoom, clearFloorPlanImageCache, removeTagged } from '../three/room-builder';
 import { addSignalOverlays } from '../three/signal-overlay';
 import { computeFloorOpenings, computeWallOpenings } from '../three/wall-openings';
 import type { FloorLayout, RoomLayout, ViewSettings } from '../lib/types';
@@ -178,6 +178,11 @@ export function useSceneEffects({
 
     removeTagged(scene, ROOM_OBJECT_TAGS.Floor, ROOM_OBJECT_TAGS.Wall);
 
+    // The building no longer has a floor plan: release the decoded multi-MB
+    // image. (Only here — see clearFloorPlanImageCache for why buildRoom must
+    // not drop it per image-less call.)
+    if (!layout.floorPlanImage) clearFloorPlanImageCache();
+
     const floorsToRender = view.showAllFloors
       ? layout.floors.map((floor, index) => ({ floor, index }))
       : [{ floor: activeFloor, index: activeFloorIndex }];
@@ -229,7 +234,11 @@ export function useSceneEffects({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, rendererRef, cameraRef,
-    layout.width, layout.height, shellFinishesKey, wallOpeningsKey,
+    // interiorWallsKey: opening ownership is classified across exterior AND
+    // interior walls (nearest wall wins), so the exterior hole set changes
+    // when interior walls do — without this dep a door claimed by a new
+    // interior wall stays double-cut into the exterior wall (#119).
+    layout.width, layout.height, shellFinishesKey, wallOpeningsKey, interiorWallsKey,
     layout.floorPlanImage, layout.floorPlanOpacity, layout.floorPlanFitMode,
     view.floorPlan3DEffect, view.showAllFloors, view.wallDisplay,
     activeFloorIndex,
@@ -585,8 +594,15 @@ export function useSceneEffects({
       baseY: layout.floors.length * FLOOR_HEIGHT_METERS,
       spec: layout.roof,
     });
+    // buildRoof adds meshes visible; only applyWallDisplay hides the roof in
+    // cutaway/walls-down mode, and it otherwise runs on orbit — so a roof
+    // rebuilt while the walls are open would pop in until the camera moves (#119).
+    const camera = cameraRef.current;
+    if (camera) {
+      applyWallDisplay(scene, camera.position.x, camera.position.z, view.wallDisplay, layout.width, layout.height);
+    }
     requestShadowUpdate();
-  }, [isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, layout.roof, layout.width, layout.height, layout.floors.length, activeFloorIndex, view.showAllFloors]);
+  }, [isReady, invalidate, requestShadowUpdate, threeModuleRef, sceneRef, cameraRef, layout.roof, layout.width, layout.height, layout.floors.length, activeFloorIndex, view.showAllFloors, view.wallDisplay]);
 
   // 2D top-down view. The backing store is sized to the container's
   // clientWidth/clientHeight × devicePixelRatio (via a ResizeObserver) so the

--- a/components/room-organizer/panels/actions-panel.tsx
+++ b/components/room-organizer/panels/actions-panel.tsx
@@ -20,7 +20,7 @@ export interface ActionsPanelProps {
 
 export function ActionsPanel(props: ActionsPanelProps): JSX.Element {
   const { layout, activeFloor, actions, isReady } = useRoomEditor();
-  const { setSelectedItemId, setExtraSelectedIds } = useSelection();
+  const { selectOnly, setSelectedItemId, setExtraSelectedIds } = useSelection();
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const hasItems = activeFloor.items.length > 0;
@@ -112,7 +112,7 @@ export function ActionsPanel(props: ActionsPanelProps): JSX.Element {
             <Button
               onClick={() => {
                 actions.clearItems();
-                setSelectedItemId(null);
+                selectOnly(null);
               }}
               variant="outline"
               size="sm"

--- a/components/room-organizer/panels/bottom-hud.tsx
+++ b/components/room-organizer/panels/bottom-hud.tsx
@@ -24,7 +24,7 @@ export interface BottomHudProps {
 
 export function BottomHud({ selectedWall, onSelectedWallChange, onOrbit, onZoom, onFit, placeCatalogItem }: BottomHudProps): JSX.Element {
   const { layout, activeFloor, actions, view, toggle, setView, isReady, error, gameMode, setGameMode, playCue } = useRoomEditor();
-  const { setSelectedItemId, setExtraSelectedIds } = useSelection();
+  const { selectOnly, setSelectedItemId, setExtraSelectedIds } = useSelection();
   const [buildToolCategory, setBuildToolCategory] = useState<BuildToolCategory>('seating');
 
   if (!isReady || error) return <></>;
@@ -122,7 +122,7 @@ export function BottomHud({ selectedWall, onSelectedWallChange, onOrbit, onZoom,
           category={buildToolCategory === 'walls' ? 'all' : buildToolCategory}
           onAdd={(catalogItem) => {
             const id = placeCatalogItem(catalogItem);
-            setSelectedItemId(id);
+            selectOnly(id);
             playCue('place');
           }}
         />

--- a/components/room-organizer/panels/placed-items-panel.tsx
+++ b/components/room-organizer/panels/placed-items-panel.tsx
@@ -17,7 +17,7 @@ export function PlacedItemsPanel({
   onRemove,
 }: PlacedItemsPanelProps): JSX.Element {
   const { activeFloor, collidingIds } = useRoomEditor();
-  const { selectedItemId, setSelectedItemId } = useSelection();
+  const { selectedItemId, selectOnly } = useSelection();
   const items = activeFloor.items;
   const [query, setQuery] = useState('');
 
@@ -61,7 +61,7 @@ export function PlacedItemsPanel({
                       ? 'border-red-400 bg-red-50/60'
                       : 'border-border'
                 }`}
-                onClick={() => setSelectedItemId(item.id)}
+                onClick={() => selectOnly(item.id)}
               >
                 <span className="text-sm flex items-center gap-2">
                   <span>{item.icon}</span>

--- a/components/room-organizer/panels/sidebar-drawer.tsx
+++ b/components/room-organizer/panels/sidebar-drawer.tsx
@@ -65,7 +65,7 @@ export function SidebarDrawer({
   removeItem,
 }: SidebarDrawerProps): JSX.Element {
   const { layout, activeFloor, actions, view, isReady, playCue, history, catalogQuery, setCatalogQuery } = useRoomEditor();
-  const { selectedItem, setSelectedItemId, allSelectedIds } = useSelection();
+  const { selectedItem, selectOnly, allSelectedIds } = useSelection();
   const [sidebarTab, setSidebarTabRaw] = useState<SidebarTab>(() => {
     if (typeof window === 'undefined') return 'build';
     const saved = localStorage.getItem('standalone-room-organizer-sidebar-tab');
@@ -183,7 +183,7 @@ export function SidebarDrawer({
                 onQueryChange={setCatalogQuery}
                 onAdd={(catalogItem) => {
                   const id = placeCatalogItem(catalogItem);
-                  setSelectedItemId(id);
+                  selectOnly(id);
                   playCue('place');
                 }}
               />
@@ -200,7 +200,7 @@ export function SidebarDrawer({
                   if (items.length === 0) return;
                   actions.addItems(items);
                   const last = items[items.length - 1];
-                  if (last) setSelectedItemId(last.id);
+                  if (last) selectOnly(last.id);
                 }}
               />
 
@@ -225,7 +225,7 @@ export function SidebarDrawer({
                   hasCollision={hasCollisions(selectedItem, activeFloor.items, layout.width, layout.height)}
                   onDuplicate={(id) => {
                     const newId = actions.duplicateItem(id);
-                    setSelectedItemId(newId);
+                    selectOnly(newId);
                   }}
                 />
               )}
@@ -253,7 +253,7 @@ export function SidebarDrawer({
                     ...template,
                     floors: template.floors.map((floor) => ({ ...floor, items: [...floor.items] })),
                   });
-                  setSelectedItemId(null);
+                  selectOnly(null);
                 }}
               />
 
@@ -261,7 +261,7 @@ export function SidebarDrawer({
                 currentLayout={layout}
                 onLoad={(loaded) => {
                   actions.applyLayout(loaded);
-                  setSelectedItemId(null);
+                  selectOnly(null);
                   history.clear();
                 }}
               />

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -259,42 +259,68 @@ export function RoomOrganizer(): JSX.Element {
     if (renderer) renderer.render(sceneRef.current!, camera);
     // The scene refs are declared below (useThreeScene) so they can't appear
     // in this dep array without a TDZ error; they're stable ref objects anyway.
+    // activeFloor.id: removing floor 0 (or reordering) can change WHICH floor
+    // is active while the index stays 0 — keying on the index alone carried
+    // the deleted floor's selection onto its replacement (#117).
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [activeFloorIndex]);
+  }, [activeFloorIndex, activeFloor.id]);
 
-  const handleSelect = useCallback((id: string, mode: 'replace' | 'toggle') => {
-    if (mode === 'replace') {
-      setSelectedItemId(id);
-      setExtraSelectedIds(new Set());
-      return;
-    }
-    setSelectedItemId((current) => {
-      if (current === null) {
-        return id;
+  // Ghost-selection guard: whenever the floor's items change (undo/redo,
+  // import, clear floor, deletes from any path), drop selected ids that no
+  // longer exist; a vanished primary promotes the first surviving extra (#117).
+  useEffect(() => {
+    const ids = new Set(activeFloor.items.map((item) => item.id));
+    const primaryGone = selectedItemId !== null && !ids.has(selectedItemId);
+    const hasStaleExtras = Array.from(extraSelectedIds).some((id) => !ids.has(id));
+    if (!primaryGone && !hasStaleExtras) return;
+    const liveExtras = Array.from(extraSelectedIds).filter((id) => ids.has(id));
+    if (primaryGone) setSelectedItemId(liveExtras.shift() ?? null);
+    setExtraSelectedIds(new Set(liveExtras));
+  }, [activeFloor.items, selectedItemId, extraSelectedIds]);
+
+  // Make `id` the sole selection (null clears). The one way panels set a
+  // primary — pairing the two setters at every call site is how stale extras
+  // leaked into later group operations (#117).
+  const selectOnly = useCallback((id: string | null) => {
+    setSelectedItemId(id);
+    setExtraSelectedIds((extras) => (extras.size === 0 ? extras : new Set()));
+  }, []);
+
+  // Plain reads + flat setter calls. The previous version computed the
+  // promotion inside a nested setState updater and read the result back
+  // synchronously — that only works on React's eager-evaluation path, and
+  // StrictMode's double-invoked updaters ran the toggle twice (#117).
+  const handleSelect = useCallback(
+    (id: string, mode: 'replace' | 'toggle') => {
+      if (mode === 'replace') {
+        selectOnly(id);
+        return;
       }
-      if (current === id) {
+      if (selectedItemId === null) {
+        setSelectedItemId(id);
+        return;
+      }
+      if (selectedItemId === id) {
         // Toggling the primary off: promote an extra to primary (keeping the
         // rest of the multi-select intact) or clear the selection entirely.
-        let promoted: string | null = null;
-        setExtraSelectedIds((extras) => {
-          if (extras.size === 0) return extras;
-          const next = new Set(extras);
-          const [first] = next;
-          promoted = first ?? null;
-          if (promoted !== null) next.delete(promoted);
-          return next;
-        });
-        return promoted;
+        const [promoted] = extraSelectedIds;
+        if (promoted === undefined) {
+          setSelectedItemId(null);
+          return;
+        }
+        const next = new Set(extraSelectedIds);
+        next.delete(promoted);
+        setExtraSelectedIds(next);
+        setSelectedItemId(promoted);
+        return;
       }
-      setExtraSelectedIds((extras) => {
-        const next = new Set(extras);
-        if (next.has(id)) next.delete(id);
-        else next.add(id);
-        return next;
-      });
-      return current;
-    });
-  }, []);
+      const next = new Set(extraSelectedIds);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      setExtraSelectedIds(next);
+    },
+    [selectedItemId, extraSelectedIds, selectOnly]
+  );
 
   const allSelectedIds = useMemo(() => {
     const set = new Set(extraSelectedIds);
@@ -448,10 +474,10 @@ export function RoomOrganizer(): JSX.Element {
     onHydrate: useCallback(
       (saved: RoomLayout) => {
         actions.applyLayout(saved);
-        setSelectedItemId(null);
+        selectOnly(null);
         history.clear();
       },
-      [actions, history]
+      [actions, history, selectOnly]
     ),
   });
 
@@ -756,8 +782,9 @@ export function RoomOrganizer(): JSX.Element {
       extraSelectedIds,
       setExtraSelectedIds,
       allSelectedIds,
+      selectOnly,
     }),
-    [selectedItemId, setSelectedItemId, selectedItem, extraSelectedIds, setExtraSelectedIds, allSelectedIds]
+    [selectedItemId, setSelectedItemId, selectedItem, extraSelectedIds, setExtraSelectedIds, allSelectedIds, selectOnly]
   );
 
   return (
@@ -813,7 +840,7 @@ export function RoomOrganizer(): JSX.Element {
           if (!item) return;
           const world = worldPositionFromClient(clientX, clientY);
           const newId = placeCatalogItem(item, world ?? undefined);
-          setSelectedItemId(newId);
+          selectOnly(newId);
         }}
       />
 

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -150,9 +150,11 @@ export function buildRoom(THREE: ThreeModule, options: RoomBuilderOptions): void
   if (options.floorPlanImage) {
     material = buildFloorPlanMaterial(THREE, options, options.floorPlanImage);
   } else {
-    // No floor-plan image on this rebuild: drop the decoded-image cache so a
-    // removed (possibly multi-MB) data URL isn't retained forever.
-    floorPlanImageCache = null;
+    // Note: an image-less call must NOT drop the decoded-image cache here —
+    // only floor 0 carries the plan, so in a multi-floor rebuild every upper
+    // floor would wipe the cache floor 0 just warmed and the multi-MB data
+    // URL would re-decode on every other rebuild (#119). The caller clears
+    // the cache via clearFloorPlanImageCache() when the plan is truly gone.
     material = buildFloorMaterial(THREE, {
       pattern: options.floorPattern ?? 'solid',
       color: options.floorColor,
@@ -256,6 +258,15 @@ function addFoundation(
 // disposed along with their meshes) keyed on the URL; single entry, since a
 // building has one floor plan.
 let floorPlanImageCache: { url: string; image: HTMLImageElement } | null = null;
+
+/**
+ * Drop the decoded floor-plan cache. Call when the building no longer has a
+ * plan (so a removed multi-MB data URL isn't retained) — not per image-less
+ * buildRoom call, which would thrash the cache in multi-floor rebuilds (#119).
+ */
+export function clearFloorPlanImageCache(): void {
+  floorPlanImageCache = null;
+}
 
 function buildFloorPlanMaterial(
   THREE: ThreeModule,


### PR DESCRIPTION
Two commits, one per issue (disjoint files).

## #119 — scene-effect staleness (four fixes)

- **Exterior cutouts vs interior walls**: the shell effect now keys on `interiorWallsKey`. Opening ownership is classified across exterior *and* interior walls, so drawing/deleting an interior wall near a door changed the exterior hole set without triggering a rebuild — leaving the door double-cut, or sticking through solid wall.
- **Roof vs wall-display mode**: the roof effect applies `applyWallDisplay` after rebuilding, so restyling the roof in cutaway/walls-down no longer pops it over the open interior until the camera orbits.
- **NPC teardown**: cleanup now calls `invalidate` + `requestShadowUpdate` — toggling NPCs off erases them (and their shadows) instead of leaving them in the last painted frame (render-on-demand violation).
- **Floor-plan cache thrash**: the decoded-image cache is dropped via a new `clearFloorPlanImageCache()` only when the building truly has no plan, instead of by every image-less `buildRoom` call — which wiped the cache floor 0 had just warmed on every multi-floor rebuild, re-decoding the multi-MB data URL every other rebuild.

## #117 — ghost multi-selects (three layers)

- **`selectOnly(id)`** added to SelectionContext (set primary + clear extras atomically); all nine leaky call sites migrated — catalog strip/panel adds, sets, resize-panel duplicate, templates, library load, clear floor, placed-items row click, catalog drop, and hydrate.
- **`handleSelect` flattened**: the promote-an-extra logic no longer runs inside a nested setState updater reading its result synchronously — that relied on React's eager-evaluation path and double-fired the toggle under StrictMode.
- **Backstops**: a prune effect drops selected ids that no longer exist on the active floor (undo/redo, imports, deletes from any path; a vanished primary promotes the first surviving extra), and the floor-switch cleanup keys on `activeFloor.id` in addition to the index, so removing floor 0 no longer carries the deleted floor's selection onto its replacement.

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` (203 tests) all pass. Caveat: no new unit tests — these fixes live in React effect/context glue the suite can't reach without mounting the full editor, and multi-select gestures can't be driven headless; the lib/reducer layers underneath are already covered.

Fixes #117
Fixes #119