### PR TITLE
Schema hardening round 3 (#121); low-severity roundup (#122)

### DIFF
--- a/components/room-organizer/hooks/layout-reducer.test.ts
+++ b/components/room-organizer/hooks/layout-reducer.test.ts
@@ -204,6 +204,22 @@ describe('layoutReducer — bulk item operations', () => {
     expect(activeItems(state).every((i) => i.locked === false)).toBe(true);
   });
 
+  it('setInteriorWallColor paints only the matching interior wall (#122)', () => {
+    const floor = makeFloor({
+      interiorWalls: [
+        { id: 'w1', x1: 0, z1: 0, x2: 1, z2: 0 },
+        { id: 'w2', x1: 1, z1: 0, x2: 1, z2: 1 },
+      ],
+    });
+    const state = layoutReducer(
+      { layout: makeLayout({ floors: [floor] }), activeFloorIndex: 0 },
+      { type: 'setInteriorWallColor', id: 'w1', color: '#123456' }
+    );
+    const walls = state.layout.floors[0]!.interiorWalls!;
+    expect(walls.find((w) => w.id === 'w1')!.color).toBe('#123456');
+    expect(walls.find((w) => w.id === 'w2')!.color).toBeUndefined();
+  });
+
   it('bulkSetPositions never moves locked items (#115)', () => {
     const state = layoutReducer(
       stateWith([

--- a/components/room-organizer/hooks/layout-reducer.ts
+++ b/components/room-organizer/hooks/layout-reducer.ts
@@ -28,6 +28,7 @@ export type LayoutAction =
   | { type: 'setFloorPattern'; pattern: FloorPattern }
   | { type: 'setWallPattern'; pattern: WallPattern }
   | { type: 'setWallColor'; wall: WallId; color: string | null }
+  | { type: 'setInteriorWallColor'; id: string; color: string }
   // floor-scoped items — target the active floor
   | { type: 'addCatalogItem'; catalogItem: CatalogItem; id: string; position?: { x: number; z: number } }
   | { type: 'removeItem'; id: string }
@@ -126,6 +127,13 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
         else next[action.wall] = action.color;
         return { ...floor, wallColors: next };
       });
+    case 'setInteriorWallColor':
+      return withActiveFloor(state, (floor) => ({
+        ...floor,
+        interiorWalls: (floor.interiorWalls ?? []).map((wall) =>
+          wall.id === action.id ? { ...wall, color: action.color } : wall
+        ),
+      }));
 
     // -- floor plan ---------------------------------------------------------
     case 'setFloorPlan': {
@@ -377,17 +385,17 @@ export function layoutReducer(state: LayoutState, action: LayoutAction): LayoutS
       const source = state.layout.floors[action.sourceIndex];
       if (!source) return state;
       // `action.idSuffix` is a per-duplication random tag generated OUTSIDE the
-      // reducer (see use-layout-store.ts) — the reducer stays deterministic in
-      // its inputs, while two duplications within the same millisecond can no
-      // longer clone colliding item/wall ids.
-      const stamp = Date.now();
+      // reducer (see use-layout-store.ts): it alone makes the cloned ids
+      // unique, keeping the reducer fully deterministic in its inputs — the
+      // Date.now() stamp it used to mix in broke that purity for no extra
+      // collision protection (#122).
       const clonedItems: FurnitureItem[] = source.items.map((item, idx) => ({
         ...item,
-        id: `${item.type}-${stamp}-${action.idSuffix}-${idx}`,
+        id: `${item.type}-${action.idSuffix}-${idx}`,
       }));
       const clonedWalls: InteriorWall[] | undefined = source.interiorWalls?.map((wall, idx) => ({
         ...wall,
-        id: `wall-${stamp}-${action.idSuffix}-${idx}`,
+        id: `wall-${action.idSuffix}-${idx}`,
       }));
       const floor: FloorLayout = {
         ...source,

--- a/components/room-organizer/hooks/use-layout-state.ts
+++ b/components/room-organizer/hooks/use-layout-state.ts
@@ -40,6 +40,7 @@ export interface LayoutActions {
   setFloorPattern(pattern: FloorPattern): void;
   setWallPattern(pattern: WallPattern): void;
   setWallColor(wall: WallId, color: string | null): void;
+  setInteriorWallColor(id: string, color: string): void;
   setFloorPlan(image: string | null): void;
   setFloorPlanOpacity(opacity: number): void;
   setFloorPlanFitMode(mode: FloorPlanFitMode): void;

--- a/components/room-organizer/hooks/use-layout-store.ts
+++ b/components/room-organizer/hooks/use-layout-store.ts
@@ -67,6 +67,7 @@ export const layoutStore = createStore<LayoutStoreState>()((set) => {
     setFloorPattern: (pattern: FloorPattern) => dispatch({ type: 'setFloorPattern', pattern }),
     setWallPattern: (pattern: WallPattern) => dispatch({ type: 'setWallPattern', pattern }),
     setWallColor: (wall: WallId, color: string | null) => dispatch({ type: 'setWallColor', wall, color }),
+    setInteriorWallColor: (id: string, color: string) => dispatch({ type: 'setInteriorWallColor', id, color }),
     setFloorPlan: (image) => dispatch({ type: 'setFloorPlan', image }),
     setFloorPlanOpacity: (opacity) => dispatch({ type: 'setFloorPlanOpacity', opacity }),
     setFloorPlanFitMode: (mode: FloorPlanFitMode) => dispatch({ type: 'setFloorPlanFitMode', mode }),

--- a/components/room-organizer/hooks/use-scene-effects.ts
+++ b/components/room-organizer/hooks/use-scene-effects.ts
@@ -295,6 +295,9 @@ export function useSceneEffects({
         group.userData.id = item.id;
         group.userData.floorIndex = index;
         group.userData.locked = item.locked === true || !isActive;
+        // Inactive-floor groups are excluded from pointer raycasts entirely
+        // (see drag-handlers' furnitureList, #122).
+        group.userData.ghostFloor = !isActive;
 
         if (!isActive && view.showAllFloors) {
           ghostifyGroup(group);

--- a/components/room-organizer/hooks/use-three-scene.ts
+++ b/components/room-organizer/hooks/use-three-scene.ts
@@ -311,6 +311,11 @@ export function useThreeScene(options: UseThreeSceneOptions): UseThreeSceneResul
           /* swallow */
         }
       }
+      // The sky-gradient CanvasTexture installed by applyTimeOfDay lives on
+      // scene.background — the swap path only disposes its predecessor, so
+      // the final one leaks on full editor unmount without this (#122).
+      const background = sceneRef.current?.background;
+      if (background && 'dispose' in background) background.dispose();
       sceneRef.current = null;
       cameraRef.current = null;
       rendererRef.current = null;

--- a/components/room-organizer/lib/constants.ts
+++ b/components/room-organizer/lib/constants.ts
@@ -16,6 +16,10 @@ export const MAX_FLOORS = 4;
  * collision math while still accepting any realistic custom layout.
  */
 export const MAX_ROOM_DIMENSION = 100;
+// Item dims from external data (share URLs, imports) need a cap too: a
+// width of 1e12 passes a bare positivity check and destroys the scene scale
+// (camera framing, collision math, shadow map) (#121).
+export const MAX_ITEM_DIMENSION = 50;
 
 /** How far a bracketed security camera stands off the wall, in metres. */
 export const CAMERA_BRACKET_ARM = 0.22;
@@ -127,7 +131,7 @@ export const FURNITURE_CATALOG = [
 
   // People / scale references
   { type: 'person', category: 'people', name: 'Adult', width: 0.5, depth: 0.3, height: 1.75, color: '#FFCDD2', icon: '🧍', price: 0 },
-  { type: 'pet', category: 'people', name: 'Pet', width: 0.45, depth: 0.2, height: 0.4, color: '#A1887F', icon: '🐕', price: 0 },
+  { type: 'pet', category: 'people', name: 'Pet', width: 0.45, depth: 0.65, height: 0.4, color: '#A1887F', icon: '🐕', price: 0 },
 
   // Structure
   { type: 'stairs', category: 'structure', name: 'Stairs', width: 1.2, depth: 2.4, height: 3.0, color: '#8B4513', icon: '🪜', price: 1500, stairsDirection: 'north' },

--- a/components/room-organizer/lib/library.ts
+++ b/components/room-organizer/lib/library.ts
@@ -114,8 +114,14 @@ export function saveNamedLayout(layout: RoomLayout, name: string): SaveResult | 
   try {
     writeIndex(index);
   } catch {
-    if (previousBlob === null) window.localStorage.removeItem(layoutKey(id));
-    else window.localStorage.setItem(layoutKey(id), previousBlob);
+    // Best-effort rollback: restoring the blob can ITSELF hit the quota that
+    // just failed the index write — never let that escape the save call (#122).
+    try {
+      if (previousBlob === null) window.localStorage.removeItem(layoutKey(id));
+      else window.localStorage.setItem(layoutKey(id), previousBlob);
+    } catch {
+      /* quota still exhausted — the stale blob stays but the index is intact */
+    }
     return null;
   }
 
@@ -139,7 +145,14 @@ export function deleteNamedLayout(id: string): boolean {
   const index = readIndex();
   const filtered = index.entries.filter((entry) => entry.id !== id);
   if (filtered.length === index.entries.length) return false;
+  // Index first, blob second: the old order removed the blob and then let a
+  // quota throw out of writeIndex, leaving a ghost index entry whose layout
+  // was already gone (#122). removeItem itself cannot hit quota.
+  try {
+    writeIndex({ entries: filtered });
+  } catch {
+    return false;
+  }
   window.localStorage.removeItem(layoutKey(id));
-  writeIndex({ entries: filtered });
   return true;
 }

--- a/components/room-organizer/lib/room-shapes.test.ts
+++ b/components/room-organizer/lib/room-shapes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import { generateRoomShape } from './room-shapes';
+
+describe('generateRoomShape — hexagon orientation (#122)', () => {
+  it('stamps a flat-top hexagon spanning the full requested width', () => {
+    const walls = generateRoomShape('hexagon', 0, 0, 4, 4, 'test');
+    const xs = walls.flatMap((w) => [w.x1, w.x2]);
+    const zs = walls.flatMap((w) => [w.z1, w.z2]);
+    // Full width: vertices at 0°/180° reach ±width/2.
+    expect(Math.max(...xs)).toBeCloseTo(2, 10);
+    expect(Math.min(...xs)).toBeCloseTo(-2, 10);
+    // Flat top and bottom: the extreme z is shared by TWO vertices (an edge),
+    // not a single point — the old +30° phase produced a pointy top.
+    const maxZ = Math.max(...zs);
+    const topVertices = new Set(
+      walls.flatMap((w) => [
+        ...(Math.abs(w.z1 - maxZ) < 1e-9 ? [w.x1] : []),
+        ...(Math.abs(w.z2 - maxZ) < 1e-9 ? [w.x2] : []),
+      ])
+    );
+    expect(topVertices.size).toBe(2);
+  });
+});

--- a/components/room-organizer/lib/room-shapes.ts
+++ b/components/room-organizer/lib/room-shapes.ts
@@ -152,7 +152,10 @@ function outlinePoints(shapeId: RoomShapeId, w: number, d: number): readonly Vec
       // Regular hexagon inscribed in width × depth, flat top and bottom.
       const out: Vec2[] = [];
       for (let i = 0; i < 6; i += 1) {
-        const a = (Math.PI / 3) * i + Math.PI / 6;
+        // No phase offset: vertices at 0deg/60deg/... give a flat top and
+        // bottom and reach the full requested width, matching the picker
+        // thumbnail. The old +30deg phase drew it pointy-top at 87% width (#122).
+        const a = (Math.PI / 3) * i;
         out.push({ x: Math.cos(a) * hw, z: Math.sin(a) * hd });
       }
       return out;

--- a/components/room-organizer/lib/schema.test.ts
+++ b/components/room-organizer/lib/schema.test.ts
@@ -1,11 +1,33 @@
 import { describe, expect, it } from 'vitest';
 import { makeFloor, makeItem, makeLayout } from './__testfixtures__/fixtures';
-import { MAX_FLOORS, MAX_ROOM_DIMENSION } from './constants';
+import { MAX_FLOORS, MAX_ITEM_DIMENSION, MAX_ROOM_DIMENSION } from './constants';
 import { isFloorLayout, isFurnitureItem, isRoomLayout, parseStoredLayout } from './schema';
 
 describe('isFurnitureItem', () => {
   it('accepts a well-formed item', () => {
     expect(isFurnitureItem(makeItem())).toBe(true);
+  });
+
+  it.each([
+    ['uncapped width', makeItem({ width: 1e12 })],
+    ['uncapped height', makeItem({ height: MAX_ITEM_DIMENSION + 1 })],
+    ['negative signalRange', makeItem({ signalRange: -3 })],
+    ['negative visionRange', makeItem({ visionRange: -1 })],
+    ['visionFov over a full circle', makeItem({ visionFov: 720 })],
+    ['unknown sofaShape', makeItem({ sofaShape: 'Z-shape' as never })],
+    ['unknown stairsDirection', makeItem({ stairsDirection: 'up' as never })],
+    ['non-string cctvModelId', makeItem({ cctvModelId: 42 as never })],
+    ['non-boolean hasVisionCone', makeItem({ hasVisionCone: 'yes' as never })],
+  ])('rejects %s (#121)', (_label, value) => {
+    expect(isFurnitureItem(value)).toBe(false);
+  });
+
+  it('accepts valid enum/range fields (#121)', () => {
+    expect(
+      isFurnitureItem(
+        makeItem({ sofaShape: 'L-shape', stairsDirection: 'north', visionFov: 90, visionRange: 5, signalRange: 8, hasVisionCone: true, cctvModelId: 'some-model' })
+      )
+    ).toBe(true);
   });
 
   it('accepts an item without optional fields', () => {
@@ -69,8 +91,16 @@ describe('isRoomLayout', () => {
     ['over-max dimension', makeLayout({ width: MAX_ROOM_DIMENSION + 1 })],
     ['empty floors', makeLayout({ floors: [] })],
     ['too many floors', makeLayout({ floors: Array.from({ length: MAX_FLOORS + 1 }, (_, i) => makeFloor({ id: `f${i}` })) })],
+    ['non-string layout id', makeLayout({ id: 7 as never })],
+    ['floorPlanOpacity above 1', makeLayout({ floorPlanOpacity: 1.5 })],
+    ['negative floorPlanOpacity', makeLayout({ floorPlanOpacity: -0.2 })],
   ])('rejects %s', (_label, value) => {
     expect(isRoomLayout(value)).toBe(false);
+  });
+
+  it('rejects an interior wall with a non-string color (#121)', () => {
+    const floor = { ...makeFloor(), interiorWalls: [{ id: 'w', x1: 0, z1: 0, x2: 1, z2: 1, color: 5 }] };
+    expect(isFloorLayout(floor)).toBe(false);
   });
 
   it('rejects a bad roof style', () => {

--- a/components/room-organizer/lib/schema.ts
+++ b/components/room-organizer/lib/schema.ts
@@ -1,8 +1,18 @@
-import { MAX_FLOORS, MAX_ROOM_DIMENSION } from './constants';
-import type { FloorLayout, FloorPlanFitMode, FurnitureItem, RoofStyle, RoomLayout } from './types';
+import { MAX_FLOORS, MAX_ITEM_DIMENSION, MAX_ROOM_DIMENSION } from './constants';
+import type {
+  FloorLayout,
+  FloorPlanFitMode,
+  FurnitureItem,
+  RoofStyle,
+  RoomLayout,
+  SofaShape,
+  StairsDirection,
+} from './types';
 
 const FIT_MODES: readonly FloorPlanFitMode[] = ['stretch', 'cover', 'contain'];
 const ROOF_STYLES: readonly RoofStyle[] = ['none', 'flat', 'gable', 'hipped'];
+const SOFA_SHAPES: readonly SofaShape[] = ['standard', 'L-shape', 'U-shape'];
+const STAIRS_DIRECTIONS: readonly StairsDirection[] = ['north', 'south', 'east', 'west'];
 
 function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
@@ -19,6 +29,19 @@ function isPositiveNumber(value: unknown): value is number {
  */
 function isRoomDimension(value: unknown): value is number {
   return isPositiveNumber(value) && value <= MAX_ROOM_DIMENSION;
+}
+
+/**
+ * Item dims need an upper bound too: room dims are capped at 100 but a
+ * crafted item `width: 1e12` passed a bare positivity check and destroyed
+ * the scene scale (#121).
+ */
+function isItemDimension(value: unknown): value is number {
+  return isPositiveNumber(value) && value <= MAX_ITEM_DIMENSION;
+}
+
+function isOptionalPositiveNumber(value: unknown): boolean {
+  return value === undefined || isPositiveNumber(value);
 }
 
 function isOptionalBoolean(value: unknown): boolean {
@@ -51,9 +74,9 @@ export function isFurnitureItem(value: unknown): value is FurnitureItem {
     typeof v.id !== 'string' ||
     typeof v.type !== 'string' ||
     typeof v.name !== 'string' ||
-    !isPositiveNumber(v.width) ||
-    !isPositiveNumber(v.depth) ||
-    !isPositiveNumber(v.height) ||
+    !isItemDimension(v.width) ||
+    !isItemDimension(v.depth) ||
+    !isItemDimension(v.height) ||
     typeof v.color !== 'string' ||
     typeof v.icon !== 'string'
   ) {
@@ -63,10 +86,24 @@ export function isFurnitureItem(value: unknown): value is FurnitureItem {
   if (v.category !== undefined && typeof v.category !== 'string') return false;
   if (v.position !== undefined && !isVec2(v.position)) return false;
   if (v.rotation !== undefined && !isFiniteNumber(v.rotation)) return false;
-  if (v.signalRange !== undefined && !isFiniteNumber(v.signalRange)) return false;
-  if (v.visionRange !== undefined && !isFiniteNumber(v.visionRange)) return false;
-  if (v.visionFov !== undefined && !isFiniteNumber(v.visionFov)) return false;
+  // Ranges must be positive: negative signal/vision values invert ring and
+  // cone geometry (#121). FOV additionally caps at a full circle.
+  if (!isOptionalPositiveNumber(v.signalRange)) return false;
+  if (!isOptionalPositiveNumber(v.visionRange)) return false;
+  if (v.visionFov !== undefined && (!isPositiveNumber(v.visionFov) || v.visionFov > 360)) return false;
   if (v.wallRotation !== undefined && !isFiniteNumber(v.wallRotation)) return false;
+  // Enum-ish fields ingested from external data must match their unions —
+  // an unknown sofaShape/stairsDirection reaches builder switch statements
+  // unchecked (#121). cctvModelId only needs to be a string: unknown ids
+  // fall back to the default model at lookup time.
+  if (v.sofaShape !== undefined && !SOFA_SHAPES.includes(v.sofaShape as SofaShape)) return false;
+  if (
+    v.stairsDirection !== undefined &&
+    !STAIRS_DIRECTIONS.includes(v.stairsDirection as StairsDirection)
+  ) {
+    return false;
+  }
+  if (v.cctvModelId !== undefined && typeof v.cctvModelId !== 'string') return false;
   // Booleans must be real booleans: a corrupt `locked:"no"` reads truthy for
   // keyboard-delete guards yet fails `=== true` drag checks, desyncing the two.
   if (!isOptionalBoolean(v.locked)) return false;
@@ -74,6 +111,7 @@ export function isFurnitureItem(value: unknown): value is FurnitureItem {
   if (!isOptionalBoolean(v.cameraBracket)) return false;
   if (!isOptionalBoolean(v.isCCTV)) return false;
   if (!isOptionalBoolean(v.isWiFiAccessPoint)) return false;
+  if (!isOptionalBoolean(v.hasVisionCone)) return false;
   return true;
 }
 
@@ -107,6 +145,7 @@ export function isFloorLayout(value: unknown): value is FloorLayout {
       ) {
         return false;
       }
+      if (wall.color !== undefined && typeof wall.color !== 'string') return false;
     }
   }
   return true;
@@ -117,6 +156,7 @@ export function isRoomLayout(value: unknown): value is RoomLayout {
   const v = value;
 
   if (typeof v.name !== 'string') return false;
+  if (v.id !== undefined && typeof v.id !== 'string') return false;
   if (!isRoomDimension(v.width)) return false;
   if (!isRoomDimension(v.height)) return false;
   if (
@@ -129,7 +169,14 @@ export function isRoomLayout(value: unknown): value is RoomLayout {
   }
 
   if (v.floorPlanImage !== undefined && !isDataImageUrl(v.floorPlanImage)) return false;
-  if (v.floorPlanOpacity !== undefined && !isFiniteNumber(v.floorPlanOpacity)) return false;
+  // Opacity outside [0,1] is corruption, not preference — the UI slider only
+  // produces this range and canvas globalAlpha silently misbehaves outside it.
+  if (
+    v.floorPlanOpacity !== undefined &&
+    (!isFiniteNumber(v.floorPlanOpacity) || v.floorPlanOpacity < 0 || v.floorPlanOpacity > 1)
+  ) {
+    return false;
+  }
   if (
     v.floorPlanFitMode !== undefined &&
     !FIT_MODES.includes(v.floorPlanFitMode as FloorPlanFitMode)

--- a/components/room-organizer/panels/item-resize-panel.tsx
+++ b/components/room-organizer/panels/item-resize-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useId } from 'react';
+import { useId, useState } from 'react';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
@@ -177,10 +177,12 @@ interface PositionInputsProps {
 function PositionInputs({ x, z, onChange }: PositionInputsProps): JSX.Element {
   const xId = useId();
   const zId = useId();
-  const parseOrFallback = (raw: string, fallback: number) => {
-    const parsed = parseFloat(raw);
-    return Number.isFinite(parsed) ? parsed : fallback;
-  };
+  // While a field is being edited, show the raw draft instead of the
+  // re-formatted value: feeding toFixed(2) back on every keystroke snapped
+  // intermediate states like "-" or "1." away mid-typing (#122). Commit only
+  // parseable drafts; blur restores the canonical formatting.
+  const [xDraft, setXDraft] = useState<string | null>(null);
+  const [zDraft, setZDraft] = useState<string | null>(null);
   return (
     <div className="grid grid-cols-2 gap-2">
       <div>
@@ -191,8 +193,13 @@ function PositionInputs({ x, z, onChange }: PositionInputsProps): JSX.Element {
           id={xId}
           type="number"
           step={0.1}
-          value={x.toFixed(2)}
-          onChange={(event) => onChange(parseOrFallback(event.target.value, x), z)}
+          value={xDraft ?? x.toFixed(2)}
+          onChange={(event) => {
+            setXDraft(event.target.value);
+            const parsed = parseFloat(event.target.value);
+            if (Number.isFinite(parsed)) onChange(parsed, z);
+          }}
+          onBlur={() => setXDraft(null)}
         />
       </div>
       <div>
@@ -203,8 +210,13 @@ function PositionInputs({ x, z, onChange }: PositionInputsProps): JSX.Element {
           id={zId}
           type="number"
           step={0.1}
-          value={z.toFixed(2)}
-          onChange={(event) => onChange(x, parseOrFallback(event.target.value, z))}
+          value={zDraft ?? z.toFixed(2)}
+          onChange={(event) => {
+            setZDraft(event.target.value);
+            const parsed = parseFloat(event.target.value);
+            if (Number.isFinite(parsed)) onChange(x, parsed);
+          }}
+          onBlur={() => setZDraft(null)}
         />
       </div>
     </div>

--- a/components/room-organizer/panels/templates-panel.tsx
+++ b/components/room-organizer/panels/templates-panel.tsx
@@ -24,7 +24,11 @@ export function TemplatesPanel({ onLoadTemplate }: TemplatesPanelProps): JSX.Ele
         <CardTitle className="text-base">Templates</CardTitle>
       </CardHeader>
       <CardContent>
-        <Select onValueChange={(key) => onLoadTemplate(ROOM_TEMPLATES[key as RoomTemplateKey])}>
+        {/* Controlled with an always-empty value so choosing the SAME template
+            twice still fires onValueChange (Radix suppresses same-value
+            changes on an uncontrolled select) — re-applying a template after
+            edits was a silent no-op (#122). */}
+        <Select value="" onValueChange={(key) => onLoadTemplate(ROOM_TEMPLATES[key as RoomTemplateKey])}>
           <SelectTrigger>
             <SelectValue placeholder="Load a template..." />
           </SelectTrigger>

--- a/components/room-organizer/panels/wall-paint-panel.tsx
+++ b/components/room-organizer/panels/wall-paint-panel.tsx
@@ -136,6 +136,13 @@ export function WallPaintPanel(props: WallPaintPanelProps): JSX.Element {
   const { activeFloor: floor, actions } = useRoomEditor();
 
   const applyWallColor = (target: WallId | 'all', color: string) => {
+    // A selected INTERIOR wall gets painted itself — previously an interior
+    // selection fell through to 'all' and silently repainted the four
+    // exterior walls instead (#122).
+    if (selectedInteriorId !== null) {
+      actions.setInteriorWallColor(selectedInteriorId, color);
+      return;
+    }
     if (target === 'all') {
       actions.setWallColor('north', color);
       actions.setWallColor('south', color);
@@ -156,14 +163,18 @@ export function WallPaintPanel(props: WallPaintPanelProps): JSX.Element {
     props.selectedWall && props.selectedWall.kind === 'exterior'
       ? (props.selectedWall.id as WallId)
       : null;
+  const selectedInteriorId =
+    props.selectedWall && props.selectedWall.kind === 'interior' ? props.selectedWall.id : null;
   const applyTo: WallId | 'all' = selectedExteriorId ?? 'all';
 
   const currentWallPattern = floor.wallPattern ?? 'solid';
   const currentFloorPattern = floor.floorPattern ?? 'solid';
   const currentWallColor =
-    (selectedExteriorId
-      ? floor.wallColors?.[selectedExteriorId]
-      : floor.wallColors?.north) ?? '#e8dcc4';
+    (selectedInteriorId
+      ? floor.interiorWalls?.find((wall) => wall.id === selectedInteriorId)?.color ?? '#e0e0e0'
+      : selectedExteriorId
+        ? floor.wallColors?.[selectedExteriorId]
+        : floor.wallColors?.north) ?? '#e8dcc4';
 
   const activeWallPalette =
     WALL_PALETTES.find((g) => g.id === wallGroup) ?? WALL_PALETTES[0]!;
@@ -227,7 +238,7 @@ export function WallPaintPanel(props: WallPaintPanelProps): JSX.Element {
                   color: 'var(--pc-cyan-glow)',
                 }}
               >
-                · Wall selected
+                {selectedInteriorId ? '· Interior wall selected' : '· Wall selected'}
               </span>
             )}
           </SectionLabel>

--- a/components/room-organizer/panels/walls-panel.tsx
+++ b/components/room-organizer/panels/walls-panel.tsx
@@ -17,7 +17,7 @@ const WALL_LABELS: Record<WallId, string> = {
 };
 
 const FLOOR_PATTERNS: ReadonlyArray<FloorPattern> = ['solid', 'wood', 'tile', 'carpet', 'concrete'];
-const WALL_PATTERNS: ReadonlyArray<WallPattern> = ['solid', 'brick', 'wallpaper', 'panel', 'plaster'];
+const WALL_PATTERNS: ReadonlyArray<WallPattern> = ['solid', 'brick', 'wallpaper', 'panel', 'plaster', 'siding'];
 
 const DEFAULT_WALL_COLOR = '#cccccc';
 

--- a/components/room-organizer/plotcraft/icon.tsx
+++ b/components/room-organizer/plotcraft/icon.tsx
@@ -640,9 +640,14 @@ const CATEGORY_TO_ICON: Record<string, PlotcraftIconName> = {
 };
 
 export function iconForItem(type: string, category?: string): PlotcraftIconName {
+  // Own-property lookups only: `type` comes from saved/imported layouts, so a
+  // crafted "constructor"/"toString" would otherwise resolve an inherited
+  // Object.prototype member and render a blank glyph instead of the fallback (#122).
   return (
-    TYPE_TO_ICON[type] ??
-    (category ? CATEGORY_TO_ICON[category] : undefined) ??
+    (Object.hasOwn(TYPE_TO_ICON, type) ? TYPE_TO_ICON[type] : undefined) ??
+    (category !== undefined && Object.hasOwn(CATEGORY_TO_ICON, category)
+      ? CATEGORY_TO_ICON[category]
+      : undefined) ??
     'box'
   );
 }

--- a/components/room-organizer/three/drag-handlers.ts
+++ b/components/room-organizer/three/drag-handlers.ts
@@ -91,7 +91,12 @@ export function attachDragHandlers({
   const furnitureList = (): ThreeNS.Object3D[] => {
     const revision = (scene.userData[FURNITURE_REVISION_KEY] as number | undefined) ?? 0;
     if (revision !== furnitureCacheRevision) {
-      furnitureCache = scene.children.filter((obj) => obj.userData.type === 'furniture');
+      // Ghosted furniture on inactive floors (show-all-floors mode) is
+      // scenery, not a pointer target: clicking it silently dropped the
+      // current selection and the hover cursor reacted to it (#122).
+      furnitureCache = scene.children.filter(
+        (obj) => obj.userData.type === 'furniture' && obj.userData.ghostFloor !== true
+      );
       furnitureCacheRevision = revision;
     }
     return furnitureCache;

--- a/components/room-organizer/three/room-builder.ts
+++ b/components/room-organizer/three/room-builder.ts
@@ -65,6 +65,15 @@ export function applyWallDisplay(
     }
     if (tag !== ROOM_OBJECT_TAGS.Wall) continue;
 
+    // Id-less Wall-tagged helpers (the snap grid) stay visible in EVERY mode
+    // — checking this after the mode branches made walls-down hide the floor
+    // grid, which Sims-style walls-down is supposed to keep (#122).
+    const wallId = obj.userData.wallId as WallId | undefined;
+    if (!wallId) {
+      obj.visible = true;
+      continue;
+    }
+
     if (mode === 'down') {
       obj.visible = false;
       continue;
@@ -75,12 +84,6 @@ export function applyWallDisplay(
     }
 
     // Cutaway: hide the wall if the camera is on its outer side.
-    const wallId = obj.userData.wallId as WallId | undefined;
-    if (!wallId) {
-      // Items without an id (e.g. the GridHelper) stay visible.
-      obj.visible = true;
-      continue;
-    }
 
     let nx = 0;
     let nz = 0;

--- a/components/room-organizer/three/wall-patterns.ts
+++ b/components/room-organizer/three/wall-patterns.ts
@@ -18,13 +18,11 @@ interface PatternRenderer {
   draw(ctx: CanvasRenderingContext2D, size: number, baseColor: string): void;
   /** How many tiles per meter of wall length. */
   repeatPerMeter: number;
-  opacity: number;
 }
 
 const PATTERNS: Record<Exclude<WallPattern, 'solid'>, PatternRenderer> = {
   brick: {
     repeatPerMeter: 0.8,
-    opacity: 0.55,
     draw(ctx, size, baseColor) {
       ctx.fillStyle = baseColor;
       ctx.fillRect(0, 0, size, size);
@@ -46,7 +44,6 @@ const PATTERNS: Record<Exclude<WallPattern, 'solid'>, PatternRenderer> = {
   },
   wallpaper: {
     repeatPerMeter: 1.2,
-    opacity: 0.55,
     draw(ctx, size, baseColor) {
       ctx.fillStyle = baseColor;
       ctx.fillRect(0, 0, size, size);
@@ -66,7 +63,6 @@ const PATTERNS: Record<Exclude<WallPattern, 'solid'>, PatternRenderer> = {
   },
   panel: {
     repeatPerMeter: 0.5,
-    opacity: 0.55,
     draw(ctx, size, baseColor) {
       ctx.fillStyle = baseColor;
       ctx.fillRect(0, 0, size, size);
@@ -97,7 +93,6 @@ const PATTERNS: Record<Exclude<WallPattern, 'solid'>, PatternRenderer> = {
   },
   plaster: {
     repeatPerMeter: 0.3,
-    opacity: 0.5,
     draw(ctx, size, baseColor) {
       ctx.fillStyle = baseColor;
       ctx.fillRect(0, 0, size, size);
@@ -120,7 +115,6 @@ const PATTERNS: Record<Exclude<WallPattern, 'solid'>, PatternRenderer> = {
   // subtle shadow line under each.
   siding: {
     repeatPerMeter: 0.5,
-    opacity: 0.7,
     draw(ctx, size, baseColor) {
       ctx.fillStyle = baseColor;
       ctx.fillRect(0, 0, size, size);
@@ -183,7 +177,6 @@ export function buildWallMaterial(
     return new THREE.MeshStandardMaterial({
       color: options.color,
       transparent: true,
-      opacity: 0.3,
       side: THREE.DoubleSide,
     });
   }


### PR DESCRIPTION
Two commits, one per issue (`constants.ts` lands in the roundup commit; the schema commit uses its new `MAX_ITEM_DIMENSION` export).

## #122 — 13-item roundup

- **Interior-wall painting**: new `setInteriorWallColor` reducer action wired to the paint panel — an interior selection previously fell through to 'all' and repainted the four exterior walls. The 3D renderer already honoured `InteriorWall.color`, so only the action/panel were missing; schema already validates the field (see #121 commit).
- **Inputs/selects**: X/Z position inputs keep a typing draft (no more `toFixed(2)` snap-back mid-keystroke); Templates select is controlled-empty so re-applying the same template works; walls panel gained the missing `siding` pattern.
- **Geometry/3D polish**: hexagon stamp is flat-top at full width (regression test added); walls-down keeps the snap grid; pet catalog depth matches its mesh footprint; ghosted inactive-floor furniture is excluded from pointer raycasts (no more click-steal/hover in show-all-floors).
- **Hygiene**: library delete writes the index before removing the blob and save-rollback can't throw from the quota path; scene teardown disposes the sky-gradient texture; `duplicateFloor` drops `Date.now()` (random `idSuffix` alone keeps ids unique — reducer purity restored); `iconForItem` uses own-property lookups (`type: \"constructor\"` no longer renders blank); dead `opacity` field removed from wall patterns.

## #121 — schema hardening round 3

Item dims capped at `MAX_ITEM_DIMENSION` (50 m); `sofaShape`/`stairsDirection` validated against their unions; `cctvModelId` string-checked; `hasVisionCone` joins the boolean checks; interior-wall `color` and layout `id` type-checked; `floorPlanOpacity` restricted to [0,1]; `signalRange`/`visionRange` must be positive and `visionFov` ≤ 360. One rejected-fixture test per rule.

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` all pass — 223 tests (207 + 16 new).

Fixes #121
Fixes #122