### PR TITLE
Close the test-coverage gaps and surface cross-tab autosave races (#123)

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ components/
     │   ├── use-achievements.ts          Diffed unlock detection
     │   ├── use-recent-colors.ts         Persisted LRU colour palette
     │   ├── use-keyboard-shortcuts.ts    Centralised key handling
-    │   └── use-layout-persistence.ts    Hydrate (share → local) + auto-save
+    │   └── use-layout-persistence.ts    Hydrate (share → local) + auto-save + cross-tab notice
     └── panels/                          Presentation (most use context)
         ├── lot-badge.tsx                Top-left lot name + sidebar toggle
         ├── sidebar-drawer.tsx           Full sidebar with 4-tab panel layout

--- a/components/room-organizer/hooks/use-layout-persistence.react.test.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.react.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { makeLayout } from '../lib/__testfixtures__/fixtures';
+import { STORAGE_KEY } from '../lib/constants';
+import { useLayoutPersistence } from './use-layout-persistence';
+
+function fireStorage(key: string, newValue: string | null): void {
+  window.dispatchEvent(new StorageEvent('storage', { key, newValue }));
+}
+
+describe('useLayoutPersistence — cross-tab guard (#123)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  const setup = () =>
+    renderHook(() =>
+      useLayoutPersistence({
+        layout: makeLayout({ name: 'This tab' }),
+        onHydrate: () => {},
+        debounceMs: 60_000,
+      })
+    );
+
+  it('surfaces a valid layout saved by another tab', () => {
+    const { result } = setup();
+    expect(result.current.remoteLayout).toBeNull();
+    const remote = makeLayout({ name: 'Other tab' });
+    act(() => fireStorage(STORAGE_KEY, JSON.stringify(remote)));
+    expect(result.current.remoteLayout).toEqual(remote);
+  });
+
+  it('ignores writes to other keys, removals, and unreadable payloads', () => {
+    const { result } = setup();
+    act(() => fireStorage('some-other-key', JSON.stringify(makeLayout())));
+    act(() => fireStorage(STORAGE_KEY, null));
+    act(() => fireStorage(STORAGE_KEY, '{not json'));
+    act(() => fireStorage(STORAGE_KEY, JSON.stringify({ width: 5 })));
+    expect(result.current.remoteLayout).toBeNull();
+  });
+
+  it('clearRemoteLayout dismisses the notice', () => {
+    const { result } = setup();
+    act(() => fireStorage(STORAGE_KEY, JSON.stringify(makeLayout({ name: 'Other tab' }))));
+    expect(result.current.remoteLayout).not.toBeNull();
+    act(() => result.current.clearRemoteLayout());
+    expect(result.current.remoteLayout).toBeNull();
+  });
+});

--- a/components/room-organizer/hooks/use-layout-persistence.ts
+++ b/components/room-organizer/hooks/use-layout-persistence.ts
@@ -1,6 +1,7 @@
-import { useEffect, useRef, useState } from 'react';
-import { AUTOSAVE_DEBOUNCE_MS } from '../lib/constants';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { AUTOSAVE_DEBOUNCE_MS, STORAGE_KEY } from '../lib/constants';
 import { backupUnreadableLayout, loadLayout, saveLayout } from '../lib/persistence';
+import { parseStoredLayout } from '../lib/schema';
 import { decodeShareUrl, isShareHash } from '../lib/share';
 import type { RoomLayout } from '../lib/types';
 
