### PR TITLE
2D plan/minimap parity (#118); layer-aware collision model (#120)

### DIFF
--- a/components/room-organizer/canvas-2d/render.ts
+++ b/components/room-organizer/canvas-2d/render.ts
@@ -9,13 +9,23 @@ export interface Render2DOptions {
   /** The floor to render — its items, floor colour, etc. */
   floor: FloorLayout;
   selectedItemId: string | null;
+  /** Multi-select extras — outlined like the primary so group state is visible (#118). */
+  extraSelectedIds?: ReadonlySet<string>;
   showMeasurements: boolean;
   showWiFiSignals: boolean;
   showHeatmap?: boolean;
   hasCollision: (item: FurnitureItem) => boolean;
+  /**
+   * Margin (CSS px) around the room. The default suits the full-screen 2D
+   * view; small consumers (the 180×130 minimap) must pass a small value or
+   * the margin consumes the whole canvas (#118).
+   */
+  padding?: number;
 }
 
 const PADDING = 60;
+// Matches the 0.16 m thickness modelled in three/interior-walls.ts.
+const INTERIOR_WALL_THICKNESS_M = 0.16;
 
 // Decoded floor-plan image cache, keyed on the data-URL. Decoding a multi-MB
 // data-URL is async: the first render kicks off the load and re-renders once
@@ -25,15 +35,22 @@ const PADDING = 60;
 let floorPlanImageCache: { url: string; image: HTMLImageElement } | null = null;
 
 /**
- * Callback the render effect installs so the async floor-plan decode can
- * trigger a full repaint (redrawing the whole scene in the right layer order)
- * once the image is ready. Set via {@link setFloorPlanRepaintHandler}.
+ * Callbacks the consumers install so the async floor-plan decode can trigger
+ * a full repaint (redrawing the whole scene in the right layer order) once
+ * the image is ready. A set, not a single slot: the 2D view AND the minimap
+ * render concurrently, and a single-slot handler dropped whichever consumer
+ * didn't own it — the minimap never repainted after a decode (#118).
  */
-let requestRepaint: (() => void) | null = null;
+const repaintHandlers = new Set<() => void>();
 
-/** Register the repaint handler used when an async floor-plan image finishes loading. */
-export function setFloorPlanRepaintHandler(handler: (() => void) | null): void {
-  requestRepaint = handler;
+/** Register a repaint handler; returns the disposer that unregisters it. */
+export function addFloorPlanRepaintHandler(handler: () => void): () => void {
+  repaintHandlers.add(handler);
+  return () => repaintHandlers.delete(handler);
+}
+
+function requestRepaint(): void {
+  for (const handler of repaintHandlers) handler();
 }
 const WIFI_RING_FILLS = ['rgba(0, 255, 0, 0.15)', 'rgba(255, 255, 0, 0.10)', 'rgba(255, 102, 0, 0.08)'];
 const WIFI_RING_STROKES = ['rgba(0, 255, 0, 0.4)', 'rgba(255, 255, 0, 0.3)', 'rgba(255, 102, 0, 0.2)'];
@@ -57,16 +74,18 @@ export function render2DTopDown(options: Render2DOptions): void {
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
   ctx.clearRect(0, 0, viewWidth, viewHeight);
 
+  const padding = options.padding ?? PADDING;
   const scale = Math.min(
-    (viewWidth - PADDING * 2) / layout.width,
-    (viewHeight - PADDING * 2) / layout.height
+    (viewWidth - padding * 2) / layout.width,
+    (viewHeight - padding * 2) / layout.height
   );
   const offsetX = (viewWidth - layout.width * scale) / 2;
   const offsetY = (viewHeight - layout.height * scale) / 2;
 
   drawFloor(ctx, layout, floor, offsetX, offsetY, scale);
   drawGrid(ctx, layout, offsetX, offsetY, scale);
-  drawRoomOutline(ctx, layout, offsetX, offsetY, scale);
+  drawRoomOutline(ctx, layout, floor, offsetX, offsetY, scale);
+  drawInteriorWalls(ctx, layout, floor, offsetX, offsetY, scale);
 
   if (options.showHeatmap) {
     drawHeatmap(ctx, layout, floor.items, offsetX, offsetY, scale, viewWidth, viewHeight);
@@ -99,11 +118,16 @@ function drawFloor(
     ctx.fillStyle = floor.floorColor;
     ctx.fillRect(offsetX, offsetY, layout.width * scale, layout.height * scale);
 
+    // naturalWidth guard: a broken image also reports `complete`, and
+    // drawImage on it throws InvalidStateError — which would abort the whole
+    // paint (grid and furniture never drawn) on every repaint (#118).
     if (floorPlanImageCache?.url === url && floorPlanImageCache.image.complete) {
       const img = floorPlanImageCache.image;
-      ctx.globalAlpha = layout.floorPlanOpacity ?? 1;
-      ctx.drawImage(img, offsetX, offsetY, layout.width * scale, layout.height * scale);
-      ctx.globalAlpha = 1;
+      if (img.naturalWidth > 0) {
+        ctx.globalAlpha = layout.floorPlanOpacity ?? 1;
+        ctx.drawImage(img, offsetX, offsetY, layout.width * scale, layout.height * scale);
+        ctx.globalAlpha = 1;
+      }
       return;
     }
 
@@ -159,13 +183,61 @@ function drawGrid(
 function drawRoomOutline(
   ctx: CanvasRenderingContext2D,
   layout: RoomLayout,
+  floor: FloorLayout,
   offsetX: number,
   offsetY: number,
   scale: number
 ): void {
-  ctx.strokeStyle = '#666';
-  ctx.lineWidth = 3;
-  ctx.strokeRect(offsetX, offsetY, layout.width * scale, layout.height * scale);
+  // Per-edge, not strokeRect: a wall hidden via Wall Visibility (or Delete)
+  // reads as a light dashed boundary instead of a solid wall (#118).
+  const hidden = new Set(floor.hiddenWalls ?? []);
+  const x0 = offsetX;
+  const y0 = offsetY;
+  const x1 = offsetX + layout.width * scale;
+  const y1 = offsetY + layout.height * scale;
+  const edges = [
+    { id: 'north', from: [x0, y0], to: [x1, y0] },
+    { id: 'south', from: [x0, y1], to: [x1, y1] },
+    { id: 'west', from: [x0, y0], to: [x0, y1] },
+    { id: 'east', from: [x1, y0], to: [x1, y1] },
+  ] as const;
+  for (const edge of edges) {
+    const isHidden = hidden.has(edge.id);
+    ctx.save();
+    ctx.strokeStyle = isHidden ? '#bbb' : '#666';
+    ctx.lineWidth = isHidden ? 1.5 : 3;
+    if (isHidden) ctx.setLineDash([6, 4]);
+    ctx.beginPath();
+    ctx.moveTo(edge.from[0], edge.from[1]);
+    ctx.lineTo(edge.to[0], edge.to[1]);
+    ctx.stroke();
+    ctx.restore();
+  }
+}
+
+function drawInteriorWalls(
+  ctx: CanvasRenderingContext2D,
+  layout: RoomLayout,
+  floor: FloorLayout,
+  offsetX: number,
+  offsetY: number,
+  scale: number
+): void {
+  const walls = floor.interiorWalls ?? [];
+  if (walls.length === 0) return;
+  const halfW = layout.width / 2;
+  const halfD = layout.height / 2;
+  ctx.save();
+  ctx.strokeStyle = '#555';
+  ctx.lineCap = 'butt';
+  ctx.lineWidth = Math.max(2, INTERIOR_WALL_THICKNESS_M * scale);
+  for (const wall of walls) {
+    ctx.beginPath();
+    ctx.moveTo(offsetX + (wall.x1 + halfW) * scale, offsetY + (wall.z1 + halfD) * scale);
+    ctx.lineTo(offsetX + (wall.x2 + halfW) * scale, offsetY + (wall.z2 + halfD) * scale);
+    ctx.stroke();
+  }
+  ctx.restore();
 }
 
 function drawSignalRings(
@@ -227,6 +299,10 @@ function drawFurniture(
     if (options.selectedItemId === item.id) {
       ctx.strokeStyle = collision ? '#ff6666' : '#00ff00';
       ctx.lineWidth = 3;
+    } else if (options.extraSelectedIds?.has(item.id)) {
+      // Multi-select extras share the primary's green, slightly thinner.
+      ctx.strokeStyle = collision ? '#ff6666' : '#00cc00';
+      ctx.lineWidth = 2;
     } else if (collision) {
       ctx.strokeStyle = '#ff0000';
       ctx.lineWidth = 2;

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, type RefObject, type MutableRefObject } from 'react';
-import { render2DTopDown, setFloorPlanRepaintHandler } from '../canvas-2d/render';
+import { addFloorPlanRepaintHandler, render2DTopDown } from '../canvas-2d/render';
 import { hasCollisions } from '../lib/geometry';
 import { FLOOR_HEIGHT_METERS } from '../lib/types';
 import { disposeObject, removeAndDispose } from '../three/builder-utils';
@@ -633,6 +633,7 @@ export function useSceneEffects({
         layout,
         floor: activeFloor,
         selectedItemId,
+        extraSelectedIds,
         showMeasurements: view.showMeasurements,
         showWiFiSignals: view.showWiFiSignals,
         showHeatmap: view.showHeatmap,
@@ -640,7 +641,7 @@ export function useSceneEffects({
       });
     };
 
-    setFloorPlanRepaintHandler(paint);
+    const removeRepaintHandler = addFloorPlanRepaintHandler(paint);
     paint();
 
     const observer = new ResizeObserver(paint);
@@ -648,9 +649,9 @@ export function useSceneEffects({
 
     return () => {
       observer.disconnect();
-      setFloorPlanRepaintHandler(null);
+      removeRepaintHandler();
     };
-  }, [invalidate, canvas2DRef, view.view2D, view.showMeasurements, view.showWiFiSignals, view.showHeatmap, layout, activeFloor, selectedItemId]);
+  }, [invalidate, canvas2DRef, view.view2D, view.showMeasurements, view.showWiFiSignals, view.showHeatmap, layout, activeFloor, selectedItemId, extraSelectedIds]);
 }
 
 export { measurementDistance } from '../three/measurement';

--- a/components/room-organizer/lib/constants.ts
+++ b/components/room-organizer/lib/constants.ts
@@ -167,7 +167,9 @@ export const ROOM_TEMPLATES = {
     { id: 'nightstand-1', type: 'nightstand', category: 'bedroom', name: 'Nightstand', width: 0.5, depth: 0.4, height: 0.6, color: '#8B4513', icon: '🕯️', price: 120, position: { x: -1.3, z: -0.5 }, rotation: 0 },
     { id: 'nightstand-2', type: 'nightstand', category: 'bedroom', name: 'Nightstand', width: 0.5, depth: 0.4, height: 0.6, color: '#8B4513', icon: '🕯️', price: 120, position: { x: 1.3, z: -0.5 }, rotation: 0 },
     { id: 'wardrobe-1', type: 'wardrobe', category: 'bedroom', name: 'Wardrobe', width: 1.4, depth: 0.6, height: 2.1, color: '#6D4C41', icon: '🚪', price: 540, position: { x: -1.0, z: 1.3 }, rotation: 0 },
-    { id: 'lamp-1', type: 'lamp', category: 'electronics', name: 'Lamp', width: 0.3, depth: 0.3, height: 1.5, color: '#FFD700', icon: '💡', price: 110, position: { x: -1.5, z: 1.2 }, rotation: 0 },
+    // Opposite corner from the wardrobe — at (-1.5, 1.2) the floor lamp stood
+    // inside the wardrobe's footprint (#120).
+    { id: 'lamp-1', type: 'lamp', category: 'electronics', name: 'Lamp', width: 0.3, depth: 0.3, height: 1.5, color: '#FFD700', icon: '💡', price: 110, position: { x: 1.5, z: 1.3 }, rotation: 0 },
   ]),
   livingRoom: singleFloorTemplate('Living Room', 6, 5, '#D4C5B9', [
     { id: 'sofa-1', type: 'sofa', category: 'seating', name: 'Sofa', width: 2.0, depth: 0.9, height: 0.8, color: '#4A5568', icon: '🛋️', price: 650, position: { x: 0, z: -1.5 }, rotation: 0, sofaShape: 'standard' },

--- a/components/room-organizer/lib/geometry.test.ts
+++ b/components/room-organizer/lib/geometry.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { makeItem } from './__testfixtures__/fixtures';
+import { ROOM_TEMPLATES } from './constants';
 import {
   autoOrganize,
   boundingRadius,
@@ -136,6 +137,43 @@ describe('hasCollisions', () => {
     expect(hasCollisions(door, [door], W, D)).toBe(false);
     const other = makeItem({ id: 'o', type: 'window', width: 1, depth: 0.2, position: { x: 5, z: 0 } });
     expect(hasCollisions(door, [door, other], W, D)).toBe(true);
+  });
+
+  it('a rug under a sofa is not a collision (#120)', () => {
+    const rug = makeItem({ id: 'r', type: 'rug', width: 2, depth: 1.4, height: 0.02, position: { x: 0, z: 0 } });
+    const sofa = makeItem({ id: 's', type: 'sofa', width: 2, depth: 0.9, height: 0.8, position: { x: 0, z: 0 } });
+    expect(hasCollisions(rug, [rug, sofa], W, D)).toBe(false);
+    expect(hasCollisions(sofa, [rug, sofa], W, D)).toBe(false);
+  });
+
+  it('furniture flush under a window or camera is not a collision (#120)', () => {
+    const sofa = makeItem({ id: 's', type: 'sofa', width: 2, depth: 0.9, height: 0.8, position: { x: 0, z: -4.5 } });
+    const window = makeItem({ id: 'w', type: 'window', width: 1.2, depth: 0.12, position: { x: 0, z: -5 } });
+    const cam = makeItem({ id: 'c', type: 'security-camera', width: 0.3, depth: 0.2, position: { x: 3, z: -4.85 } });
+    const sofa2 = makeItem({ id: 's2', type: 'sofa', width: 2, depth: 0.9, height: 0.8, position: { x: 3, z: -4.5 } });
+    const items = [sofa, window, cam, sofa2];
+    expect(hasCollisions(sofa, items, W, D)).toBe(false);
+    expect(hasCollisions(window, items, W, D)).toBe(false);
+    expect(hasCollisions(cam, items, W, D)).toBe(false);
+  });
+
+  it('wall-plane items still collide with each other (#120)', () => {
+    const cam = makeItem({ id: 'c', type: 'security-camera', width: 0.3, depth: 0.2, position: { x: 5, z: 0 } });
+    const door = makeItem({ id: 'd', type: 'door', width: 1, depth: 0.2, position: { x: 5, z: 0 } });
+    expect(hasCollisions(cam, [cam, door], W, D)).toBe(true);
+  });
+
+  it('every shipped template loads with zero collisions (#120)', () => {
+    for (const [key, template] of Object.entries(ROOM_TEMPLATES)) {
+      for (const floor of template.floors) {
+        for (const item of floor.items) {
+          expect(
+            hasCollisions(item, floor.items, template.width, template.height),
+            `${key}: ${item.id}`
+          ).toBe(false);
+        }
+      }
+    }
   });
 
   it('outdoor items are flagged when they poke into the room', () => {

--- a/components/room-organizer/lib/geometry.ts
+++ b/components/room-organizer/lib/geometry.ts
@@ -1,4 +1,4 @@
-import { isOpening } from './opening-snap';
+import { isWallMounted } from './opening-snap';
 import type { FurnitureItem, Vec2 } from './types';
 
 export function boundingRadius(item: Pick<FurnitureItem, 'width' | 'depth'>): number {
@@ -110,6 +110,44 @@ export function itemFullyOutside(item: FurnitureItem, roomWidth: number, roomDep
   );
 }
 
+/**
+ * Anything at or under this height goes UNDER furniture by design (rugs are
+ * 0.02 m) — a rug beneath a sofa is the intended use, not a collision.
+ */
+const LOW_PROFILE_MAX_HEIGHT = 0.05;
+
+function isLowProfile(item: Pick<FurnitureItem, 'height'>): boolean {
+  return item.height <= LOW_PROFILE_MAX_HEIGHT;
+}
+
+// Intended-stacking families (#120): small tabletop items sit ON these
+// surfaces (the Office template puts the computer and lamp on the desk) and
+// seats tuck UNDER tables (the Kitchen template's dining chairs). Items have
+// no elevation field, so the layer model is by type.
+const SURFACE_TYPES = new Set(['desk', 'dining-table', 'coffee-table', 'counter', 'nightstand', 'dresser']);
+const TABLETOP_TYPES = new Set(['computer', 'lamp', 'plant', 'books', 'candles', 'flowerpot', 'wifi']);
+const SEAT_TYPES = new Set(['chair', 'dining-chair', 'bench']);
+
+function isIntendedStack(a: FurnitureItem, b: FurnitureItem): boolean {
+  const stacksOn = (surface: FurnitureItem, top: FurnitureItem): boolean =>
+    SURFACE_TYPES.has(surface.type) && (TABLETOP_TYPES.has(top.type) || SEAT_TYPES.has(top.type));
+  return stacksOn(a, b) || stacksOn(b, a);
+}
+
+/**
+ * Layer-aware pair test (#120). Wall-plane items (doors, windows, cameras)
+ * collide only with EACH OTHER — two doors overlapping on one wall is real,
+ * but floor furniture flush under a window or beneath a 2.4 m camera is the
+ * intended use. The old symmetric 2D test flagged the shipped Living Room
+ * template (rug under sofa) red on load.
+ */
+function pairCollides(a: FurnitureItem, b: FurnitureItem): boolean {
+  if (isWallMounted(a.type) !== isWallMounted(b.type)) return false;
+  if (isLowProfile(a) || isLowProfile(b)) return false;
+  if (isIntendedStack(a, b)) return false;
+  return itemsOverlap(a, b);
+}
+
 export function hasCollisions(
   item: FurnitureItem,
   allItems: readonly FurnitureItem[],
@@ -117,24 +155,21 @@ export function hasCollisions(
   roomDepth: number
 ): boolean {
   if (!item.position) return false;
-  // Security cameras mount on the wall plane and may sit on its exterior side
-  // when aimed outward, so the room-bounds test doesn't apply to them.
-  if (item.type === 'security-camera') return false;
-  // Openings (doors/windows) live in the wall plane by design, so the
-  // room-bounds test never applies — they'd always poke through the wall and
-  // read as out-of-bounds. They still collide with other items on the wall.
-  if (isOpening(item.type)) {
-    return allItems.some((other) => other.id !== item.id && itemsOverlap(item, other));
-  }
+  const overlapsAnother = (): boolean =>
+    allItems.some((other) => other.id !== item.id && pairCollides(item, other));
+  // Wall-plane items (doors, windows, cameras) live in — or on the exterior
+  // side of — the wall by design, so the room-bounds test never applies:
+  // they'd always poke through the wall and read as out-of-bounds.
+  if (isWallMounted(item.type)) return overlapsAnother();
   // Outdoor items belong outside the building footprint — flag them when any
   // part of their footprint pokes into the room. They still collide with
   // other items (e.g. two trees on the same spot).
   if (item.category === 'outdoor') {
     if (!itemFullyOutside(item, roomWidth, roomDepth)) return true;
-    return allItems.some((other) => other.id !== item.id && itemsOverlap(item, other));
+    return overlapsAnother();
   }
   if (!itemInBounds(item, roomWidth, roomDepth)) return true;
-  return allItems.some((other) => other.id !== item.id && itemsOverlap(item, other));
+  return overlapsAnother();
 }
 
 export type AutoOrganizeStrategy = 'shelf' | 'by-category' | 'by-size';

--- a/components/room-organizer/panels/catalog-strip.tsx
+++ b/components/room-organizer/panels/catalog-strip.tsx
@@ -258,7 +258,7 @@ function CatalogTile({ item, onAdd }: CatalogTileProps): JSX.Element {
     <button
       type="button"
       onClick={() => onAdd(item)}
-      title={`${item.name} — ${CURRENCY_SYMBOL}${item.price.toLocaleString()}. Drag onto the canvas to place precisely.`}
+      title={`${item.name} — ${CURRENCY_SYMBOL}${item.price.toLocaleString()}. Drag onto the 3D view to place precisely.`}
       draggable
       onDragStart={(event) => {
         event.dataTransfer.effectAllowed = 'copy';

--- a/components/room-organizer/panels/furniture-catalog-panel.tsx
+++ b/components/room-organizer/panels/furniture-catalog-panel.tsx
@@ -79,7 +79,7 @@ export function FurnitureCatalogPanel({
           </div>
         )}
         <p className="text-[10px] text-muted-foreground mt-3 text-center">
-          Click to drop at centre · drag onto the floor to place precisely
+          Click to drop at centre · drag onto the 3D view to place precisely
         </p>
       </CardContent>
     </Card>
@@ -154,7 +154,7 @@ function CatalogTile({ item, onAdd }: CatalogTileProps): JSX.Element {
     <button
       type="button"
       onClick={() => onAdd(item)}
-      title={`${item.name} — drag onto the canvas to place precisely, or click to drop at center`}
+      title={`${item.name} — drag onto the 3D view to place precisely, or click to drop at center`}
       draggable
       onDragStart={(event) => {
         event.dataTransfer.effectAllowed = 'copy';

--- a/components/room-organizer/panels/minimap.tsx
+++ b/components/room-organizer/panels/minimap.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useEffect, useRef } from 'react';
-import { render2DTopDown } from '../canvas-2d/render';
+import { addFloorPlanRepaintHandler, render2DTopDown } from '../canvas-2d/render';
 import { hasCollisions } from '../lib/geometry';
 import type { FloorLayout, RoomLayout } from '../lib/types';
 
 const MINIMAP_WIDTH = 180;
 const MINIMAP_HEIGHT = 130;
+// The renderer's default 60px margin was tuned for the full-screen 2D view
+// and left this canvas ~10px of drawable height (#118).
+const MINIMAP_PADDING = 6;
 
 export interface MinimapProps {
   layout: RoomLayout;
@@ -19,16 +22,22 @@ export function Minimap({ layout, floor, selectedItemId }: MinimapProps): JSX.El
 
   useEffect(() => {
     const canvas = canvasRef.current;
-    if (!canvas) return;
-    render2DTopDown({
-      canvas,
-      layout,
-      floor,
-      selectedItemId,
-      showMeasurements: false,
-      showWiFiSignals: false,
-      hasCollision: (item) => hasCollisions(item, floor.items, layout.width, layout.height),
-    });
+    if (!canvas) return undefined;
+    const paint = () =>
+      render2DTopDown({
+        canvas,
+        layout,
+        floor,
+        selectedItemId,
+        showMeasurements: false,
+        showWiFiSignals: false,
+        hasCollision: (item) => hasCollisions(item, floor.items, layout.width, layout.height),
+        padding: MINIMAP_PADDING,
+      });
+    paint();
+    // Repaint when an async floor-plan decode lands — the minimap renders in
+    // 3D view where the 2D view's handler isn't registered (#118).
+    return addFloorPlanRepaintHandler(paint);
   }, [layout, floor, selectedItemId]);
 
   return (


### PR DESCRIPTION
Two commits, one per issue (disjoint files).

## #118 — 2D plan & minimap parity

- **Interior walls draw in 2D** at their modelled 0.16 m thickness — and since the printed blueprint reuses `render2DTopDown`, it inherits them (plus everything below) for free.
- **Hidden exterior walls** render as light dashed boundaries instead of solid strokes (per-edge outline replaces `strokeRect`).
- **Minimap is usable again**: `padding` became a renderer option; the minimap passes 6 px instead of inheriting the full-screen 60 px margin that left its 180×130 canvas ~10 px of drawable height.
- **Repaint fan-out**: the async floor-plan decode handler is now a multi-consumer set with disposers; the minimap registers its own, so a plan decode repaints it in 3D view instead of being dropped by the single-slot handler.
- **Broken plan images** can no longer throw out of `drawImage` and abort the whole paint (`naturalWidth` guard).
- Multi-select **extras are outlined** in 2D; catalog tooltips now say "3D view" since the 2D canvas takes no drops.

Verified with a Playwright screenshot: interior wall polylines render in the 2D plan where they were previously invisible.

## #120 — layer-aware collision

`pairCollides` now models layers instead of raw 2D overlap:
- wall-plane items (doors/windows/cameras) collide only with **each other** — furniture flush under a window/camera is the intended use;
- low-profile items (height ≤ 0.05 m — rugs) go under furniture by design;
- type-based stacking families: tabletop items on surfaces (office computer/lamp on the desk) and seats under tables (kitchen dining chairs).

The rules were derived by enumerating every overlapping pair across all shipped templates — which also exposed a genuine bug the model must NOT excuse: the Bedroom template's floor lamp stood inside the wardrobe (moved to the free corner). A regression test asserts every shipped template loads with **zero** collisions.

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` all pass — 207 tests (203 + 4 new).

Fixes #118
Fixes #120