@@ -21,6 +22,16 @@ export interface UseLayoutPersistenceResult {
    * "Saved" when the layout never actually made it to localStorage.
    */
   saveError: boolean;
+  /**
+   * The layout another tab saved over ours, or null. Autosave stays
+   * last-writer-wins between tabs (full merge is out of scope, #123), but the
+   * race is surfaced instead of silent: the HUD shows a notice and can adopt
+   * this snapshot. The caller decides what "adopt" means (an undoable
+   * applyLayout — NOT the hydrate path, which would clear history).
+   */
+  remoteLayout: RoomLayout | null;
+  /** Dismiss the cross-tab notice (also call after adopting `remoteLayout`). */
+  clearRemoteLayout(): void;
 }
 
 export function useLayoutPersistence({
@@ -40,6 +51,25 @@ export function useLayoutPersistence({
   const [lastSavedAt, setLastSavedAt] = useState<number | null>(null);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState(false);
+  const [remoteLayout, setRemoteLayout] = useState<RoomLayout | null>(null);
+
+  // Cross-tab guard (#123): the `storage` event only fires in OTHER tabs of
+  // the same origin, so any event on our key means a different tab saved.
+  useEffect(() => {
+    const onStorage = (event: StorageEvent): void => {
+      if (event.key !== STORAGE_KEY || event.newValue === null) return;
+      try {
+        const parsed = parseStoredLayout(JSON.parse(event.newValue));
+        if (parsed) setRemoteLayout(parsed);
+      } catch {
+        /* another tab wrote something unreadable — nothing to offer */
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []);
+
+  const clearRemoteLayout = useCallback(() => setRemoteLayout(null), []);
 
   useEffect(() => {
     if (hasHydratedRef.current) return;
@@ -142,5 +172,5 @@ export function useLayoutPersistence({
     };
   }, []);
 
-  return { lastSavedAt, saving, saveError };
+  return { lastSavedAt, saving, saveError, remoteLayout, clearRemoteLayout };
 }

--- a/components/room-organizer/lib/opening-snap.test.ts
+++ b/components/room-organizer/lib/opening-snap.test.ts
@@ -1,9 +1,139 @@
 import { describe, expect, it } from 'vitest';
-import { settleWallMountedItem } from './opening-snap';
+import {
+  reseatWallMountedItem,
+  settleWallMountedItem,
+  snapOpeningToWall,
+  snapWallMountedItem,
+} from './opening-snap';
 
 // 8×8 room throughout: walls at x = ±4, z = ±4.
 const W = 8;
 const D = 8;
+
+describe('snapOpeningToWall — exterior walls (#123)', () => {
+  it.each([
+    ['north', { x: 1, z: -3 }, { x: 1, z: -4 }, 0],
+    ['south', { x: -1, z: 3 }, { x: -1, z: 4 }, Math.PI],
+    ['east', { x: 3, z: 1 }, { x: 4, z: 1 }, -Math.PI / 2],
+    ['west', { x: -3, z: -1 }, { x: -4, z: -1 }, Math.PI / 2],
+  ])('snaps to the %s wall on-plane with the wall-aligned rotation', (_wall, cursor, position, rotation) => {
+    const snap = snapOpeningToWall({ position: cursor, itemWidth: 1, roomWidth: W, roomDepth: D });
+    expect(snap.wallKind).toBe('exterior');
+    expect(snap.position.x).toBeCloseTo(position.x, 10);
+    expect(snap.position.z).toBeCloseTo(position.z, 10);
+    expect(snap.rotation).toBeCloseTo(rotation, 10);
+  });
+
+  it('clamps the opening inside the wall ends', () => {
+    const snap = snapOpeningToWall({ position: { x: 9, z: -3.8 }, itemWidth: 1.2, roomWidth: W, roomDepth: D });
+    expect(snap.position.x).toBeCloseTo(4 - 0.6, 10);
+    expect(snap.position.z).toBe(-4);
+  });
+});
+
+describe('snapOpeningToWall — interior walls (#123)', () => {
+  const wall = { id: 'iw', x1: -2, z1: 0, x2: 2, z2: 0 };
+
+  it('prefers a nearby interior wall over a farther exterior wall', () => {
+    const snap = snapOpeningToWall({
+      position: { x: 0.5, z: 0.3 },
+      itemWidth: 0.9,
+      roomWidth: W,
+      roomDepth: D,
+      interiorWalls: [wall],
+    });
+    expect(snap.wallKind).toBe('interior');
+    expect(snap.position.z).toBeCloseTo(0, 10);
+    expect(snap.position.x).toBeCloseTo(0.5, 10);
+    // Wall direction (+x): rotation = -atan2(0, 4) = 0.
+    expect(snap.rotation).toBeCloseTo(0, 10);
+    expect(snap.interiorWall).toMatchObject({ x1: -2, z1: 0, x2: 2, z2: 0 });
+  });
+
+  it('insets the snap point so the opening cannot overflow the segment ends', () => {
+    const snap = snapOpeningToWall({
+      position: { x: 2.4, z: 0.05 },
+      itemWidth: 0.9,
+      roomWidth: W,
+      roomDepth: D,
+      interiorWalls: [wall],
+    });
+    expect(snap.wallKind).toBe('interior');
+    // Clamped to segment end minus the half-width inset: 2 − 0.45.
+    expect(snap.position.x).toBeCloseTo(2 - 0.45, 10);
+  });
+
+  it('ignores segments too short to hold the opening', () => {
+    const stub = { id: 's', x1: 0, z1: 0, x2: 0.5, z2: 0 };
+    const snap = snapOpeningToWall({
+      position: { x: 0.2, z: 0.1 },
+      itemWidth: 0.9,
+      roomWidth: W,
+      roomDepth: D,
+      interiorWalls: [stub],
+    });
+    expect(snap.wallKind).toBe('exterior');
+  });
+});
+
+describe('snapWallMountedItem — interior seating side (#123)', () => {
+  const wall = { id: 'iw', x1: -2, z1: 0, x2: 2, z2: 0 };
+
+  it.each([
+    ['cursor on +z side', 0.4, 1],
+    ['cursor on -z side', -0.4, -1],
+  ])('seats the camera on the side the cursor dropped (%s)', (_label, cursorZ, sideSign) => {
+    const snap = snapWallMountedItem({
+      position: { x: 0, z: cursorZ },
+      itemWidth: 0.3,
+      itemDepth: 0.2,
+      roomWidth: W,
+      roomDepth: D,
+      interiorWalls: [wall],
+    });
+    expect(snap.wallKind).toBe('interior');
+    // Inset = depth/2 + 0.02 + interior half-thickness (0.08) = 0.2.
+    expect(snap.position.z).toBeCloseTo(sideSign * 0.2, 10);
+  });
+});
+
+describe('reseatWallMountedItem (#123)', () => {
+  it('stands a bracketed camera off the wall by the arm length', () => {
+    const pos = reseatWallMountedItem({
+      position: { x: 0, z: -3.8 },
+      itemWidth: 0.3,
+      itemDepth: 0.2,
+      roomWidth: W,
+      roomDepth: D,
+      rotation: 0,
+      bracketArm: 0.22,
+    });
+    // North wall inward normal is +z: base on the wall plane, body 0.22 in.
+    expect(pos.z).toBeCloseTo(-4 + 0.22, 10);
+    expect(pos.x).toBeCloseTo(0, 10);
+  });
+
+  it('flush camera seats on the side it faces — turned outward, it moves outside', () => {
+    const inward = reseatWallMountedItem({
+      position: { x: 0, z: -3.9 },
+      itemWidth: 0.3,
+      itemDepth: 0.2,
+      roomWidth: W,
+      roomDepth: D,
+      rotation: 0, // faces +z = into the room
+    });
+    const outward = reseatWallMountedItem({
+      position: { x: 0, z: -3.9 },
+      itemWidth: 0.3,
+      itemDepth: 0.2,
+      roomWidth: W,
+      roomDepth: D,
+      rotation: Math.PI, // faces -z = out through the north wall
+    });
+    expect(inward.z).toBeCloseTo(-4 + 0.12, 10);
+    expect(outward.z).toBeCloseTo(-4 - 0.12, 10);
+  });
+});
 
 describe('settleWallMountedItem (#116)', () => {
   it('returns null for items that do not mount on walls', () => {

--- a/components/room-organizer/lib/room-shapes.test.ts
+++ b/components/room-organizer/lib/room-shapes.test.ts
@@ -1,5 +1,32 @@
 import { describe, expect, it } from 'vitest';
-import { generateRoomShape } from './room-shapes';
+import { ROOM_SHAPES, generateRoomShape } from './room-shapes';
+
+describe('generateRoomShape — every shape (#123)', () => {
+  it.each(ROOM_SHAPES.map((shape) => [shape.id]))('%s fits the requested bounds and closes its outline', (id) => {
+    const walls = generateRoomShape(id, 0, 0, 5, 4, 'test');
+    expect(walls.length).toBeGreaterThanOrEqual(3);
+    const eps = 1e-9;
+    for (const wall of walls) {
+      for (const [x, z] of [
+        [wall.x1, wall.z1],
+        [wall.x2, wall.z2],
+      ]) {
+        expect(Math.abs(x!)).toBeLessThanOrEqual(2.5 + eps);
+        expect(Math.abs(z!)).toBeLessThanOrEqual(2 + eps);
+      }
+    }
+    // Closed loop: every vertex is shared by exactly two wall endpoints.
+    const counts = new Map<string, number>();
+    for (const wall of walls) {
+      for (const key of [`${wall.x1.toFixed(6)},${wall.z1.toFixed(6)}`, `${wall.x2.toFixed(6)},${wall.z2.toFixed(6)}`]) {
+        counts.set(key, (counts.get(key) ?? 0) + 1);
+      }
+    }
+    for (const [vertex, count] of counts) {
+      expect(count, `vertex ${vertex} of ${id}`).toBe(2);
+    }
+  });
+});
 
 describe('generateRoomShape — hexagon orientation (#122)', () => {
   it('stamps a flat-top hexagon spanning the full requested width', () => {

--- a/components/room-organizer/lib/surprise.test.ts
+++ b/components/room-organizer/lib/surprise.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { itemsOverlap, rotatedHalfExtents } from './geometry';
+import { surpriseLayout } from './surprise';
+
+describe('surpriseLayout (#123)', () => {
+  it('is deterministic for a pinned seed', () => {
+    const a = surpriseLayout({ roomWidth: 6, roomDepth: 5, seed: 42 });
+    const b = surpriseLayout({ roomWidth: 6, roomDepth: 5, seed: 42 });
+    expect(a).toEqual(b);
+    expect(a.length).toBeGreaterThan(0);
+  });
+
+  it('different seeds produce different layouts', () => {
+    const a = surpriseLayout({ roomWidth: 6, roomDepth: 5, seed: 1 });
+    const b = surpriseLayout({ roomWidth: 6, roomDepth: 5, seed: 2 });
+    expect(a).not.toEqual(b);
+  });
+
+  it('never assigns duplicate ids', () => {
+    const items = surpriseLayout({ roomWidth: 8, roomDepth: 8, seed: 7 });
+    expect(new Set(items.map((i) => i.id)).size).toBe(items.length);
+  });
+
+  it('keeps every generated item inside the room across many seeds', () => {
+    for (let seed = 0; seed < 25; seed++) {
+      const w = 4 + (seed % 5);
+      const d = 3 + (seed % 4);
+      for (const item of surpriseLayout({ roomWidth: w, roomDepth: d, seed })) {
+        const { halfW, halfD } = rotatedHalfExtents(item);
+        expect(Math.abs(item.position!.x) + halfW, `seed ${seed}: ${item.id}`).toBeLessThanOrEqual(w / 2 + 1e-9);
+        expect(Math.abs(item.position!.z) + halfD, `seed ${seed}: ${item.id}`).toBeLessThanOrEqual(d / 2 + 1e-9);
+      }
+    }
+  });
+
+  it('decor never overlaps the placed set or other decor', () => {
+    for (let seed = 0; seed < 10; seed++) {
+      const items = surpriseLayout({ roomWidth: 7, roomDepth: 6, seed });
+      const decor = items.filter((i) => i.id.startsWith('surprise-decor'));
+      for (const piece of decor) {
+        for (const other of items) {
+          if (other.id === piece.id) continue;
+          expect(itemsOverlap(piece, other), `seed ${seed}: ${piece.id} vs ${other.id}`).toBe(false);
+        }
+      }
+    }
+  });
+
+  it('a tiny room still yields a usable (possibly decor-only) result without throwing', () => {
+    const items = surpriseLayout({ roomWidth: 2.2, roomDepth: 2.2, seed: 3 });
+    for (const item of items) {
+      const { halfW, halfD } = rotatedHalfExtents(item);
+      expect(Math.abs(item.position!.x) + halfW).toBeLessThanOrEqual(1.1 + 1e-9);
+      expect(Math.abs(item.position!.z) + halfD).toBeLessThanOrEqual(1.1 + 1e-9);
+    }
+  });
+});

--- a/components/room-organizer/panels/header-stats.tsx
+++ b/components/room-organizer/panels/header-stats.tsx
@@ -10,12 +10,19 @@ export interface HeaderStatsProps {
   lastSavedAt?: number | null;
   saving?: boolean;
   saveError?: boolean;
+  /** Another tab saved a different layout (#123). */
+  remoteChange?: boolean;
+  onAdoptRemote?(): void;
+  onDismissRemote?(): void;
 }
 
 export function HeaderStats({
   lastSavedAt = null,
   saving = false,
   saveError = false,
+  remoteChange = false,
+  onAdoptRemote,
+  onDismissRemote,
 }: HeaderStatsProps): JSX.Element {
   // `layout` from the store selector — re-renders only on layout changes.
   const layout = useLayout();
@@ -37,6 +44,65 @@ export function HeaderStats({
         intent={overBudget ? 'danger' : ratio > 0.85 ? 'warning' : 'normal'}
       />
       <SaveIndicator lastSavedAt={lastSavedAt} saving={saving} saveError={saveError} />
+      {remoteChange && (
+        <RemoteChangeNotice onAdopt={onAdoptRemote} onDismiss={onDismissRemote} />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Cross-tab notice (#123): another tab saved over this tab's layout. Autosave
+ * stays last-writer-wins, but the race is made visible with a one-click,
+ * undoable way to load the other tab's version.
+ */
+function RemoteChangeNotice({
+  onAdopt,
+  onDismiss,
+}: {
+  onAdopt?: () => void;
+  onDismiss?: () => void;
+}): JSX.Element {
+  const buttonStyle: React.CSSProperties = {
+    border: '1px solid var(--pc-warn-amber)',
+    borderRadius: 999,
+    background: 'transparent',
+    color: 'var(--pc-warn-amber)',
+    fontFamily: 'var(--pc-font-display)',
+    fontWeight: 700,
+    fontSize: 10,
+    padding: '2px 8px',
+    cursor: 'pointer',
+  };
+  return (
+    <div
+      role="status"
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 8,
+        borderRadius: 999,
+        border: '1px solid var(--pc-warn-amber)',
+        background: 'rgba(242,181,61,0.18)',
+        padding: '4px 10px',
+        color: 'var(--pc-warn-amber)',
+        fontFamily: 'var(--pc-font-body)',
+        fontSize: 11,
+        fontWeight: 600,
+      }}
+    >
+      <span>Changed in another tab</span>
+      <button
+        type="button"
+        style={buttonStyle}
+        onClick={onAdopt}
+        title="Load the other tab's version (Ctrl+Z undoes it)"
+      >
+        Load
+      </button>
+      <button type="button" style={buttonStyle} onClick={onDismiss} title="Keep this tab's version" aria-label="Dismiss">
+        ✕
+      </button>
     </div>
   );
 }

--- a/components/room-organizer/room-organizer.tsx
+++ b/components/room-organizer/room-organizer.tsx
@@ -469,7 +469,7 @@ export function RoomOrganizer(): JSX.Element {
     [actions]
   ));
 
-  const { lastSavedAt, saving: isSaving, saveError } = useLayoutPersistence({
+  const { lastSavedAt, saving: isSaving, saveError, remoteLayout, clearRemoteLayout } = useLayoutPersistence({
     layout,
     onHydrate: useCallback(
       (saved: RoomLayout) => {
@@ -480,6 +480,16 @@ export function RoomOrganizer(): JSX.Element {
       [actions, history, selectOnly]
     ),
   });
+
+  // Adopt the snapshot another tab saved (#123). Deliberately a plain
+  // applyLayout, not the hydrate path: it lands as a normal history entry, so
+  // switching to the other tab's version is one Ctrl+Z away from being undone.
+  const adoptRemoteLayout = useCallback(() => {
+    if (!remoteLayout) return;
+    actions.applyLayout(remoteLayout);
+    selectOnly(null);
+    clearRemoteLayout();
+  }, [remoteLayout, actions, selectOnly, clearRemoteLayout]);
 
   const selectedItem = useMemo(
     () => (selectedItemId ? activeFloor.items.find((item) => item.id === selectedItemId) ?? null : null),
@@ -869,6 +879,9 @@ export function RoomOrganizer(): JSX.Element {
             lastSavedAt={lastSavedAt}
             saving={isSaving}
             saveError={saveError}
+            remoteChange={remoteLayout !== null}
+            onAdoptRemote={adoptRemoteLayout}
+            onDismissRemote={clearRemoteLayout}
           />
         </div>
       </div>


### PR DESCRIPTION
Two commits, one per half of the issue.

## Test coverage (+28 tests, suite 223 → 251)

- **opening-snap**: the core snapping math itself (previous tests only covered the shared `settleWallMountedItem` wrapper) — snap to each exterior wall with wall-aligned rotation, wall-end clamping, interior walls winning over farther exterior walls, endpoint insets so openings can't overflow a segment, too-short segments skipped, cursor-side seating with the interior half-thickness inset, and bracket/flush camera reseat including the faces-outward case.
- **surprise**: seeded determinism, distinct seeds differ, unique ids, all items in-bounds across 25 seed/room-size combinations, decor never overlaps the placed set, tiny rooms degrade gracefully.
- **room-shapes**: every shipped shape's stamped polygon fits the requested bounds and forms a closed loop (each vertex shared by exactly two wall endpoints).

## Cross-tab autosave guard

Last-writer-wins between tabs stays (full merge is out of scope per the issue), but the race is now visible instead of silent:

- `useLayoutPersistence` listens for `storage` events — which only fire in *other* same-origin tabs — and exposes the foreign snapshot after validating it with `parseStoredLayout`.
- The HUD shows an amber **"Changed in another tab"** notice with **Load** / dismiss. Load applies the snapshot via a plain `applyLayout` (deliberately not the hydrate path, which clears history), so adopting is one Ctrl+Z away from being undone.
- jsdom hook tests cover the event handling (valid snapshot surfaces; wrong keys, removals, and corrupt payloads ignored; dismiss clears).
- **Verified end-to-end with two real Playwright tabs**: tab B saved a different layout → tab A's notice appeared → Load adopted it (name visible in the header) → notice cleared.

## Checks

`npm run typecheck`, `npm run lint`, `npm run test` all pass — 251 tests.

Fixes #123